### PR TITLE
Adding literals to feols and fepois api's

### DIFF
--- a/pyfixest/did/estimation.py
+++ b/pyfixest/did/estimation.py
@@ -2,10 +2,10 @@ from typing import Optional, Union
 
 import pandas as pd
 
-from pyfixest.estimation.literals import vcov_type_options
 from pyfixest.did.did2s import DID2S, _did2s_estimate, _did2s_vcov
 from pyfixest.did.lpdid import LPDID
 from pyfixest.did.twfe import TWFE
+from pyfixest.estimation.literals import vcov_type_options
 
 
 def event_study(

--- a/pyfixest/did/estimation.py
+++ b/pyfixest/did/estimation.py
@@ -2,10 +2,10 @@ from typing import Optional, Union
 
 import pandas as pd
 
-from pyfixest.estimation.literals import VcovTypeOptions
 from pyfixest.did.did2s import DID2S, _did2s_estimate, _did2s_vcov
 from pyfixest.did.lpdid import LPDID
 from pyfixest.did.twfe import TWFE
+from pyfixest.estimation.literals import VcovTypeOptions
 
 
 def event_study(

--- a/pyfixest/did/estimation.py
+++ b/pyfixest/did/estimation.py
@@ -6,7 +6,6 @@ from pyfixest.estimation.literals import VcovTypeOptions
 from pyfixest.did.did2s import DID2S, _did2s_estimate, _did2s_vcov
 from pyfixest.did.lpdid import LPDID
 from pyfixest.did.twfe import TWFE
-from pyfixest.estimation.literals import vcov_type_options
 
 
 def event_study(

--- a/pyfixest/did/estimation.py
+++ b/pyfixest/did/estimation.py
@@ -2,6 +2,7 @@ from typing import Optional, Union
 
 import pandas as pd
 
+from pyfixest.estimation.literals import VcovTypeOptions
 from pyfixest.did.did2s import DID2S, _did2s_estimate, _did2s_vcov
 from pyfixest.did.lpdid import LPDID
 from pyfixest.did.twfe import TWFE
@@ -269,7 +270,7 @@ def lpdid(
     idname: str,
     tname: str,
     gname: str,
-    vcov: Optional[Union[vcov_type_options, dict[str, str]]] = None,
+    vcov: Optional[Union[VcovTypeOptions, dict[str, str]]] = None,
     pre_window: Optional[int] = None,
     post_window: Optional[int] = None,
     never_treated: int = 0,

--- a/pyfixest/did/estimation.py
+++ b/pyfixest/did/estimation.py
@@ -2,6 +2,7 @@ from typing import Optional, Union
 
 import pandas as pd
 
+from pyfixest.estimation.literals import vcov_type_options
 from pyfixest.did.did2s import DID2S, _did2s_estimate, _did2s_vcov
 from pyfixest.did.lpdid import LPDID
 from pyfixest.did.twfe import TWFE
@@ -268,7 +269,7 @@ def lpdid(
     idname: str,
     tname: str,
     gname: str,
-    vcov: Optional[Union[str, dict[str, str]]] = None,
+    vcov: Optional[Union[vcov_type_options, dict[str, str]]] = None,
     pre_window: Optional[int] = None,
     post_window: Optional[int] = None,
     never_treated: int = 0,

--- a/pyfixest/did/lpdid.py
+++ b/pyfixest/did/lpdid.py
@@ -6,7 +6,7 @@ import pandas as pd
 from pyfixest.did.did import DID
 from pyfixest.estimation.estimation import feols
 from pyfixest.estimation.feols_ import Feols
-from pyfixest.estimation.literals import vcov_type_options
+from pyfixest.estimation.literals import VcovTypeOptions
 from pyfixest.report.visualize import _coefplot
 
 
@@ -52,7 +52,7 @@ class LPDID(DID):
         xfml: str,
         att: bool,
         cluster: str,
-        vcov: Optional[Union[vcov_type_options, dict[str, str]]] = None,
+        vcov: Optional[Union[VcovTypeOptions, dict[str, str]]] = None,
         pre_window: Optional[int] = None,
         post_window: Optional[int] = None,
         never_treated: Optional[int] = 0,
@@ -202,7 +202,7 @@ def _lpdid_estimate(
     pre_window: int,
     post_window: int,
     att: bool = True,
-    vcov: Optional[Union[vcov_type_options, dict[str, str]]] = None,
+    vcov: Optional[Union[VcovTypeOptions, dict[str, str]]] = None,
     xfml: Optional[str] = None,
 ) -> pd.DataFrame:
     """
@@ -220,7 +220,7 @@ def _lpdid_estimate(
         Variable name for calendar period.
     gname:  str
         unit-specific time of initial treatment.
-    vcov: vcov_type_options, dict[str, str], None
+    vcov: VcovTypeOptions, dict[str, str], None
         The name of the cluster variable. If None, then defaults to {"CRV1": idname}.
         Either "iid", "hetero", or a dictionary, e.g. {"CRV1": idname} or
         {"CRV3": "idname"}. You can pass anything that is accepted by the vcov

--- a/pyfixest/did/lpdid.py
+++ b/pyfixest/did/lpdid.py
@@ -10,7 +10,6 @@ from pyfixest.estimation.literals import vcov_type_options
 from pyfixest.report.visualize import _coefplot
 
 
-
 class LPDID(DID):
     """
     A class used to represent the Local Projections Diff-in-Diff Estimator.
@@ -221,7 +220,7 @@ def _lpdid_estimate(
         Variable name for calendar period.
     gname:  str
         unit-specific time of initial treatment.
-    vcov: str
+    vcov: vcov_type_options, dict[str, str], None
         The name of the cluster variable. If None, then defaults to {"CRV1": idname}.
         Either "iid", "hetero", or a dictionary, e.g. {"CRV1": idname} or
         {"CRV3": "idname"}. You can pass anything that is accepted by the vcov

--- a/pyfixest/did/lpdid.py
+++ b/pyfixest/did/lpdid.py
@@ -6,7 +6,9 @@ import pandas as pd
 from pyfixest.did.did import DID
 from pyfixest.estimation.estimation import feols
 from pyfixest.estimation.feols_ import Feols
+from pyfixest.estimation.literals import vcov_type_options
 from pyfixest.report.visualize import _coefplot
+
 
 
 class LPDID(DID):
@@ -51,7 +53,7 @@ class LPDID(DID):
         xfml: str,
         att: bool,
         cluster: str,
-        vcov: Optional[Union[str, dict[str, str]]] = None,
+        vcov: Optional[Union[vcov_type_options, dict[str, str]]] = None,
         pre_window: Optional[int] = None,
         post_window: Optional[int] = None,
         never_treated: Optional[int] = 0,
@@ -201,7 +203,7 @@ def _lpdid_estimate(
     pre_window: int,
     post_window: int,
     att: bool = True,
-    vcov: Optional[Union[str, dict[str, str]]] = None,
+    vcov: Optional[Union[vcov_type_options, dict[str, str]]] = None,
     xfml: Optional[str] = None,
 ) -> pd.DataFrame:
     """

--- a/pyfixest/estimation/__init__.py
+++ b/pyfixest/estimation/__init__.py
@@ -1,3 +1,4 @@
+from pyfixest.estimation import literals
 from pyfixest.estimation.demean_ import (
     demean,
 )
@@ -40,4 +41,5 @@ __all__ = [
     "Fepois",
     "Feiv",
     "FixestMulti",
+    "literals"
 ]

--- a/pyfixest/estimation/__init__.py
+++ b/pyfixest/estimation/__init__.py
@@ -41,5 +41,5 @@ __all__ = [
     "Fepois",
     "Feiv",
     "FixestMulti",
-    "literals"
+    "literals",
 ]

--- a/pyfixest/estimation/estimation.py
+++ b/pyfixest/estimation/estimation.py
@@ -7,10 +7,10 @@ from pyfixest.estimation.feols_ import Feols
 from pyfixest.estimation.fepois_ import Fepois
 from pyfixest.estimation.FixestMulti_ import FixestMulti
 from pyfixest.estimation.literals import (
-    fixef_rm_options,
-    solver_options,
-    vcov_type_options,
-    weights_type_options,
+    FixedRmOptions,
+    SolverOptions,
+    VcovTypeOptions,
+    WeightsTypeOptions,
 )
 from pyfixest.utils.dev_utils import DataFrameType
 from pyfixest.utils.utils import ssc
@@ -19,10 +19,10 @@ from pyfixest.utils.utils import ssc
 def feols(
     fml: str,
     data: DataFrameType,  # type: ignore
-    vcov: Optional[Union[vcov_type_options, dict[str, str]]] = None,
+    vcov: Optional[Union[VcovTypeOptions, dict[str, str]]] = None,
     weights: Union[None, str] = None,
     ssc: dict[str, Union[str, bool]] = ssc(),
-    fixef_rm: fixef_rm_options = "none",
+    fixef_rm: FixedRmOptions = "none",
     fixef_tol=1e-08,
     collin_tol: float = 1e-10,
     drop_intercept: bool = False,
@@ -30,8 +30,8 @@ def feols(
     copy_data: bool = True,
     store_data: bool = True,
     lean: bool = False,
-    weights_type: weights_type_options = "aweights",
-    solver: solver_options = "np.linalg.solve",
+    weights_type: WeightsTypeOptions = "aweights",
+    solver: SolverOptions = "np.linalg.solve",
     use_compression: bool = False,
     reps: int = 100,
     seed: Optional[int] = None,
@@ -53,7 +53,7 @@ def feols(
     data : DataFrameType
         A pandas or polars dataframe containing the variables in the formula.
 
-    vcov : Union[vcov_type_options, dict[str, str]]
+    vcov : Union[VcovTypeOptions, dict[str, str]]
         Type of variance-covariance matrix for inference. Options include "iid",
         "hetero", "HC1", "HC2", "HC3", or a dictionary for CRV1/CRV3 inference.
 
@@ -65,7 +65,7 @@ def feols(
     ssc : str
         A ssc object specifying the small sample correction for inference.
 
-    fixef_rm : fixef_rm_options
+    fixef_rm : FixedRmOptions
         Specifies whether to drop singleton fixed effects.
         Options: "none" (default), "singleton".
 
@@ -107,12 +107,12 @@ def feols(
         to obtain the appropriate standard-errors at estimation time,
         since obtaining different SEs won't be possible afterwards.
 
-    weights_type: weights_type_options, optional
+    weights_type: WeightsTypeOptions, optional
         Options include `aweights` or `fweights`. `aweights` implement analytic or
         precision weights, while `fweights` implement frequency weights. For details
         see this blog post: https://notstatschat.rbind.io/2020/08/04/weights-in-statistics/.
 
-    solver : solver_options, optional.
+    solver : SolverOptions, optional.
         The solver to use for the regression. Can be either "np.linalg.solve" or
         "np.linalg.lstsq". Defaults to "np.linalg.solve".
 
@@ -418,15 +418,15 @@ def feols(
 def fepois(
     fml: str,
     data: DataFrameType,  # type: ignore
-    vcov: Optional[Union[vcov_type_options, dict[str, str]]] = None,
+    vcov: Optional[Union[VcovTypeOptions, dict[str, str]]] = None,
     ssc: dict[str, Union[str, bool]] = ssc(),
-    fixef_rm: fixef_rm_options = "none",
+    fixef_rm: FixedRmOptions = "none",
     fixef_tol: float = 1e-08,
     iwls_tol: float = 1e-08,
     iwls_maxiter: int = 25,
     collin_tol: float = 1e-10,
     separation_check: Optional[list[str]] = ["fe"],
-    solver: solver_options = "np.linalg.solve",
+    solver: SolverOptions = "np.linalg.solve",
     drop_intercept: bool = False,
     i_ref1=None,
     copy_data: bool = True,
@@ -455,14 +455,14 @@ def fepois(
     data : DataFrameType
         A pandas or polars dataframe containing the variables in the formula.
 
-    vcov : Union[vcov_type_options, dict[str, str]]
+    vcov : Union[VcovTypeOptions, dict[str, str]]
         Type of variance-covariance matrix for inference. Options include "iid",
         "hetero", "HC1", "HC2", "HC3", or a dictionary for CRV1/CRV3 inference.
 
     ssc : str
         A ssc object specifying the small sample correction for inference.
 
-    fixef_rm : fixef_rm_options
+    fixef_rm : FixedRmOptions
         Specifies whether to drop singleton fixed effects.
         Options: "none" (default), "singleton".
 
@@ -482,7 +482,7 @@ def fepois(
         Methods to identify and drop separated observations.
         Either "fe" or "ir". Executes "fe" by default.
 
-    solver : solver_options, optional.
+    solver : SolverOptions, optional.
         The solver to use for the regression. Can be either "np.linalg.solve" or
         "np.linalg.lstsq". Defaults to "np.linalg.solve".
 

--- a/pyfixest/estimation/estimation.py
+++ b/pyfixest/estimation/estimation.py
@@ -6,6 +6,12 @@ from pyfixest.errors import FeatureDeprecationError
 from pyfixest.estimation.feols_ import Feols
 from pyfixest.estimation.fepois_ import Fepois
 from pyfixest.estimation.FixestMulti_ import FixestMulti
+from pyfixest.estimation.literals import (
+    fixef_rm_options,
+    solver_options,
+    vcov_type_options,
+    weights_type_options,
+)
 from pyfixest.utils.dev_utils import DataFrameType
 from pyfixest.utils.utils import ssc
 
@@ -13,10 +19,10 @@ from pyfixest.utils.utils import ssc
 def feols(
     fml: str,
     data: DataFrameType,  # type: ignore
-    vcov: Optional[Union[str, dict[str, str]]] = None,
+    vcov: Optional[Union[vcov_type_options, dict[str, str]]] = None,
     weights: Union[None, str] = None,
     ssc: dict[str, Union[str, bool]] = ssc(),
-    fixef_rm: str = "none",
+    fixef_rm: fixef_rm_options = "none",
     fixef_tol=1e-08,
     collin_tol: float = 1e-10,
     drop_intercept: bool = False,
@@ -24,8 +30,8 @@ def feols(
     copy_data: bool = True,
     store_data: bool = True,
     lean: bool = False,
-    weights_type: str = "aweights",
-    solver: str = "np.linalg.solve",
+    weights_type: weights_type_options = "aweights",
+    solver: solver_options = "np.linalg.solve",
     use_compression: bool = False,
     reps: int = 100,
     seed: Optional[int] = None,
@@ -47,7 +53,7 @@ def feols(
     data : DataFrameType
         A pandas or polars dataframe containing the variables in the formula.
 
-    vcov : Union[str, dict[str, str]]
+    vcov : Union[vcov_type_options, dict[str, str]]
         Type of variance-covariance matrix for inference. Options include "iid",
         "hetero", "HC1", "HC2", "HC3", or a dictionary for CRV1/CRV3 inference.
 
@@ -59,7 +65,7 @@ def feols(
     ssc : str
         A ssc object specifying the small sample correction for inference.
 
-    fixef_rm : str
+    fixef_rm : fixef_rm_options
         Specifies whether to drop singleton fixed effects.
         Options: "none" (default), "singleton".
 
@@ -101,12 +107,12 @@ def feols(
         to obtain the appropriate standard-errors at estimation time,
         since obtaining different SEs won't be possible afterwards.
 
-    weights_type: str, optional
+    weights_type: weights_type_options, optional
         Options include `aweights` or `fweights`. `aweights` implement analytic or
         precision weights, while `fweights` implement frequency weights. For details
         see this blog post: https://notstatschat.rbind.io/2020/08/04/weights-in-statistics/.
 
-    solver : str, optional.
+    solver : solver_options, optional.
         The solver to use for the regression. Can be either "np.linalg.solve" or
         "np.linalg.lstsq". Defaults to "np.linalg.solve".
 
@@ -412,15 +418,15 @@ def feols(
 def fepois(
     fml: str,
     data: DataFrameType,  # type: ignore
-    vcov: Optional[Union[str, dict[str, str]]] = None,
+    vcov: Optional[Union[vcov_type_options, dict[str, str]]] = None,
     ssc: dict[str, Union[str, bool]] = ssc(),
-    fixef_rm: str = "none",
+    fixef_rm: fixef_rm_options = "none",
     fixef_tol: float = 1e-08,
     iwls_tol: float = 1e-08,
     iwls_maxiter: int = 25,
     collin_tol: float = 1e-10,
     separation_check: Optional[list[str]] = ["fe"],
-    solver: str = "np.linalg.solve",
+    solver: solver_options = "np.linalg.solve",
     drop_intercept: bool = False,
     i_ref1=None,
     copy_data: bool = True,
@@ -449,14 +455,14 @@ def fepois(
     data : DataFrameType
         A pandas or polars dataframe containing the variables in the formula.
 
-    vcov : Union[str, dict[str, str]]
+    vcov : Union[vcov_type_options, dict[str, str]]
         Type of variance-covariance matrix for inference. Options include "iid",
         "hetero", "HC1", "HC2", "HC3", or a dictionary for CRV1/CRV3 inference.
 
     ssc : str
         A ssc object specifying the small sample correction for inference.
 
-    fixef_rm : str
+    fixef_rm : fixef_rm_options
         Specifies whether to drop singleton fixed effects.
         Options: "none" (default), "singleton".
 
@@ -476,7 +482,7 @@ def fepois(
         Methods to identify and drop separated observations.
         Either "fe" or "ir". Executes "fe" by default.
 
-    solver : str, optional.
+    solver : solver_options, optional.
         The solver to use for the regression. Can be either "np.linalg.solve" or
         "np.linalg.lstsq". Defaults to "np.linalg.solve".
 

--- a/pyfixest/estimation/feols_.py
+++ b/pyfixest/estimation/feols_.py
@@ -2,7 +2,7 @@ import functools
 import gc
 import warnings
 from importlib import import_module
-from typing import Literal, Optional, Union, get_args
+from typing import Optional, Union
 
 import numba as nb
 import numpy as np
@@ -15,6 +15,7 @@ from scipy.stats import chi2, f, norm, t
 from pyfixest.errors import VcovTypeNotSupportedError
 from pyfixest.estimation.demean_ import demean_model
 from pyfixest.estimation.FormulaParser import FixestFormula
+from pyfixest.estimation.literals import prediction_type, validate_literal_argument
 from pyfixest.estimation.model_matrix_fixest_ import model_matrix_fixest
 from pyfixest.estimation.ritest import (
     _decode_resampvar,
@@ -39,8 +40,6 @@ from pyfixest.utils.dev_utils import (
     _select_order_coefs,
 )
 from pyfixest.utils.utils import get_ssc, simultaneous_crit_val
-
-prediction_type = Literal["response", "link"]
 
 
 class Feols:
@@ -1597,11 +1596,8 @@ class Feols:
             raise NotImplementedError(
                 "The predict() method is currently not supported for IV models."
             )
-        valid_types = get_args(prediction_type)
-        if type not in valid_types:
-            raise ValueError(
-                f"Invalid prediction type. Expecting one of {valid_types}. Got {type}"
-            )
+
+        validate_literal_argument(type, prediction_type)
 
         if newdata is None:
             if type == "link" or self._method == "feols":

--- a/pyfixest/estimation/feols_.py
+++ b/pyfixest/estimation/feols_.py
@@ -15,7 +15,7 @@ from scipy.stats import chi2, f, norm, t
 from pyfixest.errors import VcovTypeNotSupportedError
 from pyfixest.estimation.demean_ import demean_model
 from pyfixest.estimation.FormulaParser import FixestFormula
-from pyfixest.estimation.literals import prediction_type, _validate_literal_argument
+from pyfixest.estimation.literals import PredictionType, _validate_literal_argument
 from pyfixest.estimation.model_matrix_fixest_ import model_matrix_fixest
 from pyfixest.estimation.ritest import (
     _decode_resampvar,
@@ -1556,7 +1556,7 @@ class Feols:
         newdata: Optional[DataFrameType] = None,
         atol: float = 1e-6,
         btol: float = 1e-6,
-        type: prediction_type = "link",
+        type: PredictionType = "link",
     ) -> np.ndarray:
         """
         Predict values of the model on new data.
@@ -1597,7 +1597,7 @@ class Feols:
                 "The predict() method is currently not supported for IV models."
             )
 
-        _validate_literal_argument(type, prediction_type)
+        _validate_literal_argument(type, PredictionType)
 
         if newdata is None:
             if type == "link" or self._method == "feols":

--- a/pyfixest/estimation/feols_.py
+++ b/pyfixest/estimation/feols_.py
@@ -15,7 +15,7 @@ from scipy.stats import chi2, f, norm, t
 from pyfixest.errors import VcovTypeNotSupportedError
 from pyfixest.estimation.demean_ import demean_model
 from pyfixest.estimation.FormulaParser import FixestFormula
-from pyfixest.estimation.literals import prediction_type, validate_literal_argument
+from pyfixest.estimation.literals import prediction_type, _validate_literal_argument
 from pyfixest.estimation.model_matrix_fixest_ import model_matrix_fixest
 from pyfixest.estimation.ritest import (
     _decode_resampvar,
@@ -1597,7 +1597,7 @@ class Feols:
                 "The predict() method is currently not supported for IV models."
             )
 
-        validate_literal_argument(type, prediction_type)
+        _validate_literal_argument(type, prediction_type)
 
         if newdata is None:
             if type == "link" or self._method == "feols":

--- a/pyfixest/estimation/feols_compressed_.py
+++ b/pyfixest/estimation/feols_compressed_.py
@@ -6,7 +6,7 @@ import pandas as pd
 import polars as pl
 from tqdm import tqdm
 
-from pyfixest.estimation.feols_ import Feols, prediction_type
+from pyfixest.estimation.feols_ import Feols, PredictionType
 from pyfixest.estimation.FormulaParser import FixestFormula
 from pyfixest.utils.dev_utils import DataFrameType
 
@@ -331,7 +331,7 @@ class FeolsCompressed(Feols):
         newdata: Optional[DataFrameType] = None,
         atol: float = 1e-6,
         btol: float = 1e-6,
-        type: prediction_type = "link",
+        type: PredictionType = "link",
     ) -> np.ndarray:
         """
         Compute predicted values.

--- a/pyfixest/estimation/fepois_.py
+++ b/pyfixest/estimation/fepois_.py
@@ -10,7 +10,7 @@ from pyfixest.errors import (
     NotImplementedError,
 )
 from pyfixest.estimation.demean_ import demean
-from pyfixest.estimation.feols_ import Feols, prediction_type
+from pyfixest.estimation.feols_ import Feols, PredictionType
 from pyfixest.estimation.FormulaParser import FixestFormula
 from pyfixest.utils.dev_utils import DataFrameType, _to_integer
 
@@ -350,7 +350,7 @@ class Fepois(Feols):
         newdata: Optional[DataFrameType] = None,
         atol: float = 1e-6,
         btol: float = 1e-6,
-        type: prediction_type = "link",
+        type: PredictionType = "link",
     ) -> np.ndarray:
         """
         Return predicted values from regression model.

--- a/pyfixest/estimation/literals.py
+++ b/pyfixest/estimation/literals.py
@@ -7,7 +7,7 @@ fixef_rm_options = Literal["singleton", "none"]
 solver_options = Literal["np.linalg.solve", "np.linalg.lstsq"]
 
 
-def validate_literal_argument(arg: Any, literal: Literal) -> None:
+def validate_literal_argument(arg: Any, literal: Literal[str]) -> None:
     """
     Validate if the given argument matches one of the allowed literal types.
 
@@ -19,7 +19,7 @@ def validate_literal_argument(arg: Any, literal: Literal) -> None:
     ----------
     arg : Any
         The argument to validate.
-    literal : Literal[ValidTypes]
+    literal : Literal[str]
         A Literal type that defines the allowed values for `arg`.
 
     Raises

--- a/pyfixest/estimation/literals.py
+++ b/pyfixest/estimation/literals.py
@@ -8,6 +8,25 @@ solver_options = Literal["np.linalg.solve", "np.linalg.lstsq"]
 
 
 def validate_literal_argument(arg: Any, literal: Literal) -> None:
+    """
+    Validate if the given argument matches one of the allowed literal types.
+
+    This function checks whether the provided `arg` is among the valid types
+    returned by `get_args(literal)`. If not, it raises a ValueError with an
+    appropriate error message.
+
+    Parameters
+    ----------
+    arg : Any
+        The argument to validate.
+    literal : Literal[ValidTypes]
+        A Literal type that defines the allowed values for `arg`.
+
+    Raises
+    ------
+    ValueError
+        If `arg` is not one of the valid types defined by `literal`.
+    """
     valid_types = get_args(literal)
 
     if arg not in valid_types:

--- a/pyfixest/estimation/literals.py
+++ b/pyfixest/estimation/literals.py
@@ -1,4 +1,4 @@
-from typing import Any, Literal, _LiteralGenericAlias, get_args
+from typing import Literal, get_args, Any
 
 PredictionType = Literal["response", "link"]
 VcovTypeOptions = Literal["iid", "hetero", "HC1", "HC2", "HC3"]
@@ -7,7 +7,7 @@ FixedRmOptions = Literal["singleton", "none"]
 SolverOptions = Literal["np.linalg.solve", "np.linalg.lstsq"]
 
 
-def _validate_literal_argument(arg: Any, literal: _LiteralGenericAlias) -> None:
+def _validate_literal_argument(arg: Any, literal: Any) -> None:
     """
     Validate if the given argument matches one of the allowed literal types.
 
@@ -19,18 +19,22 @@ def _validate_literal_argument(arg: Any, literal: _LiteralGenericAlias) -> None:
     ----------
     arg : Any
         The argument to validate.
-    literal : _LiteralGenericAlias
+    literal : Any
         A Literal type that defines the allowed values for `arg`.
 
     Raises
     ------
+    TypeError
+        If `literal` does not have valid types.
     ValueError
         If `arg` is not one of the valid types defined by `literal`.
     """
-    if type(literal) is _LiteralGenericAlias:
-        valid_types = get_args(literal)
-    else:
-        raise TypeError(f"{literal} must be of Literal[...] type")
+    valid_types = get_args(literal)
+
+    if len(valid_types) < 1:
+        raise TypeError(
+            f"{literal} must be a Literal[...] type argument with least one type"
+        )
 
     if arg not in valid_types:
         raise ValueError(f"Invalid argument. Expecting one of {valid_types}. Got {arg}")

--- a/pyfixest/estimation/literals.py
+++ b/pyfixest/estimation/literals.py
@@ -1,4 +1,4 @@
-from typing import Literal, _LiteralGenericAlias, get_args, Any
+from typing import Any, Literal, _LiteralGenericAlias, get_args
 
 PredictionType = Literal["response", "link"]
 VcovTypeOptions = Literal["iid", "hetero", "HC1", "HC2", "HC3"]

--- a/pyfixest/estimation/literals.py
+++ b/pyfixest/estimation/literals.py
@@ -1,6 +1,6 @@
 from typing import Literal, _LiteralGenericAlias, get_args, Any
 
-PredictionTypeOptions = Literal["response", "link"]
+PredictionType = Literal["response", "link"]
 VcovTypeOptions = Literal["iid", "hetero", "HC1", "HC2", "HC3"]
 WeightsTypeOptions = Literal["aweights", "fweights"]
 FixedRmOptions = Literal["singleton", "none"]

--- a/pyfixest/estimation/literals.py
+++ b/pyfixest/estimation/literals.py
@@ -1,13 +1,13 @@
-from typing import Any, Literal, get_args
+from typing import Literal, _LiteralGenericAlias, get_args, Any
 
-prediction_type = Literal["response", "link"]
-vcov_type_options = Literal["iid", "hetero", "HC1", "HC2", "HC3"]
-weights_type_options = Literal["aweights", "fweights"]
-fixef_rm_options = Literal["singleton", "none"]
-solver_options = Literal["np.linalg.solve", "np.linalg.lstsq"]
+PredictionTypeOptions = Literal["response", "link"]
+VcovTypeOptions = Literal["iid", "hetero", "HC1", "HC2", "HC3"]
+WeightsTypeOptions = Literal["aweights", "fweights"]
+FixedRmOptions = Literal["singleton", "none"]
+SolverOptions = Literal["np.linalg.solve", "np.linalg.lstsq"]
 
 
-def validate_literal_argument(arg: Any, literal: Any) -> None:
+def _validate_literal_argument(arg: Any, literal: _LiteralGenericAlias) -> None:
     """
     Validate if the given argument matches one of the allowed literal types.
 
@@ -19,7 +19,7 @@ def validate_literal_argument(arg: Any, literal: Any) -> None:
     ----------
     arg : Any
         The argument to validate.
-    literal : Any
+    literal : _LiteralGenericAlias
         A Literal type that defines the allowed values for `arg`.
 
     Raises
@@ -27,10 +27,10 @@ def validate_literal_argument(arg: Any, literal: Any) -> None:
     ValueError
         If `arg` is not one of the valid types defined by `literal`.
     """
-    valid_types = get_args(literal)
+    if type(literal) is _LiteralGenericAlias:
+        valid_types = get_args(literal)
+    else:
+        raise TypeError(f"{literal} must be of Literal[...] type")
 
     if arg not in valid_types:
-        raise ValueError(
-            f"Invalid prediction type. Expecting one of {valid_types}.\
-                Got {arg}"
-        )
+        raise ValueError(f"Invalid argument. Expecting one of {valid_types}. Got {arg}")

--- a/pyfixest/estimation/literals.py
+++ b/pyfixest/estimation/literals.py
@@ -1,0 +1,17 @@
+from typing import Literal, Any, get_args
+
+prediction_type = Literal["response", "link"]
+vcov_type_options = Literal["iid", "hetero", "HC1", "HC2", "HC3"]
+weights_type_options = Literal["aweights", "fweights"]
+fixef_rm_options = Literal["singleton", "none"]
+solver_options = Literal["np.linalg.solve", "np.linalg.lstsq"]
+
+
+def validate_literal_argument(arg: Any, literal: Literal) -> None:
+    valid_types = get_args(literal)
+
+    if arg not in valid_types:
+        raise ValueError(
+            f"Invalid prediction type. Expecting one of {valid_types}.\
+                Got {arg}"
+        )

--- a/pyfixest/estimation/literals.py
+++ b/pyfixest/estimation/literals.py
@@ -1,4 +1,4 @@
-from typing import Literal, Any, get_args
+from typing import Any, Literal, get_args
 
 prediction_type = Literal["response", "link"]
 vcov_type_options = Literal["iid", "hetero", "HC1", "HC2", "HC3"]

--- a/pyfixest/estimation/literals.py
+++ b/pyfixest/estimation/literals.py
@@ -7,7 +7,7 @@ fixef_rm_options = Literal["singleton", "none"]
 solver_options = Literal["np.linalg.solve", "np.linalg.lstsq"]
 
 
-def validate_literal_argument(arg: Any, literal: Literal[str]) -> None:
+def validate_literal_argument(arg: Any, literal: Any) -> None:
     """
     Validate if the given argument matches one of the allowed literal types.
 
@@ -19,7 +19,7 @@ def validate_literal_argument(arg: Any, literal: Literal[str]) -> None:
     ----------
     arg : Any
         The argument to validate.
-    literal : Literal[str]
+    literal : Any
         A Literal type that defines the allowed values for `arg`.
 
     Raises

--- a/pyfixest/estimation/literals.py
+++ b/pyfixest/estimation/literals.py
@@ -1,4 +1,4 @@
-from typing import Literal, get_args, Any
+from typing import Any, Literal, get_args
 
 PredictionType = Literal["response", "link"]
 VcovTypeOptions = Literal["iid", "hetero", "HC1", "HC2", "HC3"]


### PR DESCRIPTION
Reference to #671. Pretty literal interpretation. Added a small validate_literal_argument function, taken from the predict method of Feols (assumption is it may be used elsewhere also).  