### PR TITLE
docs: improve installation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,16 +37,17 @@ Nevertheless, for a quick introduction, you can take a look at the [documentatio
 
 ## Installation
 
-You can install the release version from `PyPi` by running
+You can install the release version from `PyPI` by running
 
-``` py
-pip install -U pyfixest
+```py
+# inside an active virtual environment
+python -m pip install pyfixest
 ```
 
 or the development version from github by running
 
-``` py
-pip install git+https://github.com/py-econometrics/pyfixest.git
+```py
+python -m pip install git+https://github.com/py-econometrics/pyfixest
 ```
 
 ## Benchmarks


### PR DESCRIPTION
Ciao! Just discovered this project and it seems so cool! A huge throwback to my econometrics days (though I had to use Stata 🥶).

I propose to change the installation section to be more explicit about installing the package in a virtual environment. Furthermore, as a Python core developer Brett Cannon recommends, I prepended `python -m` in front of pip, for reasons better explained in his post [here](https://snarky.ca/why-you-should-use-python-m-pip/).

Feedback is appreciated!