### PR TITLE
Add `labels` argument to `coefplot()` and `iplot()`

### DIFF
--- a/docs/difference-in-differences.ipynb
+++ b/docs/difference-in-differences.ipynb
@@ -23,7 +23,7 @@
      "data": {
       "text/html": [
        "\n",
-       "            <div id=\"AeFxlr\"></div>\n",
+       "            <div id=\"BBMJkQ\"></div>\n",
        "            <script type=\"text/javascript\" data-lets-plot-script=\"library\">\n",
        "                if(!window.letsPlotCallQueue) {\n",
        "                    window.letsPlotCallQueue = [];\n",
@@ -47,9 +47,9 @@
        "                        var div = document.createElement(\"div\");\n",
        "                        div.style.color = 'darkred';\n",
        "                        div.textContent = 'Error loading Lets-Plot JS';\n",
-       "                        document.getElementById(\"AeFxlr\").appendChild(div);\n",
+       "                        document.getElementById(\"BBMJkQ\").appendChild(div);\n",
        "                    };\n",
-       "                    var e = document.getElementById(\"AeFxlr\");\n",
+       "                    var e = document.getElementById(\"BBMJkQ\");\n",
        "                    e.appendChild(script);\n",
        "                })()\n",
        "            </script>\n",
@@ -63,7 +63,7 @@
      "data": {
       "text/html": [
        "\n",
-       "            <div id=\"qzBb3t\"></div>\n",
+       "            <div id=\"mP5QcD\"></div>\n",
        "            <script type=\"text/javascript\" data-lets-plot-script=\"library\">\n",
        "                if(!window.letsPlotCallQueue) {\n",
        "                    window.letsPlotCallQueue = [];\n",
@@ -87,9 +87,9 @@
        "                        var div = document.createElement(\"div\");\n",
        "                        div.style.color = 'darkred';\n",
        "                        div.textContent = 'Error loading Lets-Plot JS';\n",
-       "                        document.getElementById(\"qzBb3t\").appendChild(div);\n",
+       "                        document.getElementById(\"mP5QcD\").appendChild(div);\n",
        "                    };\n",
-       "                    var e = document.getElementById(\"qzBb3t\");\n",
+       "                    var e = document.getElementById(\"mP5QcD\");\n",
        "                    e.appendChild(script);\n",
        "                })()\n",
        "            </script>\n",
@@ -103,9 +103,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "numpy   : 1.26.4\n",
       "pandas  : 2.2.2\n",
-      "pyfixest: 0.22.0\n",
+      "pyfixest: 0.23.0\n",
       "\n"
      ]
     }
@@ -116,6 +115,7 @@
     "import pyfixest as pf\n",
     "from pyfixest.did.estimation import did2s, lpdid\n",
     "from pyfixest.did.visualize import panelview\n",
+    "from pyfixest.report.utils import rename_event_study_coefs\n",
     "\n",
     "%load_ext watermark\n",
     "%watermark --iversions"
@@ -471,13 +471,13 @@
     {
      "data": {
       "text/html": [
-       "   <div id=\"261BWQ\"></div>\n",
+       "   <div id=\"rwZfUc\"></div>\n",
        "   <script type=\"text/javascript\" data-lets-plot-script=\"plot\">\n",
        "       (function() {\n",
        "           var plotSpec={\n",
        "\"data\":{\n",
        "\"Model\":[\"dep_var~i(rel_year,ref=-1.0)|state+year\",\"dep_var~i(rel_year,ref=-1.0)|state+year\",\"dep_var~i(rel_year,ref=-1.0)|state+year\",\"dep_var~i(rel_year,ref=-1.0)|state+year\",\"dep_var~i(rel_year,ref=-1.0)|state+year\",\"dep_var~i(rel_year,ref=-1.0)|state+year\",\"dep_var~i(rel_year,ref=-1.0)|state+year\",\"dep_var~i(rel_year,ref=-1.0)|state+year\",\"dep_var~i(rel_year,ref=-1.0)|state+year\",\"dep_var~i(rel_year,ref=-1.0)|state+year\",\"dep_var~i(rel_year,ref=-1.0)|state+year\",\"dep_var~i(rel_year,ref=-1.0)|state+year\",\"dep_var~i(rel_year,ref=-1.0)|state+year\",\"dep_var~i(rel_year,ref=-1.0)|state+year\",\"dep_var~i(rel_year,ref=-1.0)|state+year\",\"dep_var~i(rel_year,ref=-1.0)|state+year\",\"dep_var~i(rel_year,ref=-1.0)|state+year\",\"dep_var~i(rel_year,ref=-1.0)|state+year\",\"dep_var~i(rel_year,ref=-1.0)|state+year\",\"dep_var~i(rel_year,ref=-1.0)|state+year\",\"dep_var~i(rel_year,ref=-1.0)|state+year\",\"dep_var~i(rel_year,ref=-1.0)|state+year\",\"dep_var~i(rel_year,ref=-1.0)|state+year\",\"dep_var~i(rel_year,ref=-1.0)|state+year\",\"dep_var~i(rel_year,ref=-1.0)|state+year\",\"dep_var~i(rel_year,ref=-1.0)|state+year\",\"dep_var~i(rel_year,ref=-1.0)|state+year\",\"dep_var~i(rel_year,ref=-1.0)|state+year\",\"dep_var~i(rel_year,ref=-1.0)|state+year\",\"dep_var~i(rel_year,ref=-1.0)|state+year\",\"dep_var~i(rel_year,ref=-1.0)|state+year\",\"dep_var~i(rel_year,ref=-1.0)|state+year\",\"dep_var~i(rel_year,ref=-1.0)|state+year\",\"dep_var~i(rel_year,ref=-1.0)|state+year\",\"dep_var~i(rel_year,ref=-1.0)|state+year\",\"dep_var~i(rel_year,ref=-1.0)|state+year\",\"dep_var~i(rel_year,ref=-1.0)|state+year\",\"dep_var~i(rel_year,ref=-1.0)|state+year\",\"dep_var~i(rel_year,ref=-1.0)|state+year\",\"dep_var~i(rel_year,ref=-1.0)|state+year\",\"dep_var~i(rel_year,ref=-1.0)|state+year\"],\n",
-       "\"Coefficient\":[\"C(rel_year, contr.treatment(base=-1.0))[T.-20.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.-19.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.-18.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.-17.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.-16.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.-15.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.-14.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.-13.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.-12.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.-11.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.-10.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.-9.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.-8.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.-7.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.-6.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.-5.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.-4.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.-3.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.-2.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.0.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.1.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.2.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.3.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.4.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.5.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.6.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.7.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.8.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.9.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.10.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.11.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.12.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.13.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.14.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.15.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.16.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.17.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.18.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.19.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.20.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.inf]\"],\n",
+       "\"Coefficient\":[\"rel_year::-20.0\",\"rel_year::-19.0\",\"rel_year::-18.0\",\"rel_year::-17.0\",\"rel_year::-16.0\",\"rel_year::-15.0\",\"rel_year::-14.0\",\"rel_year::-13.0\",\"rel_year::-12.0\",\"rel_year::-11.0\",\"rel_year::-10.0\",\"rel_year::-9.0\",\"rel_year::-8.0\",\"rel_year::-7.0\",\"rel_year::-6.0\",\"rel_year::-5.0\",\"rel_year::-4.0\",\"rel_year::-3.0\",\"rel_year::-2.0\",\"rel_year::0.0\",\"rel_year::1.0\",\"rel_year::2.0\",\"rel_year::3.0\",\"rel_year::4.0\",\"rel_year::5.0\",\"rel_year::6.0\",\"rel_year::7.0\",\"rel_year::8.0\",\"rel_year::9.0\",\"rel_year::10.0\",\"rel_year::11.0\",\"rel_year::12.0\",\"rel_year::13.0\",\"rel_year::14.0\",\"rel_year::15.0\",\"rel_year::16.0\",\"rel_year::17.0\",\"rel_year::18.0\",\"rel_year::19.0\",\"rel_year::20.0\",\"C(rel_year, contr.treatment(base=-1.0))[T.inf]\"],\n",
        "\"Estimate\":[-0.09944466441181407,6.23519975400307E-4,0.0041247661867057995,0.021899085459484872,-0.03693340882836111,0.06957783836542085,0.03773442317032304,0.06177914337449611,0.08991270466792296,9.822487465557272E-4,-0.11303282051981747,-0.06922462711945501,-0.061289513093629025,-0.0020224309370890357,-0.05580979472634313,-0.06500868193865345,-0.009849959807181893,0.04633807990097424,0.015947312893775302,1.406404490822593,1.6605518884804105,1.7287900538935237,1.8548389960027065,1.9586760781129549,2.082161283635855,2.1910619949213292,2.279072842371443,2.3645934393351222,2.372162693677256,2.6492711880908235,2.753590871536464,2.81393547422749,2.756069650642772,2.8634270216427646,2.9866523455332556,2.9630322165965404,2.972596421114107,2.9350513290126417,2.9187065136810078,2.979701202491609,0.12805306243573136],\n",
        "\"2.5%\":[-0.2646972304933428,-0.16769018688346135,-0.17734940744469135,-0.15141773681725842,-0.23297450453669916,-0.09484387010242724,-0.13746745521817605,-0.10683560211192325,-0.08181351401234342,-0.15902123698075793,-0.2443506562456941,-0.18461172525475772,-0.18338272511269454,-0.1326928866666409,-0.1866256631156632,-0.19609917617687958,-0.11725094987359747,-0.08099122414391938,-0.11642114159510727,1.2938600189553553,1.5290095619722563,1.613915005015481,1.7368859662793283,1.8147741857905726,1.9530023735557007,2.052486677327439,2.1273424786361788,2.2460668440010756,2.257759442916458,2.5356414801659604,2.600825552379849,2.653496368155657,2.5975551692265233,2.6644161435658016,2.797916336046822,2.790239340478468,2.785720671699542,2.7446638314603184,2.7484109878126053,2.802156143045317,-0.030754737319460657],\n",
        "\"97.5%\":[0.06580790166971467,0.16893722683426196,0.18559893981810294,0.19521590773622818,0.15910768687997695,0.23399954683326896,0.21293630155882215,0.23039388886091547,0.26163892334818933,0.16098573447386938,0.018285015206059158,0.046162471015847695,0.06080369892543648,0.12864802479246282,0.07500607366297696,0.06608181229957269,0.09755103025923367,0.17366738394586786,0.14831576738265786,1.5189489626898307,1.7920942149885646,1.8436651027715665,1.9727920257260847,2.102577970435337,2.211320193716009,2.3296373125152194,2.4308032061067073,2.483120034669169,2.486565944438054,2.7629008960156867,2.906356190693079,2.974374580299323,2.914584132059021,3.0624378997197277,3.175388355019689,3.1358250927146125,3.1594721705286717,3.125438826564965,3.08900203954941,3.1572462619379014,0.2868608621909234]\n",
@@ -559,7 +559,7 @@
        "}],\n",
        "\"metainfo_list\":[]\n",
        "};\n",
-       "           var plotContainer = document.getElementById(\"261BWQ\");\n",
+       "           var plotContainer = document.getElementById(\"rwZfUc\");\n",
        "           window.letsPlotCall(function() {{\n",
        "               LetsPlot.buildPlotFromProcessedSpecs(plotSpec, -1, -1, plotContainer);\n",
        "           }});\n",
@@ -578,6 +578,7 @@
     "    figsize=figsize,\n",
     "    xintercept=18.5,\n",
     "    yintercept=0,\n",
+    "    labels = rename_event_study_coefs(fit_twfe._coefnames), # rename coefficients\n",
     ").show()"
    ]
   },
@@ -594,13 +595,13 @@
     {
      "data": {
       "text/html": [
-       "   <div id=\"rVyWC2\"></div>\n",
+       "   <div id=\"3OZ9DJ\"></div>\n",
        "   <script type=\"text/javascript\" data-lets-plot-script=\"plot\">\n",
        "       (function() {\n",
        "           var plotSpec={\n",
        "\"data\":{\n",
        "\"Model\":[\"dep_var_hat~i(rel_year,ref=-1.0)\",\"dep_var_hat~i(rel_year,ref=-1.0)\",\"dep_var_hat~i(rel_year,ref=-1.0)\",\"dep_var_hat~i(rel_year,ref=-1.0)\",\"dep_var_hat~i(rel_year,ref=-1.0)\",\"dep_var_hat~i(rel_year,ref=-1.0)\",\"dep_var_hat~i(rel_year,ref=-1.0)\",\"dep_var_hat~i(rel_year,ref=-1.0)\",\"dep_var_hat~i(rel_year,ref=-1.0)\",\"dep_var_hat~i(rel_year,ref=-1.0)\",\"dep_var_hat~i(rel_year,ref=-1.0)\",\"dep_var_hat~i(rel_year,ref=-1.0)\",\"dep_var_hat~i(rel_year,ref=-1.0)\",\"dep_var_hat~i(rel_year,ref=-1.0)\",\"dep_var_hat~i(rel_year,ref=-1.0)\",\"dep_var_hat~i(rel_year,ref=-1.0)\",\"dep_var_hat~i(rel_year,ref=-1.0)\",\"dep_var_hat~i(rel_year,ref=-1.0)\",\"dep_var_hat~i(rel_year,ref=-1.0)\",\"dep_var_hat~i(rel_year,ref=-1.0)\",\"dep_var_hat~i(rel_year,ref=-1.0)\",\"dep_var_hat~i(rel_year,ref=-1.0)\",\"dep_var_hat~i(rel_year,ref=-1.0)\",\"dep_var_hat~i(rel_year,ref=-1.0)\",\"dep_var_hat~i(rel_year,ref=-1.0)\",\"dep_var_hat~i(rel_year,ref=-1.0)\",\"dep_var_hat~i(rel_year,ref=-1.0)\",\"dep_var_hat~i(rel_year,ref=-1.0)\",\"dep_var_hat~i(rel_year,ref=-1.0)\",\"dep_var_hat~i(rel_year,ref=-1.0)\",\"dep_var_hat~i(rel_year,ref=-1.0)\",\"dep_var_hat~i(rel_year,ref=-1.0)\",\"dep_var_hat~i(rel_year,ref=-1.0)\",\"dep_var_hat~i(rel_year,ref=-1.0)\",\"dep_var_hat~i(rel_year,ref=-1.0)\",\"dep_var_hat~i(rel_year,ref=-1.0)\",\"dep_var_hat~i(rel_year,ref=-1.0)\",\"dep_var_hat~i(rel_year,ref=-1.0)\",\"dep_var_hat~i(rel_year,ref=-1.0)\",\"dep_var_hat~i(rel_year,ref=-1.0)\",\"dep_var_hat~i(rel_year,ref=-1.0)\"],\n",
-       "\"Coefficient\":[\"C(rel_year, contr.treatment(base=-1.0))[T.-20.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.-19.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.-18.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.-17.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.-16.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.-15.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.-14.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.-13.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.-12.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.-11.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.-10.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.-9.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.-8.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.-7.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.-6.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.-5.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.-4.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.-3.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.-2.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.0.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.1.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.2.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.3.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.4.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.5.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.6.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.7.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.8.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.9.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.10.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.11.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.12.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.13.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.14.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.15.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.16.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.17.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.18.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.19.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.20.0]\",\"C(rel_year, contr.treatment(base=-1.0))[T.inf]\"],\n",
+       "\"Coefficient\":[\"rel_year::-20.0\",\"rel_year::-19.0\",\"rel_year::-18.0\",\"rel_year::-17.0\",\"rel_year::-16.0\",\"rel_year::-15.0\",\"rel_year::-14.0\",\"rel_year::-13.0\",\"rel_year::-12.0\",\"rel_year::-11.0\",\"rel_year::-10.0\",\"rel_year::-9.0\",\"rel_year::-8.0\",\"rel_year::-7.0\",\"rel_year::-6.0\",\"rel_year::-5.0\",\"rel_year::-4.0\",\"rel_year::-3.0\",\"rel_year::-2.0\",\"rel_year::0.0\",\"rel_year::1.0\",\"rel_year::2.0\",\"rel_year::3.0\",\"rel_year::4.0\",\"rel_year::5.0\",\"rel_year::6.0\",\"rel_year::7.0\",\"rel_year::8.0\",\"rel_year::9.0\",\"rel_year::10.0\",\"rel_year::11.0\",\"rel_year::12.0\",\"rel_year::13.0\",\"rel_year::14.0\",\"rel_year::15.0\",\"rel_year::16.0\",\"rel_year::17.0\",\"rel_year::18.0\",\"rel_year::19.0\",\"rel_year::20.0\",\"C(rel_year, contr.treatment(base=-1.0))[T.inf]\"],\n",
        "\"Estimate\":[-0.07930900259626203,-0.02711527692295062,-0.027235402463776405,-0.033616340960386695,-0.055780655419594205,0.016745169380410263,-0.020869904492020277,-0.022209791559758614,0.00544710624064335,-0.04792471572381649,-0.03247849876040112,-0.037517320624783704,-0.030855210934354546,-0.007103797964663784,-0.03959725316883278,-0.07918224438339333,-0.034225503853840766,-0.01521372832580776,-0.03868704577129315,1.3044623834822837,1.5334859508078482,1.5971059113541846,1.7188457243602804,1.846295731365529,1.9905870364602578,2.078882518586963,2.1653976455207697,2.2589503298971727,2.2777620650044526,2.4147670896846156,2.4563355023754894,2.5072972378725447,2.481397359082737,2.626323300651735,2.812630406322005,2.762680227967199,2.8112964819353956,2.777034681333358,2.7861621743322673,2.814858795952651,0.03050454118024963],\n",
        "\"2.5%\":[-0.16955781844097395,-0.13130540752952802,-0.12259486455253849,-0.11756229552710791,-0.15942948977871008,-0.08271122043711725,-0.11742739732712289,-0.10019842442337348,-0.08409356252878664,-0.16434851717383725,-0.09940983870637829,-0.0971549340454542,-0.09366907924437727,-0.0783186413761468,-0.09280839270380008,-0.13882391873963604,-0.08903831271826186,-0.07493552208292513,-0.10202026432446265,1.1945973124552016,1.4072868326693206,1.486009874442145,1.6001313401869777,1.7528206626653347,1.8801634233496578,1.9527983426658595,2.0508390276456767,2.1453448544771807,2.1733017782429664,2.2970329618124192,2.2958846211501216,2.350999963755612,2.3156571517743996,2.4896398448330133,2.6504974566060113,2.601106273194042,2.65573568967989,2.6167655931332265,2.609420565752094,2.6520895753787617,-0.009718593893343147],\n",
        "\"97.5%\":[0.010939813248449906,0.07707485368362677,0.06812405962498569,0.05032961360633452,0.04786817893952168,0.11620155919793777,0.07568758834308233,0.05577884130385625,0.09498777501007333,0.06849908572620428,0.034452841185576046,0.02212029279588678,0.03195865737566818,0.06411104544681923,0.013613886366134517,-0.01954057002715063,0.02058730501058033,0.044508065431309606,0.024646172781876342,1.4143274545093658,1.6596850689463758,1.708201948266224,1.837560108533583,1.9397708000657234,2.101010649570858,2.204966694508066,2.2799562633958628,2.3725558053171647,2.3822223517659387,2.532501217556812,2.616786383600857,2.6635945119894773,2.647137566391075,2.7630067564704563,2.9747633560379985,2.9242541827403556,2.966857274190901,2.93730376953349,2.9629037829124405,2.9776280165265403,0.07072767625384241]\n",
@@ -682,7 +683,7 @@
        "}],\n",
        "\"metainfo_list\":[]\n",
        "};\n",
-       "           var plotContainer = document.getElementById(\"rVyWC2\");\n",
+       "           var plotContainer = document.getElementById(\"3OZ9DJ\");\n",
        "           window.letsPlotCall(function() {{\n",
        "               LetsPlot.buildPlotFromProcessedSpecs(plotSpec, -1, -1, plotContainer);\n",
        "           }});\n",
@@ -701,6 +702,7 @@
     "    figsize=figsize,\n",
     "    xintercept=18.5,\n",
     "    yintercept=0,\n",
+    "    labels = rename_event_study_coefs(fit_twfe._coefnames), # rename coefficients\n",
     ").show()"
    ]
   },
@@ -712,7 +714,7 @@
     {
      "data": {
       "text/html": [
-       "   <div id=\"jNxJ0k\"></div>\n",
+       "   <div id=\"KqDvev\"></div>\n",
        "   <script type=\"text/javascript\" data-lets-plot-script=\"plot\">\n",
        "       (function() {\n",
        "           var plotSpec={\n",
@@ -800,7 +802,7 @@
        "}],\n",
        "\"metainfo_list\":[]\n",
        "};\n",
-       "           var plotContainer = document.getElementById(\"jNxJ0k\");\n",
+       "           var plotContainer = document.getElementById(\"KqDvev\");\n",
        "           window.letsPlotCall(function() {{\n",
        "               LetsPlot.buildPlotFromProcessedSpecs(plotSpec, -1, -1, plotContainer);\n",
        "           }});\n",

--- a/pyfixest/report/summarize.py
+++ b/pyfixest/report/summarize.py
@@ -9,6 +9,7 @@ from pyfixest.estimation.feiv_ import Feiv
 from pyfixest.estimation.feols_ import Feols
 from pyfixest.estimation.fepois_ import Fepois
 from pyfixest.estimation.FixestMulti_ import FixestMulti
+from pyfixest.report.utils import _relabel_expvar
 from pyfixest.utils.dev_utils import _select_order_coefs
 
 
@@ -643,33 +644,3 @@ def _number_formatter(x: float, **kwargs) -> str:
     _int, _float = str(x_str).split(".")
     _float = _float.ljust(digits, "0")
     return _int if digits == 0 else f"{_int}.{_float}"
-
-
-def _relabel_expvar(varname: str, labels: dict, interaction_symbol: str):
-    """
-    Relabel a variable name using the labels dictionary
-    Also automatically relabel interaction terms using the labels of the individual variables.
-
-    Parameters
-    ----------
-    varname: str
-        The varname in the regression.
-    labels: dict
-        A dictionary to relabel the variables. The keys are the original variable names and the values the new names.
-    interaction_symbol: str
-        The symbol to use for displaying the interaction term.
-
-    Returns
-    -------
-    str
-        The relabeled variable
-    """
-    # When varname in labels dictionary, then relabel (note: this allows also to manually rename interaction terms in the dictionary)
-    # Otherwise: When interaction term, then split by vars, relabel, and join using interaction symbol
-    if varname in labels:
-        return labels[varname]
-    elif ":" in varname:
-        vars = varname.split(":")
-        relabeled_vars = [labels.get(v, v) for v in vars]
-        return interaction_symbol.join(relabeled_vars)
-    return varname

--- a/pyfixest/report/utils.py
+++ b/pyfixest/report/utils.py
@@ -1,0 +1,60 @@
+import re
+
+
+def _relabel_expvar(varname: str, labels: dict, interaction_symbol: str):
+    """
+    Relabel a variable name using the labels dictionary
+    Also automatically relabel interaction terms using the labels of the individual variables.
+
+    Parameters
+    ----------
+    varname: str
+        The varname in the regression.
+    labels: dict
+        A dictionary to relabel the variables. The keys are the original variable names and the values the new names.
+    interaction_symbol: str
+        The symbol to use for displaying the interaction term.
+
+    Returns
+    -------
+    str
+        The relabeled variable
+    """
+    # When varname in labels dictionary, then relabel (note: this allows also to manually rename interaction terms in the dictionary)
+    # Otherwise: When interaction term, then split by vars, relabel, and join using interaction symbol
+    if varname in labels:
+        return labels[varname]
+    elif ":" in varname:
+        vars = varname.split(":")
+        relabeled_vars = [labels.get(v, v) for v in vars]
+        return interaction_symbol.join(relabeled_vars)
+    return varname
+
+
+def _rename_categorical(col_name):
+    match = re.match(r"C\(([^)]+)\)\[T\.([\d\.]+)\]", col_name)
+    if match:
+        return f"{match.group(1)}::{int(float(match.group(2)))}"
+    return col_name
+
+
+def rename_categorical(coef_names_list: list) -> dict:
+    """
+    Rename the categorical variables in the coef_names_list.
+
+    Parameters
+    ----------
+    coef_names_list: list
+        The list of coefficient names.
+
+    Returns
+    -------
+    dict
+        A dictionary with the renamed variables.
+
+    Examples
+    --------
+    rename_categorical(["C(var)[T.1]", "C(var)[T.2]", "C(var2)[T.1]", "C(var2)[T.2]"])
+    {'C(var)[T.1]': 'var::1', 'C(var)[T.2]': 'var::2', 'C(var2)[T.1]': 'var2::1', 'C(var2)[T.2]': 'var2::2'}
+    """
+    return {col: _rename_categorical(col) for col in coef_names_list}

--- a/pyfixest/report/utils.py
+++ b/pyfixest/report/utils.py
@@ -32,10 +32,18 @@ def _relabel_expvar(varname: str, labels: dict, interaction_symbol: str):
 
 
 def _rename_categorical(col_name):
-    match = re.match(r"C\(([^)]+)\)\[T\.([\d\.]+)\]", col_name)
+    pattern = r"C\(([^,]+)(?:,[^]]+)?\)\[T\.([^]]+)\]"
+
+    # Apply the regex to extract the variable and level
+    match = re.search(pattern, col_name)
+
     if match:
-        return f"{match.group(1)}::{int(float(match.group(2)))}"
-    return col_name
+        variable = match.group(1)
+        level = match.group(2)
+        result = f"{variable}::{level}"
+        return result
+    else:
+        return col_name
 
 
 def rename_categoricals(coef_names_list: list) -> dict:
@@ -58,3 +66,43 @@ def rename_categoricals(coef_names_list: list) -> dict:
     {'C(var)[T.1]': 'var::1', 'C(var)[T.2]': 'var::2', 'C(var2)[T.1]': 'var2::1', 'C(var2)[T.2]': 'var2::2'}
     """
     return {col: _rename_categorical(col) for col in coef_names_list}
+
+
+def _rename_event_study_coefs(col_name: str):
+    pattern = r"C\(([^,]+)(?:,[^]]+)?\)\[T\.(-?\d+(?:\.\d+)?)\]"
+    match = re.search(pattern, col_name)
+
+    if match:
+        variable = match.group(1)
+        level = match.group(2)
+        result = f"{variable}::{level}"
+        return result
+    else:
+        return col_name
+
+
+def rename_event_study_coefs(coef_names_list: list):
+    """
+    Rename the event study coefficients in the coef_names_list.
+
+    Parameters
+    ----------
+    coef_names_list: list
+        The list of coefficient names to rename.
+
+    Returns
+    -------
+    dict
+        A dictionary with the renamed variables ready to be passed
+        to the "labels" argument of coefplot() and iplot().
+
+    Examples
+    --------
+    rename_event_study_coefs(["C(rel_year, contr.treatment(base=-1.0))[T.-20.0]", "C(rel_year, contr.treatment(base=-1.0))[T.-19.0]", "Intercept"])
+        {
+            'C(rel_year, contr.treatment(base=-1.0))[T.-20.0]': 'rel_year::-20.0',
+            'C(rel_year, contr.treatment(base=-1.0))[T.-19.0]': 'rel_year::-19.0',
+            'Intercept': 'Intercept'
+        }
+    """
+    return {col: _rename_event_study_coefs(col) for col in coef_names_list}

--- a/pyfixest/report/utils.py
+++ b/pyfixest/report/utils.py
@@ -38,7 +38,7 @@ def _rename_categorical(col_name):
     return col_name
 
 
-def rename_categorical(coef_names_list: list) -> dict:
+def rename_categoricals(coef_names_list: list) -> dict:
     """
     Rename the categorical variables in the coef_names_list.
 

--- a/pyfixest/report/visualize.py
+++ b/pyfixest/report/visualize.py
@@ -126,13 +126,14 @@ def iplot(
     --------
     ```{python}
     import pyfixest as pf
+    from pyfixest.report.utils import rename_categoricals
 
     df = pf.get_data()
     fit1 = pf.feols("Y ~ i(f1)", data = df)
     fit2 = pf.feols("Y ~ i(f1) + X2", data = df)
     fit3 = pf.feols("Y ~ i(f1) + X2 | f2", data = df)
 
-    pf.iplot([fit1, fit2, fit3])
+    pf.iplot([fit1, fit2, fit3], labels = rename_categoricals(fit1._coefnames))
     ```
     """
     models = _post_processing_input_checks(models)
@@ -253,13 +254,17 @@ def coefplot(
     --------
     ```{python}
     import pyfixest as pf
+    from pyfixest.report.utils import rename_categoricals
 
     df = pf.get_data()
     fit1 = pf.feols("Y ~ X1", data = df)
     fit2 = pf.feols("Y ~ X1 + X2", data = df)
     fit3 = pf.feols("Y ~ X1 + X2 | f1", data = df)
+    fit4 = pf.feols("Y ~ C(X1)", data = df)
 
     pf.coefplot([fit1, fit2, fit3])
+    pf.coefplot([fit4], labels = rename_categoricals(fit1._coefnames))
+
     ```
     """
     models = _post_processing_input_checks(models)

--- a/pyfixest/report/visualize.py
+++ b/pyfixest/report/visualize.py
@@ -21,6 +21,7 @@ from lets_plot import (
 )
 
 from pyfixest.report.summarize import _post_processing_input_checks
+from pyfixest.report.utils import _relabel_expvar
 from pyfixest.utils.dev_utils import _select_order_coefs
 
 LetsPlot.setup_html()
@@ -68,6 +69,7 @@ def iplot(
     drop: Optional[Union[list, str]] = None,
     exact_match: bool = False,
     plot_backend: str = "lets_plot",
+    labels: Optional[dict] = None,
 ):
     r"""
     Plot model coefficients for variables interacted via "i()" syntax, with
@@ -111,6 +113,9 @@ def iplot(
         instead of using regular expressions.
     plot_backend: str, optional
         The plotting backend to use between "lets_plot" (default) and "matplotlib".
+    labels: dict, optional
+        A dictionary to relabel the variables. The keys are the original variable names and the values the new names.
+        The renaming is applied after the selection of the coefficients via `keep` and `drop`.
 
     Returns
     -------
@@ -148,7 +153,7 @@ def iplot(
                 "In consequence, the '.iplot()' method is not supported."
             )
         all_icovars += fxst._icovars
-        df_model = fxst.tidy(alpha = alpha).reset_index()  # Coefficient -> simple column
+        df_model = fxst.tidy(alpha=alpha).reset_index()  # Coefficient -> simple column
         df_model["fml"] = fxst._fml
         df_model.set_index("fml", inplace=True)
         df_all.append(df_model)
@@ -176,6 +181,7 @@ def iplot(
         rotate_xticks=rotate_xticks,
         title=title,
         flip_coord=coord_flip,
+        labels=labels,
     )
 
 
@@ -192,6 +198,7 @@ def coefplot(
     drop: Optional[Union[list, str]] = None,
     exact_match: bool = False,
     plot_backend: str = "lets_plot",
+    labels: Optional[dict] = None,
 ):
     r"""
     Plot model coefficients with confidence intervals.
@@ -233,6 +240,9 @@ def coefplot(
         instead of using regular expressions.
     plot_backend: str, optional
         The plotting backend to use between "lets_plot" (default) and "matplotlib".
+    labels: dict, optional
+        A dictionary to relabel the variables. The keys are the original variable names and the values the new names.
+        The renaming is applied after the selection of the coefficients via `keep` and `drop`.
 
     Returns
     -------
@@ -284,6 +294,7 @@ def coefplot(
         rotate_xticks=rotate_xticks,
         title=title,
         flip_coord=coord_flip,
+        labels=labels,
     )
 
 
@@ -307,6 +318,7 @@ def _coefplot_lets_plot(
     rotate_xticks: float = 0,
     title: Optional[str] = None,
     flip_coord: Optional[bool] = True,
+    labels: Optional[dict] = None,
 ):
     """
     Plot model coefficients with confidence intervals.
@@ -329,15 +341,25 @@ def _coefplot_lets_plot(
         The title of the plot.
     flip_coord : bool, optional
         Whether to flip the coordinates of the plot. Default is True.
+    labels : dict, optional
+        A dictionary to relabel the variables. The keys are the original variable names and the values the new names.
 
     Returns
     -------
     object
         A lets-plot figure.
     """
+    # import pdb; pdb.set_trace()
+
     df.reset_index(inplace=True)
     df.rename(columns={"fml": "Model"}, inplace=True)
     ub, lb = 1 - alpha / 2, alpha / 2
+
+    if labels is not None:
+        interactionSymbol = " x "
+        df["Coefficient"] = df["Coefficient"].apply(
+            lambda x: _relabel_expvar(x, labels, interactionSymbol)
+        )
 
     plot = (
         ggplot(df, aes(x="Coefficient", y="Estimate", color="Model"))
@@ -375,6 +397,7 @@ def _coefplot_matplotlib(
     rotate_xticks: float = 0,
     title: Optional[str] = None,
     flip_coord: Optional[bool] = True,
+    labels: Optional[dict] = None,
     **fig_kwargs,
 ) -> so.Plot:
     """
@@ -400,6 +423,8 @@ def _coefplot_matplotlib(
         The title of the plot.
     flip_coord : bool, optional
         Whether to flip the coordinates of the plot. Default is True.
+    labels : dict, optional
+        A dictionary to relabel the variables. The keys are the original variable names and the values the new names.
     fig_kwargs : dict
         Additional keyword arguments to pass to the matplotlib figure.
 
@@ -412,6 +437,11 @@ def _coefplot_matplotlib(
     --------
     - https://seaborn.pydata.org/tutorial/objects_interface.html
     """
+    if labels is not None:
+        interactionSymbol = " x "
+        df["Coefficient"] = df["Coefficient"].apply(
+            lambda x: _relabel_expvar(x, labels, interactionSymbol)
+        )
     yintercept = yintercept if yintercept is not None else 0
     ub, lb = alpha / 2, 1 - alpha / 2
     title = title if title is not None else "Coefficient Plot"

--- a/tests/test_others.py
+++ b/tests/test_others.py
@@ -3,6 +3,7 @@ import pandas as pd
 import polars as pl
 
 from pyfixest.estimation.estimation import feols, fepois
+from pyfixest.report.utils import rename_categoricals
 from pyfixest.utils.utils import get_data, ssc
 
 
@@ -74,6 +75,7 @@ def test_coef_update():
 
     np.testing.assert_allclose(updated_coefs, full_coefs)
 
+
 def test_coef_update_inplace():
     data = get_data()
     data_subsample = data.sample(frac=0.3)
@@ -83,7 +85,9 @@ def test_coef_update_inplace():
     )
     X_new, y_new = (
         np.c_[
-            data.loc[new_points_id][["X1", "X2"]].values # only pass columns; let `update` add the intercept
+            data.loc[new_points_id][
+                ["X1", "X2"]
+            ].values  # only pass columns; let `update` add the intercept
         ],
         data.loc[new_points_id]["Y"].values,
     )
@@ -97,3 +101,14 @@ def test_coef_update_inplace():
         .values
     )
     np.testing.assert_allclose(m.coef().values, full_coefs)
+
+
+def test_rename_categoricals():
+    coefnames = ["C(var)[T.1]", "C(var)[T.2]", "C(var2)[T.1]", "C(var2)[T.2]"]
+    renamed = rename_categoricals(coefnames)
+    assert renamed == {
+        "C(var)[T.1]": "var::1",
+        "C(var)[T.2]": "var::2",
+        "C(var2)[T.1]": "var2::1",
+        "C(var2)[T.2]": "var2::2",
+    }

--- a/tests/test_others.py
+++ b/tests/test_others.py
@@ -3,7 +3,7 @@ import pandas as pd
 import polars as pl
 
 from pyfixest.estimation.estimation import feols, fepois
-from pyfixest.report.utils import rename_categoricals
+from pyfixest.report.utils import rename_categoricals, rename_event_study_coefs
 from pyfixest.utils.utils import get_data, ssc
 
 
@@ -111,4 +111,41 @@ def test_rename_categoricals():
         "C(var)[T.2]": "var::2",
         "C(var2)[T.1]": "var2::1",
         "C(var2)[T.2]": "var2::2",
+    }
+
+    # with strings:
+    coefnames = ["Intercept", "C(f4)[T.B]", "C(f4)[T.C]"]
+    renamed = rename_categoricals(coefnames)
+    assert renamed == {
+        "Intercept": "Intercept",
+        "C(f4)[T.B]": "f4::B",
+        "C(f4)[T.C]": "f4::C",
+    }
+
+    # with reference levels:
+    coefnames = [
+        "Intercept",
+        "C(f4, contr.treatment(base='A'))[T.B]",
+        "C(f4, contr.treatment(base='A'))[T.C]",
+    ]
+    renamed = rename_categoricals(coefnames)
+    assert renamed == {
+        "Intercept": "Intercept",
+        "C(f4, contr.treatment(base='A'))[T.B]": "f4::B",
+        "C(f4, contr.treatment(base='A'))[T.C]": "f4::C",
+    }
+
+
+def test_rename_event_study_coefs():
+    coefnames = [
+        "C(rel_year, contr.treatment(base=-1.0))[T.-20.0]",
+        "C(rel_year, contr.treatment(base=-1.0))[T.-19.0]",
+        "Intercept",
+    ]
+
+    renamed = rename_event_study_coefs(coefnames)
+    assert renamed == {
+        "C(rel_year, contr.treatment(base=-1.0))[T.-20.0]": "rel_year::-20.0",
+        "C(rel_year, contr.treatment(base=-1.0))[T.-19.0]": "rel_year::-19.0",
+        "Intercept": "Intercept",
     }

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -31,6 +31,11 @@ def fit3(data):
 
 
 @pytest.fixture
+def fit4(data):
+    return feols(fml="Y ~ i(f2)", data=data, vcov="iid")
+
+
+@pytest.fixture
 def fit_multi(data):
     return feols(fml="Y + Y2 ~ i(f2, X1)", data=data)
 
@@ -91,10 +96,16 @@ def test_set_figsize_none_bad_backend():
 @pytest.mark.parametrize(
     argnames="coord_flip", argvalues=[True, False], ids=["coord_flip", "no_coord_flip"]
 )
+@pytest.mark.parametrize(
+    argnames="labels",
+    argvalues=[None, {"f2": "F2", "X1": "1x"}],
+    ids=["no_labels", "labels"],
+)
 def test_iplot(
     fit1,
     fit2,
     fit3,
+    fit4,
     fit_multi,
     plot_backend,
     figsize,
@@ -103,6 +114,7 @@ def test_iplot(
     drop,
     title,
     coord_flip,
+    labels,
 ):
     plot_kwargs = {
         "plot_backend": plot_backend,
@@ -112,11 +124,13 @@ def test_iplot(
         "drop": drop,
         "title": title,
         "coord_flip": coord_flip,
+        "labels": labels,
     }
 
     fit1.iplot(**plot_kwargs)
     fit2.iplot(**plot_kwargs)
     fit3.iplot(**plot_kwargs)
+    fit4.iplot(**plot_kwargs)
     fit_multi.iplot(**plot_kwargs)
 
     iplot(fit1, **plot_kwargs)
@@ -156,10 +170,16 @@ def test_iplot_error(data):
 @pytest.mark.parametrize(
     argnames="coord_flip", argvalues=[True, False], ids=["coord_flip", "no_coord_flip"]
 )
+@pytest.mark.parametrize(
+    argnames="labels",
+    argvalues=[None, {"f2": "F2", "X1": "1x"}],
+    ids=["no_labels", "labels"],
+)
 def test_coefplot(
     fit1,
     fit2,
     fit3,
+    fit4,
     fit_multi,
     plot_backend,
     figsize,
@@ -169,6 +189,7 @@ def test_coefplot(
     drop,
     title,
     coord_flip,
+    labels,
 ):
     plot_kwargs = {
         "plot_backend": plot_backend,
@@ -179,11 +200,13 @@ def test_coefplot(
         "drop": drop,
         "title": title,
         "coord_flip": coord_flip,
+        "labels": labels,
     }
 
     fit1.coefplot(**plot_kwargs)
     fit2.coefplot(**plot_kwargs)
     fit3.coefplot(**plot_kwargs)
+    fit4.coefplot(**plot_kwargs)
     coefplot(fit1, **plot_kwargs)
     coefplot([fit1, fit2], **plot_kwargs)
     fit_multi.coefplot(**plot_kwargs)


### PR DESCRIPTION
Supports `labels` args for plotting functions, using @dsliwka's code for renaming etable output: 

![image](https://github.com/user-attachments/assets/662057ef-0719-4c8e-95f4-e851a062fd2c)
