### PR TITLE
remove duplicate error classes

### DIFF
--- a/pyfixest/did/event_study.py
+++ b/pyfixest/did/event_study.py
@@ -4,7 +4,6 @@ import pandas as pd
 
 from pyfixest.did.did2s import DID2S
 from pyfixest.did.twfe import TWFE
-from pyfixest.errors import NotImplementedError
 
 
 def event_study(

--- a/pyfixest/errors/__init__.py
+++ b/pyfixest/errors/__init__.py
@@ -38,10 +38,6 @@ class DepvarIsNotNumericError(Exception):  # noqa: D101
     pass
 
 
-class NotImplementedError(Exception):  # noqa: D101
-    pass
-
-
 class NonConvergenceError(Exception):  # noqa: D101
     pass
 
@@ -67,10 +63,8 @@ __all__ = [
     "UnderDeterminedIVError",
     "UnsupportedMultipleEstimationSyntax",
     "VcovTypeNotSupportedError",
-    "MultiEstNotSupportedError",
     "NanInClusterVarError",
     "DepvarIsNotNumericError",
-    "NotImplementedError",
     "NonConvergenceError",
     "MatrixNotFullRankError",
     "EmptyDesignMatrixError",

--- a/pyfixest/estimation/fepois_.py
+++ b/pyfixest/estimation/fepois_.py
@@ -7,7 +7,6 @@ import pandas as pd
 
 from pyfixest.errors import (
     NonConvergenceError,
-    NotImplementedError,
 )
 from pyfixest.estimation.demean_ import demean
 from pyfixest.estimation.feols_ import Feols, PredictionType


### PR DESCRIPTION
Closes #701 

Very minor changes removing the custom `NotImplementError`.

@s3alfisc I've noticed that `pyfixest.errors.__init__` includes an undefined `MultiEstNotSupportedError` in `__all__` which I have also removed. Please let me know if instead it should be defined as an additional error.