### PR TITLE
only coverage for pyfixest folder

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -48,6 +48,8 @@ jobs:
           poetry run pytest tests -m "not (extended or slow)" --cov=pyfixest --cov-report=xml
       - name: Upload to Codecov
         uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   test_slow:
     name: "Test Slow"

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Run tests
         run: |
-          poetry run pytest tests -m "not (extended or slow)" --cov=./ --cov-report=xml
+          poetry run pytest tests -m "not (extended or slow)" --cov=pyfixest --cov-report=xml
       - name: Upload to Codecov
         uses: codecov/codecov-action@v4
 


### PR DESCRIPTION
Updates to the CI pipeline:

- Compute coverage only for the content of `pyfixest/`
- Add dedicated codecov token