### PR TITLE
Predict

### DIFF
--- a/pyfixest/estimation/feiv_.py
+++ b/pyfixest/estimation/feiv_.py
@@ -281,7 +281,9 @@ class Feiv(Feols):
             self._pi_hat = model1._beta_hat
 
             # Use fitted values from the first stage
-            self._X_hat = model1._X @ model1._beta_hat  # note that model1._X is demeaned
+            self._X_hat = (
+                model1._X @ model1._beta_hat
+            )  # note that model1._X is demeaned
 
             # Residuals from the first stage
             self._v_hat = model1._u_hat

--- a/pyfixest/estimation/feiv_.py
+++ b/pyfixest/estimation/feiv_.py
@@ -230,8 +230,9 @@ class Feiv(Feols):
         B = H @ self._tZy
         self._beta_hat = self.solve_ols(A, B, _solver)
 
-        # Predicted values and residuals
-        self._get_residuals_and_predictors()
+        # residuals
+        self._u_hat = self._Y.flatten() - (self._X @ self._beta_hat).flatten()
+        self._get_predictors()
 
         # Compute scores and hessian
         self._scores = self._Z * self._u_hat[:, None]

--- a/pyfixest/estimation/feiv_.py
+++ b/pyfixest/estimation/feiv_.py
@@ -231,8 +231,7 @@ class Feiv(Feols):
         self._beta_hat = self.solve_ols(A, B, _solver)
 
         # Predicted values and residuals
-        self._Y_hat_link = self._X @ self._beta_hat
-        self._u_hat = self._Y.flatten() - self._Y_hat_link.flatten()
+        self._get_residuals_and_predictors()
 
         # Compute scores and hessian
         self._scores = self._Z * self._u_hat[:, None]

--- a/pyfixest/estimation/feiv_.py
+++ b/pyfixest/estimation/feiv_.py
@@ -281,7 +281,7 @@ class Feiv(Feols):
             self._pi_hat = model1._beta_hat
 
             # Use fitted values from the first stage
-            self._X_hat = model1._Y_hat_link
+            self._X_hat = model1._X @ model1._beta_hat  # note that model1._X is demeaned
 
             # Residuals from the first stage
             self._v_hat = model1._u_hat

--- a/pyfixest/estimation/feols_.py
+++ b/pyfixest/estimation/feols_.py
@@ -2,7 +2,7 @@ import functools
 import gc
 import warnings
 from importlib import import_module
-from typing import Optional, Union, Literal, get_args
+from typing import Literal, Optional, Union, get_args
 
 import numba as nb
 import numpy as np
@@ -452,6 +452,11 @@ class Feols:
         else:
             raise ValueError(f"Solver {solver} not supported.")
 
+    def _get_residuals_and_predictors(self) -> None:
+        self._u_hat = self._Y.flatten() - (self._X @ self._beta_hat).flatten()
+        self._Y_hat_link = self._Y_untransformed.values.flatten() - self.resid()
+        self._Y_hat_response = self._Y_hat_link
+
     def get_fit(self) -> None:
         """
         Fit an OLS model.
@@ -473,9 +478,7 @@ class Feols:
 
             self._beta_hat = self.solve_ols(self._tZX, self._tZy, _solver)
 
-            self._u_hat = self._Y.flatten() -  (self._X @ self._beta_hat).flatten()
-            self._Y_hat_link = self._Y_untransformed.values.flatten() - self.resid()
-            self._Y_hat_response = self._Y_hat_link
+            self._get_residuals_and_predictors()
 
             self._scores = _X * self._u_hat[:, None]
             self._hessian = self._tZX.copy()

--- a/pyfixest/estimation/feols_.py
+++ b/pyfixest/estimation/feols_.py
@@ -452,8 +452,7 @@ class Feols:
         else:
             raise ValueError(f"Solver {solver} not supported.")
 
-    def _get_residuals_and_predictors(self) -> None:
-        self._u_hat = self._Y.flatten() - (self._X @ self._beta_hat).flatten()
+    def _get_predictors(self) -> None:
         self._Y_hat_link = self._Y_untransformed.values.flatten() - self.resid()
         self._Y_hat_response = self._Y_hat_link
 
@@ -478,7 +477,7 @@ class Feols:
 
             self._beta_hat = self.solve_ols(self._tZX, self._tZy, _solver)
 
-            self._get_residuals_and_predictors()
+            self._u_hat = self._Y.flatten() - (self._X @ self._beta_hat).flatten()
 
             self._scores = _X * self._u_hat[:, None]
             self._hessian = self._tZX.copy()
@@ -486,6 +485,8 @@ class Feols:
             # IV attributes, set to None for OLS, Poisson
             self._tXZ = np.array([])
             self._tZZinv = np.array([])
+
+        self._get_predictors()
 
     def vcov(
         self, vcov: Union[str, dict[str, str]], data: Optional[DataFrameType] = None

--- a/pyfixest/estimation/feols_.py
+++ b/pyfixest/estimation/feols_.py
@@ -42,6 +42,7 @@ from pyfixest.utils.utils import get_ssc, simultaneous_crit_val
 
 prediction_type = Literal["response", "link"]
 
+
 class Feols:
     """
     Non user-facing class to estimate a linear regression via OLS.
@@ -1598,10 +1599,12 @@ class Feols:
             )
         valid_types = get_args(prediction_type)
         if type not in valid_types:
-            raise ValueError(f"Invalid prediction type. Expecting one of {valid_types}. Got {type}")
+            raise ValueError(
+                f"Invalid prediction type. Expecting one of {valid_types}. Got {type}"
+            )
 
         if newdata is None:
-            if type == "link" or self._method == 'feols':
+            if type == "link" or self._method == "feols":
                 return self._Y_hat_link
             else:
                 return self._Y_hat_response

--- a/pyfixest/estimation/feols_.py
+++ b/pyfixest/estimation/feols_.py
@@ -2,7 +2,7 @@ import functools
 import gc
 import warnings
 from importlib import import_module
-from typing import Optional, Union
+from typing import Optional, Union, Literal, get_args
 
 import numba as nb
 import numpy as np
@@ -40,6 +40,7 @@ from pyfixest.utils.dev_utils import (
 )
 from pyfixest.utils.utils import get_ssc, simultaneous_crit_val
 
+prediction_type = Literal["response", "link"]
 
 class Feols:
     """
@@ -80,9 +81,9 @@ class Feols:
         Indicates whether instrumental variables are used, initialized as False.
 
     _Y : np.ndarray
-        The dependent variable array.
+        The demeaned dependent variable, a two-dimensional numpy array.
     _X : np.ndarray
-        The independent variables array.
+        The demeaned independent variables, a two-dimensional numpy array.
     _X_is_empty : bool
         Indicates whether the X array is empty.
     _collin_tol : float
@@ -128,9 +129,9 @@ class Feols:
     _beta_hat : np.ndarray
         Estimated regression coefficients.
     _Y_hat_link : np.ndarray
-        Predicted values of the dependent variable.
+        Prediction at the level of the explanatory variable, i.e., the linear predictor X @ beta.
     _Y_hat_response : np.ndarray
-        Response predictions of the model.
+        Prediction at the level of the response variable, i.e., the expected predictor E(Y|X).
     _u_hat : np.ndarray
         Residuals of the regression model.
     _scores : np.ndarray
@@ -472,8 +473,9 @@ class Feols:
 
             self._beta_hat = self.solve_ols(self._tZX, self._tZy, _solver)
 
-            self._Y_hat_link = self._X @ self._beta_hat
-            self._u_hat = self._Y.flatten() - self._Y_hat_link.flatten()
+            self._u_hat = self._Y.flatten() -  (self._X @ self._beta_hat).flatten()
+            self._Y_hat_link = self._Y_untransformed.values.flatten() - self.resid()
+            self._Y_hat_response = self._Y_hat_link
 
             self._scores = _X * self._u_hat[:, None]
             self._hessian = self._tZX.copy()
@@ -1550,7 +1552,7 @@ class Feols:
         newdata: Optional[DataFrameType] = None,
         atol: float = 1e-6,
         btol: float = 1e-6,
-        type: str = "link",
+        type: prediction_type = "link",
     ) -> np.ndarray:
         """
         Predict values of the model on new data.
@@ -1590,9 +1592,15 @@ class Feols:
             raise NotImplementedError(
                 "The predict() method is currently not supported for IV models."
             )
+        valid_types = get_args(prediction_type)
+        if type not in valid_types:
+            raise ValueError(f"Invalid prediction type. Expecting one of {valid_types}. Got {type}")
 
         if newdata is None:
-            return self._Y_untransformed.to_numpy().flatten() - self.resid()
+            if type == "link" or self._method == 'feols':
+                return self._Y_hat_link
+            else:
+                return self._Y_hat_response
 
         newdata = _polars_to_pandas(newdata).reset_index(drop=False)
 

--- a/pyfixest/estimation/feols_compressed_.py
+++ b/pyfixest/estimation/feols_compressed_.py
@@ -6,7 +6,7 @@ import pandas as pd
 import polars as pl
 from tqdm import tqdm
 
-from pyfixest.estimation.feols_ import Feols
+from pyfixest.estimation.feols_ import Feols, prediction_type
 from pyfixest.estimation.FormulaParser import FixestFormula
 from pyfixest.utils.dev_utils import DataFrameType
 
@@ -184,6 +184,8 @@ class FeolsCompressed(Feols):
         # overwrite Y, X, _data
         self._data_long = data_long_mundlak if self._use_mundlak else data_long
         self._Yd = compressed_dict.Y.to_pandas()
+        # store compressed dependent variable before demeaning
+        self._Y_untransformed = self._Yd.copy()
         self._Xd = compressed_dict.X.to_pandas()
         self._fe = compressed_dict.fe.to_pandas()
         # covars = X.columns
@@ -329,7 +331,7 @@ class FeolsCompressed(Feols):
         newdata: Optional[DataFrameType] = None,
         atol: float = 1e-6,
         btol: float = 1e-6,
-        type: str = "link",
+        type: prediction_type = "link",
     ) -> np.ndarray:
         """
         Compute predicted values.

--- a/pyfixest/estimation/fepois_.py
+++ b/pyfixest/estimation/fepois_.py
@@ -292,8 +292,8 @@ class Fepois(Feols):
             stop_iterating = crit < _tol
 
         self._beta_hat = delta_new.flatten()
-        self._Y_hat_response = mu
-        self._Y_hat_link = eta
+        self._Y_hat_response = mu.flatten()
+        self._Y_hat_link = eta.flatten()
         # (Y - self._Y_hat)
         # needed for the calculation of the vcov
 

--- a/pyfixest/estimation/fepois_.py
+++ b/pyfixest/estimation/fepois_.py
@@ -10,7 +10,7 @@ from pyfixest.errors import (
     NotImplementedError,
 )
 from pyfixest.estimation.demean_ import demean
-from pyfixest.estimation.feols_ import Feols
+from pyfixest.estimation.feols_ import Feols, prediction_type
 from pyfixest.estimation.FormulaParser import FixestFormula
 from pyfixest.utils.dev_utils import DataFrameType, _to_integer
 
@@ -32,11 +32,11 @@ class Fepois(Feols):
 
     Attributes
     ----------
-    Y : np.ndarray
-        Dependent variable, a two-dimensional numpy array.
-    X : np.ndarray
-        Independent variables, a two-dimensional numpy array.
-    fe : np.ndarray
+    _Y : np.ndarray
+        The demeaned dependent variable, a two-dimensional numpy array.
+    _X : np.ndarray
+        The demeaned independent variables, a two-dimensional numpy array.
+    _fe : np.ndarray
         Fixed effects, a two-dimensional numpy array or None.
     weights : np.ndarray
         Weights, a one-dimensional numpy array or None.
@@ -297,7 +297,7 @@ class Fepois(Feols):
         # (Y - self._Y_hat)
         # needed for the calculation of the vcov
 
-        # updat for inference
+        # update for inference
         self._weights = mu_old
         self._irls_weights = mu
         # if only one dim
@@ -350,7 +350,7 @@ class Fepois(Feols):
         newdata: Optional[DataFrameType] = None,
         atol: float = 1e-6,
         btol: float = 1e-6,
-        type: str = "link",
+        type: prediction_type = "link",
     ) -> np.ndarray:
         """
         Return predicted values from regression model.
@@ -387,17 +387,13 @@ class Fepois(Feols):
             Another stopping tolerance for scipy.sparse.linalg.lsqr().
             See https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.linalg.lsqr.html
 
-
-
         Returns
         -------
         np.ndarray
             A flat array with the predicted values of the regression model.
         """
-        _Xbeta = self._Xbeta.flatten()
-        _has_fixef = self._has_fixef
 
-        if _has_fixef:
+        if self._has_fixef:
             raise NotImplementedError(
                 "Prediction with fixed effects is not yet implemented for Poisson regression."
             )
@@ -405,14 +401,7 @@ class Fepois(Feols):
             raise NotImplementedError(
                 "Prediction with function argument `newdata` is not yet implemented for Poisson regression."
             )
-
-        # y_hat = super().predict(newdata=newdata, type=type, atol=atol, btol=btol)
-        if type == "link":
-            return _Xbeta  # np.exp(_Xbeta)
-        elif type == "response":
-            return np.exp(_Xbeta)
-        else:
-            raise ValueError("type must be one of 'response' or 'link'.")
+        return super().predict(newdata=newdata, type=type, atol=atol, btol=btol)
 
 
 def _check_for_separation(

--- a/pyfixest/estimation/fepois_.py
+++ b/pyfixest/estimation/fepois_.py
@@ -392,7 +392,6 @@ class Fepois(Feols):
         np.ndarray
             A flat array with the predicted values of the regression model.
         """
-
         if self._has_fixef:
             raise NotImplementedError(
                 "Prediction with fixed effects is not yet implemented for Poisson regression."

--- a/tests/test_iv.py
+++ b/tests/test_iv.py
@@ -219,7 +219,7 @@ def test_1st_stage_iv(seed, sd, has_weight, adj_vcov):
     _F_pval_iv = fit_iv._p_value_1st_stage
 
     _pi_hat_ols = fit_ols._beta_hat
-    _X_hat_ols = fit_ols._Y_hat_link
+    _X_hat_ols = fit_ols._X @ fit_ols._beta_hat
     _v_hat_ols = fit_ols._u_hat
     _F_stat_ols = fit_ols._f_statistic
     _F_pval_ols = fit_ols._p_value


### PR DESCRIPTION
This PR is a small preliminary step for issues #467 and #468. It has two updates so far:

- make `_Y_hat_link` and `_Y_hat_response` consistent between `Feols`, `Feiv`, and `Fepois`: both attributes are now the predictors based on the regressors before demeaning (previously, `Fepois` used the regressors before demeaning while `Feols` and `Feiv` used the regressors after demeaning)
- update `Feols.predict` to use `_Y_hat_link` and `_Y_hat_response` if `newdata=None` and update `Fepois.predict` to simply call `super().predict` (which is possible because of the first step)

I will continue to update this PR to implement `Fepois.predict` with `newdata` and fixed effects.