### PR TITLE
Rename Regression Plot in Case of Duplicate Names

### DIFF
--- a/pyfixest/estimation/feols_.py
+++ b/pyfixest/estimation/feols_.py
@@ -213,6 +213,7 @@ class Feols:
         self._sample_split_value = sample_split_value
         self._sample_split_var = sample_split_var
         self._model_name = f"{FixestFormula.fml} (Sample: {self._sample_split_var} = {self._sample_split_value})"
+        self._model_name_plot = self._model_name
         self._method = "feols"
         self._is_iv = False
         self.FixestFormula = FixestFormula

--- a/pyfixest/estimation/feols_.py
+++ b/pyfixest/estimation/feols_.py
@@ -188,7 +188,14 @@ class Feols:
     _data: pd.DataFrame
         The data frame used in the estimation. None if arguments `lean = True` or
         `store_data = False`.
-
+    _model_name: str
+        The name of the model. Usually just the formula string. If split estimation is used,
+        the model name will include the split variable and value.
+    _model_name_plot: str
+        The name of the model used when plotting and summarizing models. Usually identical to
+        `_model_name`. This might be different when pf.summary() or pf.coefplot() are called
+        and models with identical _model_name attributes are passed. In this case,
+        the _model_name_plot attribute will be modified.
     """
 
     def __init__(

--- a/pyfixest/report/summarize.py
+++ b/pyfixest/report/summarize.py
@@ -1,4 +1,5 @@
 import re
+from collections import Counter
 from collections.abc import ValuesView
 from typing import Optional, Union
 
@@ -600,6 +601,23 @@ def _post_processing_input_checks(
             )
     else:
         raise TypeError("Invalid type for models argument.")
+
+    # create model_name_plot attribute to differentiate between models with the
+    # same model_name / model formula
+
+    all_model_names = [model._model_name for model in models_list]
+    for model in models_list:
+        model._model_name_plot = model._model_name
+
+    counter = Counter(all_model_names)
+    duplicate_model_names = [item for item, count in counter.items() if count > 1]
+
+    for duplicate_model in duplicate_model_names:
+        duplicates = [
+            model for model in models_list if model._model_name == duplicate_model
+        ]
+        for i, model in enumerate(duplicates):
+            model._model_name_plot = f"Model {i}: {model._model_name}"
 
     return models_list
 

--- a/pyfixest/report/summarize.py
+++ b/pyfixest/report/summarize.py
@@ -1,4 +1,5 @@
 import re
+import warnings
 from collections import Counter
 from collections.abc import ValuesView
 from typing import Optional, Union
@@ -618,6 +619,9 @@ def _post_processing_input_checks(
         ]
         for i, model in enumerate(duplicates):
             model._model_name_plot = f"Model {i}: {model._model_name}"
+            warnings.warn(
+                f"The _model_name attribute {model._model_name}' is duplicated for models in the `models` you provided. To avoid overlapping model names / plots, the _model_name_plot attribute has been changed to '{model._model_name_plot}'."
+            )
 
     return models_list
 

--- a/pyfixest/report/visualize.py
+++ b/pyfixest/report/visualize.py
@@ -156,7 +156,7 @@ def iplot(
     pf.iplot([fit1], joint = "both")
     ```
     """
-    models = _post_processing_input_checks(models)
+    models = _post_processing_input_checks(models, check_duplicate_model_names=True)
     if joint not in [False, None] and len(models) > 1:
         raise ValueError(
             "The 'joint' parameter is only available for a single model, i.e. objects of type FixestMulti are not supported."
@@ -302,7 +302,7 @@ def coefplot(
 
     ```
     """
-    models = _post_processing_input_checks(models)
+    models = _post_processing_input_checks(models, check_duplicate_model_names=True)
     if joint not in [False, None] and len(models) > 1:
         raise ValueError(
             "The 'joint' parameter is only available for a single model, i.e. objects of type FixestMulti are not supported."

--- a/pyfixest/report/visualize.py
+++ b/pyfixest/report/visualize.py
@@ -596,7 +596,7 @@ def _get_model_df(
         A tidy model frame.
     """
     df_model = fxst.tidy(alpha=alpha).reset_index()  # Coefficient -> simple column
-    df_model["fml"] = f"{fxst._model_name}: {(1- alpha) *100:.1f}%"
+    df_model["fml"] = f"{fxst._model_name_plot}: {(1- alpha) *100:.1f}%"
 
     if joint in ["both", True]:
         lb, ub = f"{alpha / 2*100:.1f}%", f"{(1 - alpha / 2)*100:.1f}%"
@@ -608,7 +608,9 @@ def _get_model_df(
             .drop([lb, ub], axis=1)
             .merge(df_joint, on="Coefficient", how="left")
         )
-        df_joint_full["fml"] = f"{fxst._model_name}: {(1- alpha) *100:.1f}% joint CIs"
+        df_joint_full["fml"] = (
+            f"{fxst._model_name_plot}: {(1- alpha) *100:.1f}% joint CIs"
+        )
         if joint == "both":
             df_model = pd.concat([df_model, df_joint_full], axis=0)
         else:

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -1,6 +1,7 @@
 import matplotlib.pyplot as plt
 import pandas as pd
 
+import pyfixest as pf
 from pyfixest.did.visualize import (
     _plot_panelview,
     _plot_panelview_output_plot,
@@ -37,6 +38,11 @@ def test_visualize():
     # FixestMulti
     fit6 = feols("Y + Y2 ~ X1 + X2 | f1", data=data)
     fit6.coefplot()
+
+    # identical models
+    fit7 = feols("Y ~ X1 + X2 | f1", data=data)
+    fit8 = feols("Y ~ X1 + X2 | f1", data=data)
+    pf.coefplot([fit7, fit8])
 
 
 def test_panelview():


### PR DESCRIPTION
Context: see #720.

Now we get three different non-overlapping models in case the `_model_name` attribute is identical across models: 

```python
import pyfixest as pf

data = pf.get_data()
fit1 = pf.feols("Y ~ X1", data = data)
fit2 = pf.feols("Y ~ X1", data = data)
fit3 = pf.feols("Y ~ X1", data = data)
fit4 = pf.feols("Y ~ X1 + X2", data = data)

pf.coefplot([fit1, fit2, fit3, fit4])
```
![image](https://github.com/user-attachments/assets/35168741-f5d8-4d5f-8f46-92f025568554)

Users are notified with a warning than an attribute is overwritten. 