### PR TITLE
Fix formula parsing bug

### DIFF
--- a/pyfixest/estimation/feols_.py
+++ b/pyfixest/estimation/feols_.py
@@ -373,6 +373,10 @@ class Feols:
         self._na_index = mm_dict.get("na_index")
         self._na_index_str = mm_dict.get("na_index_str")
         self._icovars = mm_dict.get("icovars")
+        self._X_is_empty = mm_dict.get("X_is_empty")
+
+        # Store model_spec for consistent predictions
+        self._model_spec = mm_dict.get("model_spec")
 
         self._coefnames = self._X.columns.tolist()
         self._coefnames_z = self._Z.columns.tolist() if self._Z is not None else None

--- a/pyfixest/estimation/feols_.py
+++ b/pyfixest/estimation/feols_.py
@@ -374,8 +374,6 @@ class Feols:
         self._na_index_str = mm_dict.get("na_index_str")
         self._icovars = mm_dict.get("icovars")
         self._X_is_empty = mm_dict.get("X_is_empty")
-
-        # Store model_spec for consistent predictions
         self._model_spec = mm_dict.get("model_spec")
 
         self._coefnames = self._X.columns.tolist()

--- a/pyfixest/estimation/model_matrix_fixest_.py
+++ b/pyfixest/estimation/model_matrix_fixest_.py
@@ -134,7 +134,6 @@ def model_matrix_fixest(
     )
     endogvar = Z = weights_df = fe = None
 
-    # Store the model specs for later reuse in prediction
     model_spec = mm.model_spec
 
     Y = mm["fml_second_stage"]["lhs"]

--- a/pyfixest/estimation/model_matrix_fixest_.py
+++ b/pyfixest/estimation/model_matrix_fixest_.py
@@ -76,6 +76,8 @@ def model_matrix_fixest(
             List of variables interacted with i() syntax, None if not applicable.
         - 'X_is_empty' : bool
             Flag indicating whether X is empty.
+        - 'model_spec' : formulaic ModelSpec
+            The model specification used to create the model matrices.
 
     Examples
     --------
@@ -131,6 +133,9 @@ def model_matrix_fixest(
         data, output="pandas", context={"factorize": factorize, **_context}
     )
     endogvar = Z = weights_df = fe = None
+
+    # Store the model specs for later reuse in prediction
+    model_spec = mm.model_spec
 
     Y = mm["fml_second_stage"]["lhs"]
     X = mm["fml_second_stage"]["rhs"]
@@ -217,6 +222,7 @@ def model_matrix_fixest(
         "na_index_str": na_index_str,
         "icovars": _icovars,
         "X_is_empty": X_is_empty,
+        "model_spec": model_spec,
     }
 
 

--- a/pyfixest/estimation/prediction.py
+++ b/pyfixest/estimation/prediction.py
@@ -55,16 +55,10 @@ def get_design_matrix_and_yhat(
                     "predict() with argument newdata is not supported with i() syntax."
                 )
 
-            # Use the stored model_spec instead of creating a new Formula
             if hasattr(model, "_model_spec") and model._model_spec is not None:
-                # Get the right-hand side model spec from the nested structure
-                # ModelSpecs contains fml_second_stage which contains rhs
                 rhs_spec = model._model_spec.fml_second_stage.rhs
-
-                # Use the right model spec directly with get_model_matrix
                 X = rhs_spec.get_model_matrix(newdata)
             else:
-                # Fallback to old behavior if model_spec is not available
                 xfml = model._fml.split("|")[0].split("~")[1]
                 X = Formula(xfml).get_model_matrix(newdata)
 

--- a/pyfixest/estimation/prediction.py
+++ b/pyfixest/estimation/prediction.py
@@ -56,7 +56,7 @@ def get_design_matrix_and_yhat(
                 )
 
             # Use the stored model_spec instead of creating a new Formula
-            if hasattr(model, '_model_spec') and model._model_spec is not None:
+            if hasattr(model, "_model_spec") and model._model_spec is not None:
                 # Get the right-hand side model spec from the nested structure
                 # ModelSpecs contains fml_second_stage which contains rhs
                 rhs_spec = model._model_spec.fml_second_stage.rhs

--- a/pyfixest/estimation/prediction.py
+++ b/pyfixest/estimation/prediction.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 import numpy as np
 import pandas as pd
-from formulaic import Formula
+from formulaic import Formula, ModelSpec
 from scipy.stats import t
 
 from pyfixest.utils.dev_utils import (
@@ -50,12 +50,27 @@ def get_design_matrix_and_yhat(
         newdata = _narwhals_to_pandas(newdata).reset_index(drop=False)
 
         if not model._X_is_empty:
-            xfml = model._fml.split("|")[0].split("~")[1]
             if model._icovars is not None:
                 raise NotImplementedError(
                     "predict() with argument newdata is not supported with i() syntax."
                 )
-            X = Formula(xfml).get_model_matrix(newdata)
+            
+            # Use the stored model_spec instead of creating a new Formula
+            if hasattr(model, '_model_spec') and model._model_spec is not None:
+                # Get the right-hand side model spec from the nested structure
+                # ModelSpecs contains fml_second_stage which contains rhs
+                rhs_spec = model._model_spec.fml_second_stage.rhs
+
+                # Extract the formula from the model spec
+                formula_rhs = str(rhs_spec.formula)
+                
+                # Use the right model spec directly with get_model_matrix
+                X = rhs_spec.get_model_matrix(newdata)
+            else:
+                # Fallback to old behavior if model_spec is not available
+                xfml = model._fml.split("|")[0].split("~")[1]
+                X = Formula(xfml).get_model_matrix(newdata)
+            
             X_index = X.index
 
             coef_idx = np.isin(model._coefnames, X.columns)

--- a/pyfixest/estimation/prediction.py
+++ b/pyfixest/estimation/prediction.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 import numpy as np
 import pandas as pd
-from formulaic import Formula, ModelSpec
+from formulaic import Formula
 from scipy.stats import t
 
 from pyfixest.utils.dev_utils import (
@@ -54,23 +54,20 @@ def get_design_matrix_and_yhat(
                 raise NotImplementedError(
                     "predict() with argument newdata is not supported with i() syntax."
                 )
-            
+
             # Use the stored model_spec instead of creating a new Formula
             if hasattr(model, '_model_spec') and model._model_spec is not None:
                 # Get the right-hand side model spec from the nested structure
                 # ModelSpecs contains fml_second_stage which contains rhs
                 rhs_spec = model._model_spec.fml_second_stage.rhs
 
-                # Extract the formula from the model spec
-                formula_rhs = str(rhs_spec.formula)
-                
                 # Use the right model spec directly with get_model_matrix
                 X = rhs_spec.get_model_matrix(newdata)
             else:
                 # Fallback to old behavior if model_spec is not available
                 xfml = model._fml.split("|")[0].split("~")[1]
                 X = Formula(xfml).get_model_matrix(newdata)
-            
+
             X_index = X.index
 
             coef_idx = np.isin(model._coefnames, X.columns)

--- a/tests/test_predict_resid_fixef.py
+++ b/tests/test_predict_resid_fixef.py
@@ -300,7 +300,9 @@ def test_categorical_covariate_predict():
 
 def test_specific_categorical_prediction():
     """Test prediction with a specific categorical case."""
-    test_df = pd.DataFrame({"y": [2, 3, 4, 5], "x": [1, 1, 2, 3], "f": ["a", "b", "a", "a"]})
+    test_df = pd.DataFrame(
+        {"y": [2, 3, 4, 5], "x": [1, 1, 2, 3], "f": ["a", "b", "a", "a"]}
+    )
     test_model = pf.feols("y ~ x + C(f)", data=test_df)
     prediction = test_model.predict(newdata=pd.DataFrame({"x": [1], "f": ["b"]}))
     expected_prediction = 3

--- a/tests/test_predict_resid_fixef.py
+++ b/tests/test_predict_resid_fixef.py
@@ -298,6 +298,15 @@ def test_categorical_covariate_predict():
     np.testing.assert_allclose(py_predict, r_predict, rtol=1e-08, atol=1e-08)
 
 
+def test_specific_categorical_prediction():
+    """Test prediction with a specific categorical case."""
+    test_df = pd.DataFrame({"y": [2, 3, 4, 5], "x": [1, 1, 2, 3], "f": ["a", "b", "a", "a"]})
+    test_model = pf.feols("y ~ x + C(f)", data=test_df)
+    prediction = test_model.predict(newdata=pd.DataFrame({"x": [1], "f": ["b"]}))
+    expected_prediction = 3
+    np.testing.assert_almost_equal(prediction[0], expected_prediction, decimal=3)
+
+
 def test_extract_variable_level():
     """Verify the correct extracation of lists, floats, and integers."""
     var = "C(SHOPPER_PLATFORM)[T.['ios', 'android']]"


### PR DESCRIPTION
This PR addresses a bug where the predict method re-parses the string formula which can result in a different shape of the model matrix. This is fixed by storing the modelspec object and then using that to create the model matrix, instead of re-parsing it from scratch. I've added a test case as well to test exactly this.

@s3alfisc please let me know what you think. I'm happy to do a rev or two if you'd like changes. Once you're happy, would love to get your help cutting a patch version (i.e. bumping to v0.28.1) so this fix can be picked up by pypi. 