### PR TITLE
Add JAX OLS Solver

### DIFF
--- a/pyfixest/estimation/feiv_.py
+++ b/pyfixest/estimation/feiv_.py
@@ -8,6 +8,7 @@ import pandas as pd
 from pyfixest.estimation.demean_ import demean_model
 from pyfixest.estimation.feols_ import Feols, _drop_multicollinear_variables
 from pyfixest.estimation.FormulaParser import FixestFormula
+from pyfixest.estimation.solvers import solve_ols
 
 
 class Feiv(Feols):
@@ -229,7 +230,7 @@ class Feiv(Feols):
         H = self._tXZ @ self._tZZinv
         A = H @ self._tZX
         B = H @ self._tZy
-        self._beta_hat = self.solve_ols(A, B, _solver)
+        self._beta_hat = solve_ols(A, B, _solver)
 
         # residuals
         self._u_hat = self._Y.flatten() - (self._X @ self._beta_hat).flatten()

--- a/pyfixest/estimation/fepois_.py
+++ b/pyfixest/estimation/fepois_.py
@@ -11,6 +11,7 @@ from pyfixest.errors import (
 from pyfixest.estimation.demean_ import demean
 from pyfixest.estimation.feols_ import Feols, PredictionType
 from pyfixest.estimation.FormulaParser import FixestFormula
+from pyfixest.estimation.solvers import solve_ols
 from pyfixest.utils.dev_utils import DataFrameType, _to_integer
 
 
@@ -273,7 +274,7 @@ class Fepois(Feols):
             XWX = WX.transpose() @ WX
             XWZ = WX.transpose() @ WZ
 
-            delta_new = self.solve_ols(XWX, XWZ, _solver).reshape(
+            delta_new = solve_ols(XWX, XWZ, _solver).reshape(
                 (-1, 1)
             )  # eq (10), delta_new -> reg_z
             resid = Z_resid - X_resid @ delta_new

--- a/pyfixest/estimation/solvers.py
+++ b/pyfixest/estimation/solvers.py
@@ -1,0 +1,35 @@
+import numpy as np
+from scipy.sparse.linalg import lsqr
+
+
+def solve_ols(tZX: np.ndarray, tZY: np.ndarray, solver: str) -> np.ndarray:
+    """
+    Solve the ordinary least squares problem using the specified solver.
+
+    Parameters
+    ----------
+    tZX (array-like): Z'X.
+    tZY (array-like): Z'Y.
+    solver (str): The solver to use. Supported solvers are"np.linalg.lstsq",
+    "np.linalg.solve", "scipy.sparse.linalg.lsqr" and "jax".
+
+    Returns
+    -------
+    array-like: The solution to the ordinary least squares problem.
+
+    Raises
+    ------
+    ValueError: If the specified solver is not supported.
+    """
+    if solver == "np.linalg.lstsq":
+        return np.linalg.lstsq(tZX, tZY, rcond=None)[0].flatten()
+    elif solver == "np.linalg.solve":
+        return np.linalg.solve(tZX, tZY).flatten()
+    elif solver == "scipy.sparse.linalg.lsqr":
+        return lsqr(tZX, tZY)[0].flatten()
+    elif solver == "jax":
+        import jax.numpy as jnp
+
+        return jnp.linalg.lstsq(tZX, tZY, rcond=None)[0].flatten()
+    else:
+        raise ValueError(f"Solver {solver} not supported.")

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -1,0 +1,46 @@
+import numpy as np
+import pytest
+
+from pyfixest.estimation.solvers import solve_ols
+
+
+def test_solve_ols_simple_2x2():
+    # Test case 1: Simple 2x2 system
+    tZX = np.array([[1, 2], [3, 4]])
+    tZY = np.array([5, 6])
+    solver = "np.linalg.lstsq"
+    solution = solve_ols(tZX, tZY, solver)
+    assert np.allclose(solution, np.array([-4.0, 4.5]))
+    # Verify solution satisfies the system
+    assert np.allclose(tZX @ solution, tZY)
+
+
+def test_solve_ols_identity():
+    # Test case 2: Identity matrix
+    tZX = np.eye(2)
+    tZY = np.array([1, 2])
+    solver = "np.linalg.lstsq"
+    assert np.allclose(solve_ols(tZX, tZY, solver), tZY)
+
+
+@pytest.mark.parametrize(
+    argnames="solver",
+    argvalues=["np.linalg.lstsq", "np.linalg.solve", "scipy.sparse.linalg.lsqr", "jax"],
+    ids=["np.linalg.lstsq", "np.linalg.solve", "scipy.sparse.linalg.lsqr", "jax"],
+)
+def test_solve_ols_different_solvers(solver):
+    # Test case 3: Test different solvers give same result
+    tZX = np.array([[1, 2], [3, 4]])
+    tZY = np.array([5, 6])
+    solution = solve_ols(tZX, tZY, solver)
+    assert np.allclose(solution, np.array([-4.0, 4.5]))
+    # Verify solution satisfies the system
+    assert np.allclose(tZX @ solution, tZY)
+
+
+def test_solve_ols_invalid_solver():
+    # Test case 4: Invalid solver
+    tZX = np.array([[1, 2], [3, 4]])
+    tZY = np.array([5, 6])
+    with pytest.raises(ValueError):
+        solve_ols(tZX, tZY, "invalid_solver")


### PR DESCRIPTION
See https://github.com/py-econometrics/pyfixest/pull/767#issuecomment-2566959514

Allow to use [`jax.numpy.linalg.lstsq`](https://jax.readthedocs.io/en/latest/_autosummary/jax.numpy.linalg.lstsq.html)