### PR TITLE
Add warning when predict has a type mismatch

### DIFF
--- a/pyfixest/estimation/feols_.py
+++ b/pyfixest/estimation/feols_.py
@@ -1817,20 +1817,6 @@ class Feols:
 
         newdata = _narwhals_to_pandas(newdata).reset_index(drop=False)
 
-        if self._has_fixef:
-            fixef = self._fixef.split("+")
-
-            mismatched_fixef_types = [
-                x for x in fixef if newdata[x].dtypes != self._data[x].dtypes
-            ]
-            if mismatched_fixef_types:
-                warnings.warn(
-                    f"Data types of fixed effects {mismatched_fixef_types} "
-                    "do not match the model data. This leads to mismatched keys "
-                    "in the fixed effect dictionary, and as a result, to NaN "
-                    "predictions for columns with mismatched keys."
-                )
-
         if not self._X_is_empty:
             xfml = self._fml.split("|")[0].split("~")[1]
             if self._icovars is not None:
@@ -1851,6 +1837,19 @@ class Feols:
             if self._sumFE is None:
                 self.fixef(atol, btol)
             fvals = self._fixef.split("+")
+
+            mismatched_fixef_types = [
+                x for x in fvals if newdata[x].dtypes != self._data[x].dtypes
+            ]
+
+            if mismatched_fixef_types:
+                warnings.warn(
+                    f"Data types of fixed effects {mismatched_fixef_types} "
+                    "do not match the model data. This leads to mismatched keys "
+                    "in the fixed effect dictionary, and as a result, to NaN "
+                    "predictions for columns with mismatched keys."
+                )
+
             df_fe = newdata[fvals].astype(str)
             # populate fixed effect dicts with omitted categories handling
             fixef_dicts = {}

--- a/pyfixest/estimation/feols_.py
+++ b/pyfixest/estimation/feols_.py
@@ -1820,14 +1820,16 @@ class Feols:
         if self._has_fixef:
             fixef = self._fixef.split("+")
 
-            mismatched_fixef_types = [x for x in fixef if newdata[x].dtypes != self._data[x].dtypes]
+            mismatched_fixef_types = [
+                x for x in fixef if newdata[x].dtypes != self._data[x].dtypes
+            ]
             if mismatched_fixef_types:
                 warnings.warn(
-                        f"Data types of fixed effects {mismatched_fixef_types} "
-                        "do not match the model data. This leads to mismatched keys "
-                        "in the fixed effect dictionary, and as a result, to NaN "
-                        "predictions for columns with mismatched keys."
-                        )
+                    f"Data types of fixed effects {mismatched_fixef_types} "
+                    "do not match the model data. This leads to mismatched keys "
+                    "in the fixed effect dictionary, and as a result, to NaN "
+                    "predictions for columns with mismatched keys."
+                )
 
         if not self._X_is_empty:
             xfml = self._fml.split("|")[0].split("~")[1]

--- a/pyfixest/estimation/feols_.py
+++ b/pyfixest/estimation/feols_.py
@@ -1817,6 +1817,18 @@ class Feols:
 
         newdata = _narwhals_to_pandas(newdata).reset_index(drop=False)
 
+        if self._has_fixef:
+            fixef = self._fixef.split("+")
+
+            mismatched_fixef_types = [x for x in fixef if newdata[x].dtypes != self._data[x].dtypes]
+            if mismatched_fixef_types:
+                warnings.warn(
+                        f"Data types of fixed effects {mismatched_fixef_types} "
+                        "do not match the model data. This leads to mismatched keys "
+                        "in the fixed effect dictionary, and as a result, to NaN "
+                        "predictions for columns with mismatched keys."
+                        )
+
         if not self._X_is_empty:
             xfml = self._fml.split("|")[0].split("~")[1]
             if self._icovars is not None:

--- a/pyfixest/estimation/feols_.py
+++ b/pyfixest/estimation/feols_.py
@@ -3,7 +3,7 @@ import gc
 import re
 import warnings
 from importlib import import_module
-from typing import Literal, Optional, Union, Any
+from typing import Any, Literal, Optional, Union
 
 import numba as nb
 import numpy as np

--- a/pyfixest/estimation/feols_.py
+++ b/pyfixest/estimation/feols_.py
@@ -1856,9 +1856,9 @@ class Feols:
             fixef_dicts = {}
             for f in fvals:
                 fdict = self._fixef_dict[f"C({f})"]
-                omitted_cat = [
-                    str(x) for x in self._data[f].unique().tolist() if x not in fdict
-                ]
+                omitted_cat = set(map(str, self._data[f].unique())) - set(
+                    map(str, fdict.keys())
+                )
                 if omitted_cat:
                     fdict.update({x: 0 for x in omitted_cat})
                 fixef_dicts[f"C({f})"] = fdict

--- a/pyfixest/estimation/feols_.py
+++ b/pyfixest/estimation/feols_.py
@@ -3,7 +3,7 @@ import gc
 import re
 import warnings
 from importlib import import_module
-from typing import Literal, Optional, Union
+from typing import Literal, Optional, Union, Any
 
 import numba as nb
 import numpy as np
@@ -2526,7 +2526,7 @@ def _get_vcov_type(vcov: str, fval: str):
 
 def _drop_multicollinear_variables(
     X: np.ndarray, names: list[str], collin_tol: float
-) -> tuple[np.ndarray, list[str], list[str], list[int]]:
+) -> Any:
     """
     Check for multicollinearity in the design matrices X and Z.
 

--- a/pyfixest/estimation/feols_.py
+++ b/pyfixest/estimation/feols_.py
@@ -1856,9 +1856,9 @@ class Feols:
             fixef_dicts = {}
             for f in fvals:
                 fdict = self._fixef_dict[f"C({f})"]
-                omitted_cat = set(self._data[f].unique().astype(str).tolist()) - set(
-                    fdict.keys()
-                )
+                omitted_cat = [
+                    str(x) for x in self._data[f].unique().tolist() if x not in fdict
+                ]
                 if omitted_cat:
                     fdict.update({x: 0 for x in omitted_cat})
                 fixef_dicts[f"C({f})"] = fdict

--- a/pyfixest/estimation/feols_.py
+++ b/pyfixest/estimation/feols_.py
@@ -3,7 +3,7 @@ import gc
 import re
 import warnings
 from importlib import import_module
-from typing import Any, Literal, Optional, Union
+from typing import Literal, Optional, Union
 
 import numba as nb
 import numpy as np
@@ -1856,8 +1856,8 @@ class Feols:
             fixef_dicts = {}
             for f in fvals:
                 fdict = self._fixef_dict[f"C({f})"]
-                omitted_cat = set(map(str, self._data[f].unique())) - set(
-                    map(str, fdict.keys())
+                omitted_cat = set(self._data[f].unique().astype(str).tolist()) - set(
+                    fdict.keys()
                 )
                 if omitted_cat:
                     fdict.update({x: 0 for x in omitted_cat})  # type: ignore
@@ -2526,7 +2526,7 @@ def _get_vcov_type(vcov: str, fval: str):
 
 def _drop_multicollinear_variables(
     X: np.ndarray, names: list[str], collin_tol: float
-) -> Any:
+) -> tuple[np.ndarray, list[str], list[str], list[int]]:
     """
     Check for multicollinearity in the design matrices X and Z.
 

--- a/pyfixest/estimation/model_matrix_fixest_.py
+++ b/pyfixest/estimation/model_matrix_fixest_.py
@@ -209,13 +209,13 @@ def model_matrix_fixest(
     }
 
 
-def _get_na_index(N: int, Y_index: pd.Series) -> np.ndarray:
+def _get_na_index(N: int, Y_index: pd.Index) -> np.ndarray:
     all_indices = np.arange(N)
     max_index = all_indices.max() + 1
     mask = np.ones(max_index, dtype=bool)
     Y_index_arr = Y_index.to_numpy()
     mask[Y_index_arr] = False
-    na_index = np.nonzero(mask)[0]
+    na_index = np.where(mask)[0]
     return na_index
 
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -257,6 +257,14 @@ def test_rwolf_error():
         pf.rwolf(fit.to_list(), "X1", reps=9999, seed=123)
 
 
+def test_predict_dtype_error():
+    data = get_data()
+    fit = feols("Y ~ X1 | f1", data=data)
+
+    data["f1"] = data["f1"].fillna(0).astype(int)
+    with pytest.warns(UserWarning):
+        fit.predict(newdata=data.iloc[0:100])
+
 def test_wildboottest_errors():
     data = get_data()
     fit = feols("Y ~ X1", data=data)

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -265,6 +265,7 @@ def test_predict_dtype_error():
     with pytest.warns(UserWarning):
         fit.predict(newdata=data.iloc[0:100])
 
+
 def test_wildboottest_errors():
     data = get_data()
     fit = feols("Y ~ X1", data=data)


### PR DESCRIPTION
Brings back @ivanhigueram's PR https://github.com/py-econometrics/pyfixest/pull/761 that I accidentally deleted with a mistaken hard reset. 