### PR TITLE
Implement `feglm()` function to support logistic regression 

### DIFF
--- a/pyfixest/__init__.py
+++ b/pyfixest/__init__.py
@@ -13,6 +13,7 @@ from pyfixest.estimation import (
     bonferroni,
     feols,
     fepois,
+    feglm,
     rwolf,
 )
 from pyfixest.report import coefplot, dtable, etable, iplot, make_table, summary
@@ -25,7 +26,7 @@ from pyfixest.utils import (
 __all__ = [
     "feols",
     "fepois",
-    "Stargazer",
+    "feglm",
     "etable",
     "dtable",
     "make_table",

--- a/pyfixest/estimation/FixestMulti_.py
+++ b/pyfixest/estimation/FixestMulti_.py
@@ -8,6 +8,7 @@ from pyfixest.estimation.feiv_ import Feiv
 from pyfixest.estimation.feols_ import Feols, _check_vcov_input, _deparse_vcov_input
 from pyfixest.estimation.feols_compressed_ import FeolsCompressed
 from pyfixest.estimation.fepois_ import Fepois
+from pyfixest.estimation.felogit_ import Felogit
 from pyfixest.estimation.FormulaParser import FixestFormulaParser
 from pyfixest.utils.dev_utils import DataFrameType, _polars_to_pandas
 
@@ -330,6 +331,34 @@ class FixestMulti:
                             separation_check=separation_check,
                             # solver=_solver
                         )
+                        FIT.prepare_model_matrix()
+                        FIT.to_array()
+                        FIT.drop_multicol_vars()
+
+                    elif _method == "logit":
+                        FIT = Felogit(
+                            FixestFormula=FixestFormula,
+                            data=_data,
+                            ssc_dict=_ssc_dict,
+                            drop_singletons=_drop_singletons,
+                            drop_intercept=_drop_intercept,
+                            weights=_weights,
+                            weights_type=_weights_type,
+                            solver=solver,
+                            collin_tol=collin_tol,
+                            fixef_tol=_fixef_tol,
+                            lookup_demeaned_data=lookup_demeaned_data,
+                            tol=iwls_tol,
+                            maxiter=iwls_maxiter,
+                            store_data=_store_data,
+                            copy_data=_copy_data,
+                            lean=_lean,
+                            sample_split_value=sample_split_value,
+                            sample_split_var=_splitvar,
+                            separation_check=separation_check,
+                            # solver=_solver
+                        )
+
                         FIT.prepare_model_matrix()
                         FIT.to_array()
                         FIT.drop_multicol_vars()

--- a/pyfixest/estimation/__init__.py
+++ b/pyfixest/estimation/__init__.py
@@ -7,6 +7,7 @@ from pyfixest.estimation.detect_singletons_ import (
 from pyfixest.estimation.estimation import (
     feols,
     fepois,
+    feglm
 )
 from pyfixest.estimation.feiv_ import (
     Feiv,
@@ -17,6 +18,11 @@ from pyfixest.estimation.feols_ import (
 from pyfixest.estimation.fepois_ import (
     Fepois,
 )
+
+from pyfixest.estimation.felogit_ import (
+    Felogit
+)
+
 from pyfixest.estimation.FixestMulti_ import (
     FixestMulti,
 )
@@ -31,6 +37,7 @@ from pyfixest.estimation.multcomp import (
 __all__ = [
     "feols",
     "fepois",
+    "feglm",
     "bonferroni",
     "rwolf",
     "demean",

--- a/pyfixest/estimation/estimation.py
+++ b/pyfixest/estimation/estimation.py
@@ -614,6 +614,217 @@ def fepois(
         return fixest.fetch_model(0, print_fml=False)
 
 
+
+def feglm(
+    fml: str,
+    data: DataFrameType,  # type: ignore
+    vcov: Optional[Union[str, dict[str, str]]] = None,
+    type: str = "logit",
+    ssc: dict[str, Union[str, bool]] = ssc(),
+    fixef_rm: str = "none",
+    fixef_tol: float = 1e-08,
+    iwls_tol: float = 1e-08,
+    iwls_maxiter: int = 25,
+    collin_tol: float = 1e-10,
+    separation_check: Optional[list[str]] = ["fe"],
+    solver: str = "np.linalg.solve",
+    drop_intercept: bool = False,
+    i_ref1=None,
+    copy_data: bool = True,
+    store_data: bool = True,
+    lean: bool = False,
+    split: Optional[str] = None,
+    fsplit: Optional[str] = None,
+) -> Union[Feols, Fepois, FixestMulti]:
+    """
+    Estimate a logistic regression model with fixed effects.
+
+    Parameters
+    ----------
+    fml : str
+        A two-sided formula string using fixest formula syntax.
+        Syntax: "Y ~ X1 + X2 | FE1 + FE2". "|" separates left-hand side and fixed
+        effects.
+        Special syntax includes:
+        - Stepwise regressions (sw, sw0)
+        - Cumulative stepwise regression (csw, csw0)
+        - Multiple dependent variables (Y1 + Y2 ~ X)
+        - Interaction of variables (i(X1,X2))
+        - Interacted fixed effects (fe1^fe2)
+        Compatible with formula parsing via the formulaic module.
+
+    data : DataFrameType
+        A pandas or polars dataframe containing the variables in the formula.
+
+    vcov : Union[str, dict[str, str]]
+        Type of variance-covariance matrix for inference. Options include "iid",
+        "hetero", "HC1", "HC2", "HC3", or a dictionary for CRV1/CRV3 inference.
+
+    type: str
+        Only supported type is "logit".
+
+    ssc : str
+        A ssc object specifying the small sample correction for inference.
+
+    fixef_rm : str
+        Specifies whether to drop singleton fixed effects.
+        Options: "none" (default), "singleton".
+
+    fixef_tol: float, optional
+        Tolerance for the fixed effects demeaning algorithm. Defaults to 1e-08.
+
+    iwls_tol : Optional[float], optional
+        Tolerance for IWLS convergence, by default 1e-08.
+
+    iwls_maxiter : Optional[float], optional
+        Maximum number of iterations for IWLS convergence, by default 25.
+
+    collin_tol : float, optional
+        Tolerance for collinearity check, by default 1e-10.
+
+    separation_check: list[str], optional
+        Methods to identify and drop separated observations.
+        Either "fe" or "ir". Executes "fe" by default.
+
+    solver : str, optional.
+        The solver to use for the regression. Can be either "np.linalg.solve" or
+        "np.linalg.lstsq". Defaults to "np.linalg.solve".
+
+    drop_intercept : bool, optional
+        Whether to drop the intercept from the model, by default False.
+
+    i_ref1: None
+        Deprecated with pyfixest version 0.18.0. Please use i-syntax instead, i.e.
+        fepois('Y~ i(f1, ref=1)', data = data) instead of the former
+        fepois('Y~ i(f1)', data = data, i_ref=1).
+
+    copy_data : bool, optional
+        Whether to copy the data before estimation, by default True.
+        If set to False, the data is not copied, which can save memory but
+        may lead to unintended changes in the input data outside of `fepois`.
+        For example, the input data set is re-index within the function.
+        As far as I know, the only other relevant case is
+        when using interacted fixed effects, in which case you'll find
+        a column with interacted fixed effects in the data set.
+
+    store_data : bool, optional
+        Whether to store the data in the model object, by default True.
+        If set to False, the data is not stored in the model object, which can
+        improve performance and save memory. However, it will no longer be possible
+        to access the data via the `data` attribute of the model object. This has
+        impact on post-estimation capabilities that rely on the data, e.g. `predict()`
+        or `vcov()`.
+
+    lean: bool, optional
+        False by default. If True, then all large objects are removed from the
+        returned result: this will save memory but will block the possibility
+        to use many methods. It is recommended to use the argument vcov
+        to obtain the appropriate standard-errors at estimation time,
+        since obtaining different SEs won't be possible afterwards.
+
+    split: Optional[str]
+        A character string, i.e. 'split = var'. If provided, the sample is split according to the
+        variable and one estimation is performed for each value of that variable. If you also want
+        to include the estimation for the full sample, use the argument fsplit instead.
+
+    fsplit: Optional[str]
+        This argument is the same as split but also includes the full sample as the first estimation.
+
+    Returns
+    -------
+    object
+        An instance of the `Fepois` class or an instance of class `FixestMulti`
+        for multiple models specified via `fml`.
+
+    Examples
+    --------
+    The `fepois()` function can be used to estimate a simple Poisson regression
+    model with fixed effects.
+    The following example regresses `Y` on `X1` and `X2` with fixed effects for
+    `f1` and `f2`: fixed effects are specified after the `|` symbol.
+
+    ```{python}
+    import pyfixest as pf
+
+    data = pf.get_data(model = "Fepois")
+    fit = pf.feglm("Y ~ X1 + X2 | f1 + f2", data)
+    fit.summary()
+    ```
+    For more examples, please take a look at the documentation of the `feols()`
+    function.
+    """
+    if i_ref1 is not None:
+        raise FeatureDeprecationError(
+            """
+            The 'i_ref1' function argument is deprecated with pyfixest version 0.18.0.
+            Please use i-syntax instead, i.e. fepois('Y~ i(f1, ref=1)', data = data)
+            instead of the former fepois('Y~ i(f1)', data = data, i_ref=1).
+            """
+        )
+
+    # WLS currently not supported for Poisson regression
+    weights = None
+    weights_type = "aweights"
+
+    _estimation_input_checks(
+        fml=fml,
+        data=data,
+        vcov=vcov,
+        weights=weights,
+        ssc=ssc,
+        fixef_rm=fixef_rm,
+        collin_tol=collin_tol,
+        copy_data=copy_data,
+        store_data=store_data,
+        lean=lean,
+        fixef_tol=fixef_tol,
+        weights_type=weights_type,
+        use_compression=False,
+        reps=None,
+        seed=None,
+        split=split,
+        fsplit=fsplit,
+        separation_check=separation_check,
+    )
+
+    fixest = FixestMulti(
+        data=data,
+        copy_data=copy_data,
+        store_data=store_data,
+        lean=lean,
+        fixef_tol=fixef_tol,
+        weights_type=weights_type,
+        use_compression=False,
+        reps=None,
+        seed=None,
+        split=split,
+        fsplit=fsplit,
+    )
+
+    fixest._prepare_estimation(
+        type, fml, vcov, weights, ssc, fixef_rm, drop_intercept
+    )
+    if fixest._is_iv:
+        raise NotImplementedError(
+            "IV Estimation is not supported for Poisson Regression"
+        )
+
+    fixest._estimate_all_models(
+        vcov=vcov,
+        iwls_tol=iwls_tol,
+        iwls_maxiter=iwls_maxiter,
+        collin_tol=collin_tol,
+        separation_check=separation_check,
+        solver=solver,
+    )
+
+    if fixest._is_multiple_estimation:
+        return fixest
+    else:
+        return fixest.fetch_model(0, print_fml=False)
+
+
+
 def _estimation_input_checks(
     fml: str,
     data: DataFrameType,
@@ -745,3 +956,4 @@ def _estimation_input_checks(
             raise ValueError(
                 "The function argument `separation_check` must be a list of strings containing 'fe' and/or 'ir'."
             )
+

--- a/pyfixest/estimation/felogit_.py
+++ b/pyfixest/estimation/felogit_.py
@@ -1,0 +1,105 @@
+import numpy as np
+import pandas as pd
+from typing import Union, Optional
+from pyfixest.estimation.FormulaParser import FixestFormula
+from pyfixest.estimation.model_matrix_fixest_ import model_matrix_fixest
+from pyfixest.estimation.fepois_ import Fepois
+
+class Felogit(Fepois):
+
+    def __init__(
+        self,
+        FixestFormula: FixestFormula,
+        data: pd.DataFrame,
+        ssc_dict: dict[str, Union[str, bool]],
+        drop_singletons: bool,
+        drop_intercept: bool,
+        weights: Optional[str],
+        weights_type: Optional[str],
+        collin_tol: float,
+        fixef_tol: float,
+        lookup_demeaned_data: dict[str, pd.DataFrame],
+        tol: float,
+        maxiter: int,
+        solver: str = "np.linalg.solve",
+        store_data: bool = True,
+        copy_data: bool = True,
+        lean: bool = False,
+        sample_split_var: Optional[str] = None,
+        sample_split_value: Optional[Union[str, int]] = None,
+        separation_check: Optional[list[str]] = None,
+    ):
+        super().__init__(
+            FixestFormula=FixestFormula,
+            data=data,
+            ssc_dict=ssc_dict,
+            drop_singletons=drop_singletons,
+            drop_intercept=drop_intercept,
+            weights=weights,
+            weights_type=weights_type,
+            collin_tol=collin_tol,
+            fixef_tol=fixef_tol,
+            lookup_demeaned_data=lookup_demeaned_data,
+            tol=tol,
+            maxiter=maxiter,
+            solver=solver,
+            store_data=store_data,
+            copy_data=copy_data,
+            lean=lean,
+            sample_split_var=sample_split_var,
+            sample_split_value=sample_split_value,
+            separation_check=separation_check
+        )
+
+    def get_fit(self):
+
+        "Fit GLM model via iterated weighted least squares."
+
+        # initiate IWLS algorithm
+
+        self.iterate_iwls()
+        # collect results
+
+    def iterate_iwls(self):
+
+        "Iterate over IWLS updates until convergence."
+
+        for i in range(self._maxiter):
+            if stop_iterating:
+                _convergence = True
+                break
+            if i == _maxiter:
+                raise NonConvergenceError(
+                    f"""
+                    The IWLS algorithm did not converge with {_maxiter}
+                    iterations. Try to increase the maximum number of iterations.
+                    """
+                )
+
+            self.update_iwls()
+            self.check_convergence()
+
+
+    def update_iwls(self):
+
+        "One update step of the FWLS algorithm."
+
+        _Y = self._Y
+        _X = self._X
+        _fe = self._fe
+
+        "Update GLM fit via Gauss-Newton Algorithm."
+        # define custom class for each GLM method
+        pass
+
+    def check_convergence(self):
+        "Check for convergence of the GLM algorithm."
+        pass
+
+    def fixef(self):
+        "Obtain alpha coefficients."
+        pass
+
+    def predict(self):
+        "Make predictions."
+        pass


### PR DESCRIPTION
1. This PR introduces a new function, `feglm()`, to run generalized linear models. The idea is that users will be able to run different glm's by calling `pf.feglm()` with a `type` argument, that supports "logit", "poisson", and "probit". 
2. It adds a new class, `Felogit`, which runs logistic regression. This is work in progress - most notably, we need to implement the iterated weighted least squares update steps as in Stamann (2018). `Felogit` currently inherits from the `Fepois` class. Long term, we'd likely want to implement an abstract `GLM` class, which all GLM types would then be derived from. 