### PR TITLE
fix bug in etable #

### DIFF
--- a/pyfixest/report/summarize.py
+++ b/pyfixest/report/summarize.py
@@ -254,6 +254,8 @@ def etable(
                 for i, model in enumerate(models):
                     if model._fixef is not None and fixef in model._fixef.split("+"):
                         fe_df.loc[i, fixef] = "x"
+                    else:
+                        fe_df.loc[i, fixef] = "-"
     # Replace NaNs with empty strings
     fe_df.fillna("-", inplace=True)
     # Sort by model

--- a/pyfixest/report/summarize.py
+++ b/pyfixest/report/summarize.py
@@ -256,8 +256,6 @@ def etable(
                         fe_df.loc[i, fixef] = "x"
                     else:
                         fe_df.loc[i, fixef] = "-"
-    # Replace NaNs with empty strings
-    fe_df.fillna("-", inplace=True)
     # Sort by model
     fe_df.sort_index(inplace=True)
     # Transpose & concatenate the two dataframes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyfixest"
-version = "0.24.0"
+version = "0.24.1"
 
 description = "Fast high dimensional fixed effect estimation following syntax of the fixest R package. Supports OLS, IV and Poisson regression and a range of inference procedures (HC1-3, CRV1 & CRV3, wild bootstrap, randomization inference, simultaneous CIs, Romano-Wolf's multiple testing correction). Additionally, supports (some of) the regression based new Difference-in-Differences Estimators (Did2s, Linear Projections)."
 authors = ["Alexander Fischer <alexander-fischer1801@t-online.de>", "Styfen Schär"]


### PR DESCRIPTION
Fixes #593. 

Example: 

```python
%load_ext autoreload
%autoreload 2

import pyfixest as pf

data = pf.get_data()
fit1 = pf.feols("Y ~ X1 | f1", data = data)
fit2 = pf.feols("Y ~ X1 ", data = data)

pf.etable([fit1, fit2])
```
![image](https://github.com/user-attachments/assets/85cd938f-2f3c-4fae-9376-0275d15d80ef)

```python
pf.etable([fit2, fit1])
```
![image](https://github.com/user-attachments/assets/a28d3521-8f07-49cc-bff2-684b0a416071)
