### PR TITLE
Improved robustness of feols_ regex.

### DIFF
--- a/pyfixest/estimation/feols_.py
+++ b/pyfixest/estimation/feols_.py
@@ -1305,7 +1305,7 @@ class Feols:
                 effect.
             """
             c_pattern = r"C\((.+?)\)"
-            t_pattern = r"\[T\.(.*\])"
+            t_pattern = r"\[T\.(.*?)\]"
             c_match = re.search(c_pattern, fe_string)
             t_match = re.search(t_pattern, fe_string, re.DOTALL)
 
@@ -1437,7 +1437,7 @@ class Feols:
                     new_levels = df_fe[fixef].unique()
                     old_levels = _data[fixef].unique().astype(str)
                     subdict = self._fixef_dict[
-                        f"C({fixef})"
+                        f"{fixef}"
                     ]  # as variables are called C(var) in the fixef_dict
 
                     for level in new_levels:


### PR DESCRIPTION
This is a follow-up to the [PR Clarify fixef() value error message](https://github.com/py-econometrics/pyfixest/pull/537). It looked like the formulaic encoding was adding line breaks (\n) under certain circumstances which the feols_ regex was struggling with. [Alex did the heavy lifting](https://github.com/py-econometrics/pyfixest/pull/537#issuecomment-2212392559) in refactoring the regex, and I just made things pretty and spun up a PR.  