### PR TITLE
renaming categories without T. notation

### DIFF
--- a/pyfixest/report/utils.py
+++ b/pyfixest/report/utils.py
@@ -71,7 +71,7 @@ def _rename_categorical(
         pattern = r"C\(([^,]+)(?:,[^]]+)?\)\[(?:T\.)?([^]]+)\]"
     else:
         pattern = r"([^[]+)\[(?:T\.)?([^]]+)\]"
-    
+
     # Replace labels with empty dictionary if not provided
     if labels is None:
         labels = {}

--- a/pyfixest/report/utils.py
+++ b/pyfixest/report/utils.py
@@ -36,7 +36,7 @@ def _relabel_expvar(
         # Check whether template for categorical variables is provided &
         # whether the variable is a categorical variable
         v = vars[i]
-        if cat_template != "" and ("C(" in v or "[T." in v):
+        if cat_template != "" and ("C(" in v or "[" in v):
             vars[i] = _rename_categorical(v, template=cat_template, labels=labels)
         else:
             vars[i] = labels.get(v, v)
@@ -68,9 +68,10 @@ def _rename_categorical(
     # Here two patterns are used to extract the variable and level
     # Note the second pattern matches the notation when the variable is categorical at the outset
     if col_name.startswith("C("):
-        pattern = r"C\(([^,]+)(?:,[^]]+)?\)\[T\.([^]]+)\]"
+        pattern = r"C\(([^,]+)(?:,[^]]+)?\)\[(?:T\.)?([^]]+)\]"
     else:
-        pattern = r"([^[]+)\[T\.([^]]+)\]"
+        pattern = r"([^[]+)\[(?:T\.)?([^]]+)\]"
+    
     # Replace labels with empty dictionary if not provided
     if labels is None:
         labels = {}

--- a/tests/test_others.py
+++ b/tests/test_others.py
@@ -138,6 +138,28 @@ def test_rename_categoricals():
         "C(f4, contr.treatment(base='A'))[T.C]": "f4::C",
     }
 
+    # without 'T.' in the categorical notation:
+    coefnames = [
+        "C(f4)[B]",
+        "C(f4)[C]",
+    ]
+    renamed = rename_categoricals(coefnames)
+    assert renamed == {
+        "C(f4)[B]": "f4::B",
+        "C(f4)[C]": "f4::C",
+    }
+
+    # without C() and no 'T.' notation
+    coefnames = [
+        "f4[B]",
+        "f4[C]",
+    ]
+    renamed = rename_categoricals(coefnames)
+    assert renamed == {
+        "f4[B]": "f4::B",
+        "f4[C]": "f4::C",
+    }
+
     # with categoricals:
     coefnames = ["Intercept", "variable1[T.value1]", "variable1[T.value2]"]
     renamed = rename_categoricals(coefnames)


### PR DESCRIPTION
Addresses #884. Simple fix by simply making 'T.' optional 
