### PR TITLE
update in labels: adding comment on the role of _coefname

### DIFF
--- a/pyfixest/report/summarize.py
+++ b/pyfixest/report/summarize.py
@@ -89,10 +89,10 @@ def etable(
         If True, the pattern will be matched exactly to the coefficient name
         instead of using regular expressions.
     labels: dict, optional
-        A dictionary to relabel the variables. The keys in this dictionary are the 
-        original variable names, which correspond to the names stored in the `_coefnames` 
-        attribute of the model. The values in the dictionary are the new names you want 
-        to assign to these variables. 
+        A dictionary to relabel the variables. The keys in this dictionary are the
+        original variable names, which correspond to the names stored in the `_coefnames`
+        attribute of the model. The values in the dictionary are the new names you want
+        to assign to these variables.
         Note that interaction terms will also be relabeled using the labels of the individual variables.
         The command is applied after the `keep` and `drop` commands.
     cat_template: str, optional

--- a/pyfixest/report/summarize.py
+++ b/pyfixest/report/summarize.py
@@ -89,9 +89,11 @@ def etable(
         If True, the pattern will be matched exactly to the coefficient name
         instead of using regular expressions.
     labels: dict, optional
-        A dictionary to relabel the variables. The keys are the original variable
-        names and the values the new names. Note that interaction terms will also be
-        relabeled using the labels of the individual variables.
+        A dictionary to relabel the variables. The keys in this dictionary are the 
+        original variable names, which correspond to the names stored in the `_coefname` 
+        attribute of the model. The values in the dictionary are the new names you want 
+        to assign to these variables. 
+        Note that interaction terms will also be relabeled using the labels of the individual variables.
         The command is applied after the `keep` and `drop` commands.
     cat_template: str, optional
         Template to relabel categorical variables. None by default, which applies no relabeling.

--- a/pyfixest/report/summarize.py
+++ b/pyfixest/report/summarize.py
@@ -90,7 +90,7 @@ def etable(
         instead of using regular expressions.
     labels: dict, optional
         A dictionary to relabel the variables. The keys in this dictionary are the 
-        original variable names, which correspond to the names stored in the `_coefname` 
+        original variable names, which correspond to the names stored in the `_coefnames` 
         attribute of the model. The values in the dictionary are the new names you want 
         to assign to these variables. 
         Note that interaction terms will also be relabeled using the labels of the individual variables.

--- a/pyfixest/report/visualize.py
+++ b/pyfixest/report/visualize.py
@@ -143,7 +143,8 @@ def iplot(
     rename_models : dict, optional
         A dictionary to rename the models. The keys are the original model names and the values the new names.
     labels: dict, optional
-        A dictionary to relabel the variables. The keys are the original variable names and the values the new names.
+        A dictionary to relabel the variables. The keys in this dictionary are the original variable names, which correspond to the names stored in the `_coefname` attribute of the model. The values in the dictionary are the new  names you want to assign to these variables.
+        Note that interaction terms will also be relabeled using the labels of the individual variables.
         The renaming is applied after the selection of the coefficients via `keep` and `drop`.
     joint: str or bool, optional
         Whether to plot simultaneous confidence bands for the coefficients. If True, simultaneous confidence bands
@@ -317,7 +318,8 @@ def coefplot(
     rename_models : dict, optional
         A dictionary to rename the models. The keys are the original model names and the values the new names.
     labels: dict, optional
-        A dictionary to relabel the variables. The keys are the original variable names and the values the new names.
+        A dictionary to relabel the variables. The keys in this dictionary are the original variable names, which correspond to the names stored in the `_coefname` attribute of the model. The values in the dictionary are the new  names you want to assign to these variables.
+        Note that interaction terms will also be relabeled using the labels of the individual variables.
         The renaming is applied after the selection of the coefficients via `keep` and `drop`.
     joint: str or bool, optional
         Whether to plot simultaneous confidence bands for the coefficients. If True, simultaneous confidence bands

--- a/pyfixest/report/visualize.py
+++ b/pyfixest/report/visualize.py
@@ -143,7 +143,7 @@ def iplot(
     rename_models : dict, optional
         A dictionary to rename the models. The keys are the original model names and the values the new names.
     labels: dict, optional
-        A dictionary to relabel the variables. The keys in this dictionary are the original variable names, which correspond to the names stored in the `_coefname` attribute of the model. The values in the dictionary are the new  names you want to assign to these variables.
+        A dictionary to relabel the variables. The keys in this dictionary are the original variable names, which correspond to the names stored in the `_coefnames` attribute of the model. The values in the dictionary are the new  names you want to assign to these variables.
         Note that interaction terms will also be relabeled using the labels of the individual variables.
         The renaming is applied after the selection of the coefficients via `keep` and `drop`.
     joint: str or bool, optional

--- a/pyfixest/report/visualize.py
+++ b/pyfixest/report/visualize.py
@@ -318,7 +318,7 @@ def coefplot(
     rename_models : dict, optional
         A dictionary to rename the models. The keys are the original model names and the values the new names.
     labels: dict, optional
-        A dictionary to relabel the variables. The keys in this dictionary are the original variable names, which correspond to the names stored in the `_coefname` attribute of the model. The values in the dictionary are the new  names you want to assign to these variables.
+        A dictionary to relabel the variables. The keys in this dictionary are the original variable names, which correspond to the names stored in the `_coefnames` attribute of the model. The values in the dictionary are the new  names you want to assign to these variables.
         Note that interaction terms will also be relabeled using the labels of the individual variables.
         The renaming is applied after the selection of the coefficients via `keep` and `drop`.
     joint: str or bool, optional


### PR DESCRIPTION
I modified the documentation on the three parts, as suggested by @s3alfisc 

- etable: [link](https://github.com/py-econometrics/pyfixest/blob/406bb3282eb61f892ba676c1a1d2ad6563bd1201/pyfixest/report/summarize.py#L24)
 - coefplot: [link](https://github.com/py-econometrics/pyfixest/blob/406bb3282eb61f892ba676c1a1d2ad6563bd1201/pyfixest/report/visualize.py#L256)
  - iplot: [link](https://github.com/py-econometrics/pyfixest/blob/406bb3282eb61f892ba676c1a1d2ad6563bd1201/pyfixest/report/visualize.py#L81)