### PR TITLE
Allow JAX demeaning upstream

### DIFF
--- a/pyfixest/estimation/FixestMulti_.py
+++ b/pyfixest/estimation/FixestMulti_.py
@@ -190,6 +190,7 @@ class FixestMulti:
         solver: Literal[
             "np.linalg.lstsq", "np.linalg.solve", "scipy.sparse.linalg.lsqr", "jax"
         ],
+        demeaner_backend: Literal["numba", "jax"] = "numba",
         collin_tol: float = 1e-6,
         iwls_maxiter: int = 25,
         iwls_tol: float = 1e-08,
@@ -208,6 +209,9 @@ class FixestMulti:
             for CRV1 inference or {"CRV3": "clustervar"} for CRV3 inference.
         solver: Literal["np.linalg.lstsq", "np.linalg.solve", "scipy.sparse.linalg.lsqr", "jax"],
             default is 'np.linalg.solve'. Solver to use for the estimation.
+        demeaner_backend: Literal["numba", "jax"], optional
+            The backend to use for demeaning. Can be either "numba" or "jax".
+            Defaults to "numba".
         collin_tol : float, optional
             The tolerance level for the multicollinearity check. Default is 1e-6.
         iwls_maxiter : int, optional
@@ -271,6 +275,7 @@ class FixestMulti:
                             weights=_weights,
                             weights_type=_weights_type,
                             solver=solver,
+                            demeaner_backend=demeaner_backend,
                             collin_tol=collin_tol,
                             fixef_tol=_fixef_tol,
                             lookup_demeaned_data=lookup_demeaned_data,
@@ -295,6 +300,7 @@ class FixestMulti:
                             weights=_weights,
                             weights_type=_weights_type,
                             solver=solver,
+                            demeaner_backend=demeaner_backend,
                             collin_tol=collin_tol,
                             fixef_tol=_fixef_tol,
                             lookup_demeaned_data=lookup_demeaned_data,
@@ -319,6 +325,7 @@ class FixestMulti:
                             weights=_weights,
                             weights_type=_weights_type,
                             solver=solver,
+                            demeaner_backend=demeaner_backend,
                             collin_tol=collin_tol,
                             fixef_tol=_fixef_tol,
                             lookup_demeaned_data=lookup_demeaned_data,
@@ -346,6 +353,7 @@ class FixestMulti:
                             weights=_weights,
                             weights_type=_weights_type,
                             solver=solver,
+                            demeaner_backend=demeaner_backend,
                             collin_tol=collin_tol,
                             fixef_tol=_fixef_tol,
                             lookup_demeaned_data=lookup_demeaned_data,

--- a/pyfixest/estimation/FixestMulti_.py
+++ b/pyfixest/estimation/FixestMulti_.py
@@ -1,6 +1,6 @@
 import functools
 from importlib import import_module
-from typing import Optional, Union
+from typing import Literal, Optional, Union
 
 import pandas as pd
 
@@ -187,7 +187,9 @@ class FixestMulti:
     def _estimate_all_models(
         self,
         vcov: Union[str, dict[str, str], None],
-        solver: str = "np.linalg.solve",
+        solver: Literal[
+            "np.linalg.lstsq", "np.linalg.solve", "scipy.sparse.linalg.lsqr", "jax"
+        ],
         collin_tol: float = 1e-6,
         iwls_maxiter: int = 25,
         iwls_tol: float = 1e-08,
@@ -204,8 +206,8 @@ class FixestMulti:
             - If a string, can be one of "iid", "hetero", "HC1", "HC2", "HC3".
             - If a dictionary, it should have the format {"CRV1": "clustervar"}
             for CRV1 inference or {"CRV3": "clustervar"} for CRV3 inference.
-        solver: str, default is 'np.linalg.solve'.
-            Solver to use for the estimation. Alternative is 'np.linalg.lstsq'.
+        solver: Literal["np.linalg.lstsq", "np.linalg.solve", "scipy.sparse.linalg.lsqr", "jax"],
+            default is 'np.linalg.solve'. Solver to use for the estimation.
         collin_tol : float, optional
             The tolerance level for the multicollinearity check. Default is 1e-6.
         iwls_maxiter : int, optional

--- a/pyfixest/estimation/demean_.py
+++ b/pyfixest/estimation/demean_.py
@@ -43,6 +43,8 @@ def demean_model(
         variables.
     fixef_tol: float
         The tolerance for the demeaning algorithm.
+    demeaner_backend: Literal["numba", "jax"]
+        The backend to use for demeaning.
 
     Returns
     -------

--- a/pyfixest/estimation/demean_.py
+++ b/pyfixest/estimation/demean_.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any, Callable, Literal, Optional
 
 import numba as nb
 import numpy as np
@@ -13,6 +13,7 @@ def demean_model(
     lookup_demeaned_data: dict[str, Any],
     na_index_str: str,
     fixef_tol: float,
+    demeaner_backend: Literal["numba", "jax"] = "numba",
 ) -> tuple[pd.DataFrame, pd.DataFrame]:
     """
     Demean a regression model.
@@ -65,6 +66,8 @@ def demean_model(
     if weights is not None and weights.ndim > 1:
         weights = weights.flatten()
 
+    demean_func = _set_demeaner_backend(demeaner_backend)
+
     if fe is not None:
         fe_array = fe.to_numpy()
         # check if looked dict has data for na_index
@@ -93,7 +96,7 @@ def demean_model(
                 if var_diff.ndim == 1:
                     var_diff = var_diff.reshape(len(var_diff), 1)
 
-                YX_demean_new, success = demean(
+                YX_demean_new, success = demean_func(
                     x=var_diff, flist=fe_array, weights=weights, tol=fixef_tol
                 )
                 if success is False:
@@ -116,7 +119,7 @@ def demean_model(
                 YX_demeaned = YX_demeaned_old[yx_names]
 
         else:
-            YX_demeaned, success = demean(
+            YX_demeaned, success = demean_func(
                 x=YX_array, flist=fe_array, weights=weights, tol=fixef_tol
             )
             if success is False:
@@ -298,3 +301,34 @@ def demean(
 
     success = not not_converged
     return (res, success)
+
+
+def _set_demeaner_backend(demeaner_backend: Literal["numba", "jax"]) -> Callable:
+    """Set the demeaning backend.
+
+    Currently, we allow for a numba backend and a jax backend. The latter is
+    expected to be faster on GPU.
+
+    Parameters
+    ----------
+    demeaner_backend : Literal["numba", "jax"]
+        The demeaning backend to use.
+
+    Returns
+    -------
+    Callable
+        The demeaning function.
+
+    Raises
+    ------
+    ValueError
+        If the demeaning backend is not supported.
+    """
+    if demeaner_backend == "numba":
+        return demean
+    elif demeaner_backend == "jax":
+        from pyfixest.estimation.demean_jax_ import demean_jax
+
+        return demean_jax
+    else:
+        raise ValueError(f"Invalid demeaner backend: {demeaner_backend}")

--- a/pyfixest/estimation/estimation.py
+++ b/pyfixest/estimation/estimation.py
@@ -7,6 +7,7 @@ from pyfixest.estimation.feols_ import Feols
 from pyfixest.estimation.fepois_ import Fepois
 from pyfixest.estimation.FixestMulti_ import FixestMulti
 from pyfixest.estimation.literals import (
+    DemeanerBackendOptions,
     FixedRmOptions,
     SolverOptions,
     VcovTypeOptions,
@@ -32,6 +33,7 @@ def feols(
     lean: bool = False,
     weights_type: WeightsTypeOptions = "aweights",
     solver: SolverOptions = "np.linalg.solve",
+    demeaner_backend: DemeanerBackendOptions = "numba",
     use_compression: bool = False,
     reps: int = 100,
     seed: Optional[int] = None,
@@ -115,6 +117,9 @@ def feols(
     solver : SolverOptions, optional.
         The solver to use for the regression. Can be either "np.linalg.solve" or
         "np.linalg.lstsq". Defaults to "np.linalg.solve".
+
+    demeaner_backend: DemeanerBackendOptions, optional
+        The backend to use for demeaning. Can be either "numba" or "jax". Defaults to "numba".
 
     use_compression: bool
         Whether to use sufficient statistics to losslessly fit the regression model
@@ -433,7 +438,12 @@ def feols(
     )
 
     # demean all models: based on fixed effects x split x missing value combinations
-    fixest._estimate_all_models(vcov, collin_tol=collin_tol, solver=solver)
+    fixest._estimate_all_models(
+        vcov,
+        collin_tol=collin_tol,
+        solver=solver,
+        demeaner_backend=demeaner_backend,
+    )
 
     if fixest._is_multiple_estimation:
         return fixest
@@ -453,6 +463,7 @@ def fepois(
     collin_tol: float = 1e-10,
     separation_check: Optional[list[str]] = None,
     solver: SolverOptions = "np.linalg.solve",
+    demeaner_backend: DemeanerBackendOptions = "numba",
     drop_intercept: bool = False,
     i_ref1=None,
     copy_data: bool = True,
@@ -511,6 +522,10 @@ def fepois(
     solver : SolverOptions, optional.
         The solver to use for the regression. Can be either "np.linalg.solve" or
         "np.linalg.lstsq". Defaults to "np.linalg.solve".
+
+    demeaner_backend: DemeanerBackendOptions, optional
+        The backend to use for demeaning. Can be either "numba" or "jax".
+        Defaults to "numba".
 
     drop_intercept : bool, optional
         Whether to drop the intercept from the model, by default False.
@@ -642,6 +657,7 @@ def fepois(
         collin_tol=collin_tol,
         separation_check=separation_check,
         solver=solver,
+        demeaner_backend=demeaner_backend,
     )
 
     if fixest._is_multiple_estimation:

--- a/pyfixest/estimation/feiv_.py
+++ b/pyfixest/estimation/feiv_.py
@@ -1,6 +1,6 @@
 import warnings
 from importlib import import_module
-from typing import Optional, Union
+from typing import Literal, Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -41,6 +41,8 @@ class Feiv(Feols):
         Tolerance for collinearity check.
     solver: str, default is 'np.linalg.solve'
         Solver to use for the estimation. Alternative is 'np.linalg.lstsq'.
+    demeaner_backend: Literal["numba", "jax"]
+        The backend used for demeaning.
     weights_name : Optional[str]
         Name of the weights variable.
     weights_type : Optional[str]
@@ -141,6 +143,7 @@ class Feiv(Feols):
         fixef_tol: float,
         lookup_demeaned_data: dict[str, pd.DataFrame],
         solver: str = "np.linalg.solve",
+        demeaner_backend: Literal["numba", "jax"] = "numba",
         store_data: bool = True,
         copy_data: bool = True,
         lean: bool = False,
@@ -159,6 +162,7 @@ class Feiv(Feols):
             fixef_tol,
             lookup_demeaned_data,
             solver,
+            demeaner_backend,
             store_data,
             copy_data,
             lean,
@@ -198,6 +202,7 @@ class Feiv(Feols):
                 self._lookup_demeaned_data,
                 self._na_index_str,
                 self._fixef_tol,
+                self._demeaner_backend,
             )
         else:
             self._endogvard = self._endogvar

--- a/pyfixest/estimation/feiv_.py
+++ b/pyfixest/estimation/feiv_.py
@@ -39,8 +39,8 @@ class Feiv(Feols):
         Names of the coefficients of Z.
     collin_tol : float
         Tolerance for collinearity check.
-    solver: str, default is 'np.linalg.solve'
-        Solver to use for the estimation. Alternative is 'np.linalg.lstsq'.
+    solver: Literal["np.linalg.lstsq", "np.linalg.solve", "scipy.sparse.linalg.lsqr", "jax"],
+        default is 'np.linalg.solve'. Solver to use for the estimation.
     demeaner_backend: Literal["numba", "jax"]
         The backend used for demeaning.
     weights_name : Optional[str]
@@ -142,7 +142,9 @@ class Feiv(Feols):
         collin_tol: float,
         fixef_tol: float,
         lookup_demeaned_data: dict[str, pd.DataFrame],
-        solver: str = "np.linalg.solve",
+        solver: Literal[
+            "np.linalg.lstsq", "np.linalg.solve", "scipy.sparse.linalg.lsqr", "jax"
+        ] = "np.linalg.solve",
         demeaner_backend: Literal["numba", "jax"] = "numba",
         store_data: bool = True,
         copy_data: bool = True,

--- a/pyfixest/estimation/feols_.py
+++ b/pyfixest/estimation/feols_.py
@@ -184,8 +184,8 @@ class Feols:
         Adjusted R-squared value of the model.
     _adj_r2_within : float
         Adjusted R-squared value computed on demeaned dependent variable.
-    _solver: str
-        The solver used to fit the normal equation.
+    _solver: Literal["np.linalg.lstsq", "np.linalg.solve", "scipy.sparse.linalg.lsqr", "jax"],
+        default is 'np.linalg.solve'. Solver to use for the estimation.
     _demeaner_backend: Literal["numba", "jax"]
         The backend used for demeaning.
     _data: pd.DataFrame
@@ -213,7 +213,9 @@ class Feols:
         collin_tol: float,
         fixef_tol: float,
         lookup_demeaned_data: dict[str, pd.DataFrame],
-        solver: str = "np.linalg.solve",
+        solver: Literal[
+            "np.linalg.lstsq", "np.linalg.solve", "scipy.sparse.linalg.lsqr", "jax"
+        ] = "np.linalg.solve",
         demeaner_backend: Literal["numba", "jax"] = "numba",
         store_data: bool = True,
         copy_data: bool = True,

--- a/pyfixest/estimation/feols_.py
+++ b/pyfixest/estimation/feols_.py
@@ -186,6 +186,8 @@ class Feols:
         Adjusted R-squared value computed on demeaned dependent variable.
     _solver: str
         The solver used to fit the normal equation.
+    _demeaner_backend: Literal["numba", "jax"]
+        The backend used for demeaning.
     _data: pd.DataFrame
         The data frame used in the estimation. None if arguments `lean = True` or
         `store_data = False`.
@@ -212,6 +214,7 @@ class Feols:
         fixef_tol: float,
         lookup_demeaned_data: dict[str, pd.DataFrame],
         solver: str = "np.linalg.solve",
+        demeaner_backend: Literal["numba", "jax"] = "numba",
         store_data: bool = True,
         copy_data: bool = True,
         lean: bool = False,
@@ -242,6 +245,7 @@ class Feols:
         self._collin_tol = collin_tol
         self._fixef_tol = fixef_tol
         self._solver = solver
+        self._demeaner_backend = demeaner_backend
         self._lookup_demeaned_data = lookup_demeaned_data
         self._store_data = store_data
         self._copy_data = copy_data
@@ -408,6 +412,7 @@ class Feols:
                 self._lookup_demeaned_data,
                 self._na_index_str,
                 self._fixef_tol,
+                self._demeaner_backend,
             )
         else:
             self._Yd, self._Xd = self._Y, self._X

--- a/pyfixest/estimation/feols_compressed_.py
+++ b/pyfixest/estimation/feols_compressed_.py
@@ -79,7 +79,9 @@ class FeolsCompressed(Feols):
         collin_tol: float,
         fixef_tol: float,
         lookup_demeaned_data: dict[str, pd.DataFrame],
-        solver: str = "np.linalg.solve",
+        solver: Literal[
+            "np.linalg.lstsq", "np.linalg.solve", "scipy.sparse.linalg.lsqr", "jax"
+        ],
         demeaner_backend: Literal["numba", "jax"] = "numba",
         store_data: bool = True,
         copy_data: bool = True,

--- a/pyfixest/estimation/feols_compressed_.py
+++ b/pyfixest/estimation/feols_compressed_.py
@@ -1,6 +1,6 @@
 import logging
 from dataclasses import dataclass
-from typing import Optional, Union
+from typing import Literal, Optional, Union
 
 import narwhals as nw
 import numpy as np
@@ -80,6 +80,7 @@ class FeolsCompressed(Feols):
         fixef_tol: float,
         lookup_demeaned_data: dict[str, pd.DataFrame],
         solver: str = "np.linalg.solve",
+        demeaner_backend: Literal["numba", "jax"] = "numba",
         store_data: bool = True,
         copy_data: bool = True,
         lean: bool = False,
@@ -100,6 +101,7 @@ class FeolsCompressed(Feols):
             fixef_tol,
             lookup_demeaned_data,
             solver,
+            demeaner_backend,
             store_data,
             copy_data,
             lean,

--- a/pyfixest/estimation/fepois_.py
+++ b/pyfixest/estimation/fepois_.py
@@ -50,13 +50,12 @@ class Fepois(Feols):
         Maximum number of iterations for the IRLS algorithm.
     tol : Optional[float], default=1e-08
         Tolerance level for the convergence of the IRLS algorithm.
-    solver: str, default is 'np.linalg.solve'
-        Solver to use for the estimation. Alternative is 'np.linalg.lstsq'.
+    solver: Literal["np.linalg.lstsq", "np.linalg.solve", "scipy.sparse.linalg.lsqr", "jax"],
+        default is 'np.linalg.solve'. Solver to use for the estimation.
     demeaner_backend: Literal["numba", "jax"]
         The backend used for demeaning.
     fixef_tol: float, default = 1e-08.
         Tolerance level for the convergence of the demeaning algorithm.
-    solver:
     weights_name : Optional[str]
         Name of the weights variable.
     weights_type : Optional[str]
@@ -80,7 +79,9 @@ class Fepois(Feols):
         lookup_demeaned_data: dict[str, pd.DataFrame],
         tol: float,
         maxiter: int,
-        solver: str = "np.linalg.solve",
+        solver: Literal[
+            "np.linalg.lstsq", "np.linalg.solve", "scipy.sparse.linalg.lsqr", "jax"
+        ] = "np.linalg.solve",
         demeaner_backend: Literal["numba", "jax"] = "numba",
         store_data: bool = True,
         copy_data: bool = True,

--- a/pyfixest/estimation/fepois_.py
+++ b/pyfixest/estimation/fepois_.py
@@ -1,6 +1,6 @@
 import warnings
 from importlib import import_module
-from typing import Optional, Protocol, Union
+from typing import Literal, Optional, Protocol, Union
 
 import numpy as np
 import pandas as pd
@@ -52,6 +52,8 @@ class Fepois(Feols):
         Tolerance level for the convergence of the IRLS algorithm.
     solver: str, default is 'np.linalg.solve'
         Solver to use for the estimation. Alternative is 'np.linalg.lstsq'.
+    demeaner_backend: Literal["numba", "jax"]
+        The backend used for demeaning.
     fixef_tol: float, default = 1e-08.
         Tolerance level for the convergence of the demeaning algorithm.
     solver:
@@ -79,6 +81,7 @@ class Fepois(Feols):
         tol: float,
         maxiter: int,
         solver: str = "np.linalg.solve",
+        demeaner_backend: Literal["numba", "jax"] = "numba",
         store_data: bool = True,
         copy_data: bool = True,
         lean: bool = False,
@@ -98,6 +101,7 @@ class Fepois(Feols):
             fixef_tol,
             lookup_demeaned_data,
             solver,
+            demeaner_backend,
             store_data,
             copy_data,
             lean,

--- a/pyfixest/estimation/literals.py
+++ b/pyfixest/estimation/literals.py
@@ -4,7 +4,10 @@ PredictionType = Literal["response", "link"]
 VcovTypeOptions = Literal["iid", "hetero", "HC1", "HC2", "HC3"]
 WeightsTypeOptions = Literal["aweights", "fweights"]
 FixedRmOptions = Literal["singleton", "none"]
-SolverOptions = Literal["np.linalg.solve", "np.linalg.lstsq"]
+SolverOptions = Literal[
+    "np.linalg.lstsq", "np.linalg.solve", "scipy.sparse.linalg.lsqr", "jax"
+]
+DemeanerBackendOptions = Literal["numba", "jax"]
 
 
 def _validate_literal_argument(arg: Any, literal: Any) -> None:

--- a/pyfixest/estimation/solvers.py
+++ b/pyfixest/estimation/solvers.py
@@ -1,8 +1,15 @@
 import numpy as np
 from scipy.sparse.linalg import lsqr
+from typing_extensions import Literal
 
 
-def solve_ols(tZX: np.ndarray, tZY: np.ndarray, solver: str) -> np.ndarray:
+def solve_ols(
+    tZX: np.ndarray,
+    tZY: np.ndarray,
+    solver: Literal[
+        "np.linalg.lstsq", "np.linalg.solve", "scipy.sparse.linalg.lsqr", "jax"
+    ],
+) -> np.ndarray:
     """
     Solve the ordinary least squares problem using the specified solver.
 

--- a/tests/test_demean.py
+++ b/tests/test_demean.py
@@ -1,8 +1,9 @@
 import numpy as np
+import pandas as pd
 import pyhdfe
 import pytest
 
-from pyfixest.estimation.demean_ import _set_demeaner_backend, demean
+from pyfixest.estimation.demean_ import _set_demeaner_backend, demean, demean_model
 from pyfixest.estimation.demean_jax_ import demean_jax
 
 
@@ -48,3 +49,170 @@ def test_set_demeaner_backend():
     # Test invalid backend raises ValueError
     with pytest.raises(ValueError, match="Invalid demeaner backend: invalid"):
         _set_demeaner_backend("invalid")
+
+
+def test_demean_model_no_fixed_effects():
+    """Test demean_model when there are no fixed effects."""
+    # Create sample data
+    N = 1000
+    Y = pd.DataFrame({"y": np.random.randn(N)})
+    X = pd.DataFrame({"x1": np.random.randn(N), "x2": np.random.randn(N)})
+    weights = np.ones(N)
+    lookup_dict = {}
+
+    # Test without fixed effects
+    Yd, Xd = demean_model(
+        Y=Y,
+        X=X,
+        fe=None,
+        weights=weights,
+        lookup_demeaned_data=lookup_dict,
+        na_index_str="test",
+        fixef_tol=1e-8,
+        demeaner_backend="numba",
+    )
+
+    # When no fixed effects, output should equal input
+    assert np.allclose(Y.values, Yd.values)
+    assert np.allclose(X.values, Xd.values)
+    assert Yd.columns.equals(Y.columns)
+    assert Xd.columns.equals(X.columns)
+
+
+def test_demean_model_with_fixed_effects():
+    """Test demean_model with fixed effects."""
+    # Create sample data
+    N = 1000
+    rng = np.random.default_rng(42)
+
+    Y = pd.DataFrame({"y": rng.normal(0, 1, N)})
+    X = pd.DataFrame({"x1": rng.normal(0, 1, N), "x2": rng.normal(0, 1, N)})
+    fe = pd.DataFrame({"fe1": rng.integers(0, 10, N), "fe2": rng.integers(0, 5, N)})
+    weights = np.ones(N)
+    lookup_dict = {}
+
+    # Run demean_model
+    Yd, Xd = demean_model(
+        Y=Y,
+        X=X,
+        fe=fe,
+        weights=weights,
+        lookup_demeaned_data=lookup_dict,
+        na_index_str="test",
+        fixef_tol=1e-8,
+        demeaner_backend="numba",
+    )
+
+    # Verify results are different from input (since we're demeaning)
+    assert not np.allclose(Y.values, Yd.values)
+    assert not np.allclose(X.values, Xd.values)
+
+    # Verify column names are preserved
+    assert Yd.columns.equals(Y.columns)
+    assert Xd.columns.equals(X.columns)
+
+    # Verify results are cached in lookup_dict
+    assert "test" in lookup_dict
+    cached_data = lookup_dict["test"][1]
+    assert np.allclose(cached_data[Y.columns].values, Yd.values)
+    assert np.allclose(cached_data[X.columns].values, Xd.values)
+
+
+def test_demean_model_with_weights():
+    """Test demean_model with weights."""
+    N = 1000
+    rng = np.random.default_rng(42)
+
+    Y = pd.DataFrame({"y": rng.normal(0, 1, N)})
+    X = pd.DataFrame({"x1": rng.normal(0, 1, N), "x2": rng.normal(0, 1, N)})
+    fe = pd.DataFrame({"fe1": rng.integers(0, 10, N)})
+    weights = rng.uniform(0.5, 1.5, N)
+    lookup_dict = {}
+
+    # Run with weights
+    Yd, Xd = demean_model(
+        Y=Y,
+        X=X,
+        fe=fe,
+        weights=weights,
+        lookup_demeaned_data=lookup_dict,
+        na_index_str="test",
+        fixef_tol=1e-8,
+        demeaner_backend="numba",
+    )
+
+    # Run without weights for comparison
+    Yd_unweighted, Xd_unweighted = demean_model(
+        Y=Y,
+        X=X,
+        fe=fe,
+        weights=np.ones(N),
+        lookup_demeaned_data={},
+        na_index_str="test2",
+        fixef_tol=1e-8,
+        demeaner_backend="numba",
+    )
+
+    # Results should be different with weights vs without
+    assert not np.allclose(Yd.values, Yd_unweighted.values)
+    assert not np.allclose(Xd.values, Xd_unweighted.values)
+
+
+def test_demean_model_caching():
+    """Test the caching behavior of demean_model."""
+    N = 1000
+    rng = np.random.default_rng(42)
+
+    Y = pd.DataFrame({"y": rng.normal(0, 1, N)})
+    X = pd.DataFrame({"x1": rng.normal(0, 1, N), "x2": rng.normal(0, 1, N)})
+    fe = pd.DataFrame({"fe1": rng.integers(0, 10, N)})
+    weights = np.ones(N)
+    lookup_dict = {}
+
+    # First run - should compute and cache
+    Yd1, Xd1 = demean_model(
+        Y=Y,
+        X=X,
+        fe=fe,
+        weights=weights,
+        lookup_demeaned_data=lookup_dict,
+        na_index_str="test",
+        fixef_tol=1e-8,
+        demeaner_backend="numba",
+    )
+
+    # Second run - should use cache
+    Yd2, Xd2 = demean_model(
+        Y=Y,
+        X=X,
+        fe=fe,
+        weights=weights,
+        lookup_demeaned_data=lookup_dict,
+        na_index_str="test",
+        fixef_tol=1e-8,
+        demeaner_backend="numba",
+    )
+
+    # Results should be identical
+    assert np.allclose(Yd1.values, Yd2.values)
+    assert np.allclose(Xd1.values, Xd2.values)
+
+    # Add new variable and verify partial caching
+    X_new = X.copy()
+    X_new["x3"] = rng.normal(0, 1, N)
+
+    Yd3, Xd3 = demean_model(
+        Y=Y,
+        X=X_new,
+        fe=fe,
+        weights=weights,
+        lookup_demeaned_data=lookup_dict,
+        na_index_str="test",
+        fixef_tol=1e-8,
+        demeaner_backend="numba",
+    )
+
+    # Original columns should match previous results
+    assert np.allclose(Xd3[["x1", "x2"]].values, Xd2.values)
+    # New column should be different
+    assert "x3" in Xd3.columns

--- a/tests/test_demean.py
+++ b/tests/test_demean.py
@@ -2,7 +2,7 @@ import numpy as np
 import pyhdfe
 import pytest
 
-from pyfixest.estimation.demean_ import demean
+from pyfixest.estimation.demean_ import _set_demeaner_backend, demean
 from pyfixest.estimation.demean_jax_ import demean_jax
 
 
@@ -34,3 +34,17 @@ def test_demean(demean_func):
     res_pyhdfe = algorithm.residualize(x, weights)
     res_pyfixest, success = demean_func(x, flist, weights.flatten(), tol=1e-10)
     assert np.allclose(res_pyhdfe, res_pyfixest)
+
+
+def test_set_demeaner_backend():
+    # Test numba backend
+    demean_func = _set_demeaner_backend("numba")
+    assert demean_func == demean
+
+    # Test jax backend
+    demean_func = _set_demeaner_backend("jax")
+    assert demean_func == demean_jax
+
+    # Test invalid backend raises ValueError
+    with pytest.raises(ValueError, match="Invalid demeaner backend: invalid"):
+        _set_demeaner_backend("invalid")


### PR DESCRIPTION
Following https://github.com/py-econometrics/pyfixest/pull/767, we want to expose this option to the users via the current API.