### PR TITLE
add pure numpy predict function that speeds up ~40x 

### DIFF
--- a/pyfixest/estimation/feols_.py
+++ b/pyfixest/estimation/feols_.py
@@ -1483,9 +1483,16 @@ class Feols:
                 self.fixef()
             fvals = self._fixef.split("+")
             df_fe = newdata[fvals].astype(str)
-            fixef_dicts = {
-                f"C({fixef})": self._fixef_dict[f"C({fixef})"] for fixef in fvals
-            }
+            # populate fixed effect dicts with omitted categories handling
+            fixef_dicts = {}
+            for f in fvals:
+                fdict = self._fixef_dict[f"C({f})"]
+                omitted_cat = set(self._data[f].unique().astype(str)) - set(
+                    fdict.keys()
+                )
+                if omitted_cat:
+                    fdict.update({x: 0 for x in omitted_cat})
+                fixef_dicts[f"C({f})"] = fdict
             _fixef_mat = _apply_fixef_numpy(df_fe.values, fixef_dicts)
             y_hat += np.sum(_fixef_mat, axis=1)
 


### PR DESCRIPTION
addressing an example from @b-knight on discord: the current `predict` function is quite inefficient in the presence of many FEs. 

I did a quick and dirty numpy implementation (currently implemented as `predict2` : didn't want to override the default predict method in case it upsets some unit tests that I don't know about - @s3alfisc please verify) that yields ~50x speedup and (afaict) no numerical difference. 
[Notebook](https://gist.github.com/apoorvalal/57b70a15f52d5b5612d770d3a414d50b) 

