### PR TITLE
Bug fix to display default table note in etable

### DIFF
--- a/pyfixest/report/summarize.py
+++ b/pyfixest/report/summarize.py
@@ -444,7 +444,7 @@ def etable(
             res_all.columns = pd.MultiIndex.from_arrays(cindex)
 
         # Generate generic note string if none is provided
-        if notes is None:
+        if notes == "":
             if type == "gt":
                 notes = (
                     f"Significance levels: * p < {signif_code[2]}, ** p < {signif_code[1]}, *** p < {signif_code[0]}. "


### PR DESCRIPTION
Correct a bug in etable causing that the default table notes are not displayed when the user specifies no custom notes.  