### PR TITLE
Docstring improvements for etable; improve display of qmd docs & small extension for rename_categoricals

### DIFF
--- a/docs/difference-in-differences.qmd
+++ b/docs/difference-in-differences.qmd
@@ -1,5 +1,8 @@
 ---
 title: Difference-in-Differences Estimation
+format:
+  html:
+    html-table-processing: none
 toc: true
 toc-title: "On this page"
 toc-location: left

--- a/docs/marginaleffects.qmd
+++ b/docs/marginaleffects.qmd
@@ -1,6 +1,8 @@
 ---
 title: Marginal Effects and Hypothesis Tests via `marginaleffects`
-
+format:
+  html:
+    html-table-processing: none
 toc: true
 toc-title: "On this page"
 toc-location: left

--- a/docs/quickstart.qmd
+++ b/docs/quickstart.qmd
@@ -539,10 +539,13 @@ fit_twfe = pf.feols(
     vcov={"CRV1": "state"},
 )
 
+from pyfixest.report.utils import rename_categoricals
 pf.iplot(
-    [fit_did2s, fit_twfe], coord_flip=False, figsize=(900, 400), title="TWFE vs DID2S"
-)
+    [fit_did2s, fit_twfe], coord_flip=False, figsize=(900, 400), title="TWFE vs DID2S", rotate_xticks=90,
+    labels= rename_categoricals(fit_did2s._coefnames, template="{value_int}")
+)  
 ```
+
 
 The `event_study()` function provides a common API for several event study estimators.
 

--- a/docs/quickstart.qmd
+++ b/docs/quickstart.qmd
@@ -543,7 +543,7 @@ from pyfixest.report.utils import rename_categoricals
 pf.iplot(
     [fit_did2s, fit_twfe], coord_flip=False, figsize=(900, 400), title="TWFE vs DID2S", rotate_xticks=90,
     labels= rename_categoricals(fit_did2s._coefnames, template="{value_int}")
-)  
+)
 ```
 
 

--- a/docs/quickstart.qmd
+++ b/docs/quickstart.qmd
@@ -1,6 +1,8 @@
 ---
 title: "Getting Started with PyFixest"
-format: html
+format:
+  html:
+    html-table-processing: none
 toc: true
 toc-title: "On this page"
 toc-location: left

--- a/docs/replicating-the-effect.qmd
+++ b/docs/replicating-the-effect.qmd
@@ -1,5 +1,8 @@
 ---
 title: Replicating Examples from "The Effect"
+format:
+  html:
+    html-table-processing: none
 toc: true
 toc-title: "On this page"
 toc-location: left

--- a/pyfixest/report/summarize.py
+++ b/pyfixest/report/summarize.py
@@ -119,6 +119,9 @@ def etable(
         (provided the user has specified them). With "hd" it is the other way around.
         When head_order is "d", only the dependent variable and model numbers are displayed
         and with "" only the model numbers. Default is "dh".
+    custom_model_stats: dict, optional
+        A dictionary of custom model statistics. The keys are the names of the statistics
+        and the values are lists of the same length as the number of models. Default is None.
     filename: str, optional
         The filename to save the LaTeX table to. If None, the LaTeX code is returned
         as a string. Default is None.

--- a/pyfixest/report/summarize.py
+++ b/pyfixest/report/summarize.py
@@ -27,6 +27,7 @@ def etable(
     signif_code: Optional[list] = None,
     coef_fmt: str = "b \n (se)",
     custom_stats: Optional[dict] = None,
+    custom_model_stats: Optional[dict] = None,
     keep: Optional[Union[list, str]] = None,
     drop: Optional[Union[list, str]] = None,
     exact_match: Optional[bool] = False,
@@ -38,18 +39,19 @@ def etable(
     notes: str = "",
     model_heads: Optional[list] = None,
     head_order: Optional[str] = "dh",
-    custom_model_stats: Optional[dict] = None,
     filename: Optional[str] = None,
     print_tex: Optional[bool] = False,
     **kwargs,
 ) -> Union[pd.DataFrame, str, None]:
     r"""
-    Create an esttab-like table from a list of models.
+    Generate a table summarizing the results of multiple regression models.
+    It supports various output formats including html (via great tables),  markdown, and LaTeX.
 
     Parameters
     ----------
     models : A supported model object (Feols, Fepois, Feiv, FixestMulti) or a list of
             Feols, Fepois & Feiv models.
+        The models to be summarized in the table.
     type : str, optional
         Type of output. Either "df" for pandas DataFrame, "md" for markdown,
         "gt" for great_tables, or "tex" for LaTeX table. Default is "gt".
@@ -61,7 +63,15 @@ def etable(
         p-value (p). Default is `"b \n (se)"`.
         Spaces ` `, parentheses `()`, brackets `[]`, newlines `\n` are supported.
     custom_stats: dict, optional
-        A dictionary of custom statistics. "b", "se", "t", or "p" are reserved.
+        A dictionary of custom statistics that can be used in the coef_fmt string to be displayed
+        in the coefficuent cells analogously to "b", "se" etc. The keys are the names of the custom
+        statistics, and the values are lists of lists, where each inner list contains the custom
+        statistic values for all coefficients each model.
+        Note that "b", "se", "t", or "p" are reserved and cannot be used as keys.
+    custom_model_stats: dict, optional
+        A dictionary of custom model statistics or model information displayed in a new line in the
+        bottom panel of the table. The keys are the names of the statistics (i.e. entry in the first column)
+        and the values are a lists of the same length as the number of models. Default is None.
     keep: str or list of str, optional
         The pattern for retaining coefficient names. You can pass a string (one
         pattern) or a list (multiple patterns). Default is keeping all coefficients.
@@ -119,9 +129,6 @@ def etable(
         (provided the user has specified them). With "hd" it is the other way around.
         When head_order is "d", only the dependent variable and model numbers are displayed
         and with "" only the model numbers. Default is "dh".
-    custom_model_stats: dict, optional
-        A dictionary of custom model statistics. The keys are the names of the statistics
-        and the values are lists of the same length as the number of models. Default is None.
     filename: str, optional
         The filename to save the LaTeX table to. If None, the LaTeX code is returned
         as a string. Default is None.

--- a/pyfixest/report/utils.py
+++ b/pyfixest/report/utils.py
@@ -85,22 +85,14 @@ def _rename_categorical(
         value_int = value_raw
         try:
             numeric_val = float(value_raw)
-            if numeric_val.is_integer():
-                value_int = int(numeric_val)
-            else:
-                value_int = numeric_val
+            value_int = int(numeric_val) if numeric_val.is_integer() else numeric_val
         except ValueError:
             # If not numeric at all, we'll leave it as-is
             pass
 
-        return template.format(
-            variable=variable,
-            value=value_raw,
-            value_int=value_int
-        )
+        return template.format(variable=variable, value=value_raw, value_int=value_int)
     else:
         return col_name
-
 
 
 def rename_categoricals(
@@ -114,7 +106,7 @@ def rename_categoricals(
     coef_names_list: list
         The list of coefficient names.
     template: str
-        The template to use for renaming the categorical variables. 
+        The template to use for renaming the categorical variables.
         You can use {variable}, {value}, or {value_int} placeholders.
         e.g. "{variable}::{value_int}" if you want to force integer format when possible.
         or "{value_int}" if you only want to display integers


### PR DESCRIPTION
- Corrected docstring for etable to better document use of custom_stats & custom_model_stats to address [this issue](https://github.com/py-econometrics/pyfixest/issues/806). 
- Turn off quarto html table processing to improve table rendering in documentation (as already used in table-layout.qmd)
- Extension to rename_categoricals that allows the user to display integers rather than floats when needed (for instance useful in coefplot when categorical is a time index)