### PR TITLE
Add context capture to prediction with new data

### DIFF
--- a/pyfixest/estimation/feols_.py
+++ b/pyfixest/estimation/feols_.py
@@ -1872,6 +1872,7 @@ class Feols:
             y_hat, X, X_index = get_design_matrix_and_yhat(
                 model=self,
                 newdata=newdata if newdata is not None else None,
+                context=self._context,
             )
 
             y_hat += _get_fixed_effects_prediction_component(

--- a/pyfixest/estimation/feols_.py
+++ b/pyfixest/estimation/feols_.py
@@ -1725,7 +1725,9 @@ class Feols:
         fixef_fml = "+".join(fixef_vars_C)
 
         fml_linear = f"{depvars} ~ {covars}"
-        Y, X = Formula(fml_linear).get_model_matrix(_data, output="pandas")
+        Y, X = Formula(fml_linear).get_model_matrix(
+            _data, output="pandas", context=self._context
+        )
         if self._X_is_empty:
             Y = Y.to_numpy()
             uhat = Y.flatten()

--- a/pyfixest/estimation/prediction.py
+++ b/pyfixest/estimation/prediction.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import Optional
+from typing import Optional, Union, Mapping, Any
 
 import numpy as np
 import pandas as pd
@@ -14,6 +14,7 @@ from pyfixest.utils.dev_utils import (
 def get_design_matrix_and_yhat(
     model,
     newdata: Optional[pd.DataFrame] = None,
+    context: Union[int, Mapping[str, Any]] = None,
 ):
     """
     Build the design matrix X and initializes y_hat for predictions.
@@ -57,10 +58,10 @@ def get_design_matrix_and_yhat(
 
             if hasattr(model, "_model_spec") and model._model_spec is not None:
                 rhs_spec = model._model_spec.fml_second_stage.rhs
-                X = rhs_spec.get_model_matrix(newdata)
+                X = rhs_spec.get_model_matrix(newdata, context=context)
             else:
                 xfml = model._fml.split("|")[0].split("~")[1]
-                X = Formula(xfml).get_model_matrix(newdata)
+                X = Formula(xfml).get_model_matrix(newdata, context=context)
 
             X_index = X.index
 


### PR DESCRIPTION
When a model was fitted using some functions in the formula from a given context, a prediction on new data fails as predict does not have access to the function in the context. 