### PR TITLE
fix doubleml test bug

### DIFF
--- a/tests/test_confint.py
+++ b/tests/test_confint.py
@@ -1,8 +1,8 @@
-import doubleml as dml
+import sys
+
 import numpy as np
 import pandas as pd
-from sklearn.base import clone
-from sklearn.linear_model import LinearRegression
+import pytest
 
 from pyfixest.estimation.estimation import feols
 from pyfixest.utils.utils import get_data
@@ -47,8 +47,13 @@ def test_confint():
     assert np.all(confint1 != confint3)
 
 
+@pytest.mark.skipif(sys.version_info >= (3, 12), reason="requires python3.11 or lower.")
 def test_against_doubleml():
     """Test joint CIs against DoubleML."""
+    import doubleml as dml
+    from sklearn.base import clone
+    from sklearn.linear_model import LinearRegression
+
     rng = np.random.default_rng(2002)
     n_obs = 5_000
     n_vars = 100


### PR DESCRIPTION
`doubml` does not run on python 3.12, which leads to test failures.