### PR TITLE
#890 - Show how to replicate Stata results

### DIFF
--- a/docs/stata-2-pyfixest.qmd
+++ b/docs/stata-2-pyfixest.qmd
@@ -1,0 +1,226 @@
+---
+title: "Translating Stata to PyFixest"
+format:
+  html:
+    html-table-processing: none
+toc: true
+toc-title: "On this page"
+toc-location: left
+---
+
+# How to Get Started
+
+This guide will focus on how to replicate the regression results you would get in Stata
+with the Python package `pyfixest` and assumes you know how to do things like install 
+Python packages and load data into Pandas.  For a broader introduction to doing 
+econmetrics in Python you might check out Arthur Turrell's 
+[Coding for Economist](https://aeturrell.github.io/coding-for-economists/intro.html), 
+which includes a section on 
+[Coming from Stata](https://aeturrell.github.io/coding-for-economists/coming-from-stata.html), 
+or [Tidy Finance with Python](https://www.tidy-finance.org/python/) by Christopher 
+Scheuch, Stefan Voigt, Patrick Weiss, and Christoph Frey.
+
+# Data
+
+`pyfixest` includes a function to generate a dataset for testing.
+
+```{python}
+import pyfixest as pf
+df = pf.get_data()
+```
+
+If you want to use the same dataset in Stata, you can save the data to your home 
+directory as a .dta file with
+
+```{python}
+import os
+df.to_stata(os.path.join(os.path.expanduser("~"), "pyfixest-data.dta"))
+```
+
+and then load the data in Stata with
+
+```{stata}
+cd ~
+use pyfixest-data.dta
+```
+
+# Basic OLS
+
+To do a basic linear regression in `pyfixest` you would simply use
+
+```{python}
+fit1 = pf.feols("Y ~ X1", data = df)
+fit2 = pf.feols("Y ~ X1 + X2", data = df)
+```
+
+which is equivalent to 
+
+```{stata}
+reg Y X1
+reg y X1 X2
+```
+
+in Stata.  However, you should note that this will only run the regressions and store 
+the results in `fit1` and `fit2`.  To show the results you can use some of the following 
+methods and functions.
+
+```{python}
+fit1.summary() # Basic summary statistics
+fit1.tidy() # Estimates, std errors, t-values, etc. in a "tidy" table
+pf.report.etable([fit1, fit2]) # Customizable table that can include results for multiple models
+```
+
+You can also access individual parts of the results with a variety of methods like
+
+```{python}
+fit1.coef() # Get the coefficients
+fit1.se() # Get the standard errors
+fit1.pvalue() # Get the p-values
+```
+
+## Robust Standard Errors
+
+To get heteroskedasticity robust standard errors you can use
+
+```{python}
+fit3 = pf.feols("Y ~ X1 + X2", data=df, vcov="HC1")
+fit3.summary()
+```
+
+which is equivalent to
+
+```{stata}
+reg Y X1 X2, robust
+```
+
+or
+
+```{stata}
+reg Y X1 X2, vce(robust)
+```
+
+or you can choose a different type of robust standard errors like "HC3" using 
+
+```{python}
+fit4 = pf.feols("Y ~ X1 + X2", data=df, vcov="HC3")
+fit4.summary()
+```
+
+which is equivalent to 
+
+```{stata}
+reg Y X1 X2, vce(HC3)
+```
+
+## Clustered Standard Errors
+
+To cluster the standard errors by group you can use
+
+```{python}
+fit5 = pf.feols("Y ~ X1 + X2", data=df.dropna(subset=['f1']), vcov={"CRV1": "f1"})
+fit5.summary()
+```
+
+which is equivalent to 
+
+```{stata}
+reg Y X1 X2, vce(cluster f1)
+```
+
+Note: clustered standard errors are not supported with missing values in the cluster
+variable, which is why we drop the rows with missing values for `f1`.
+
+For two way clustering you would need to use
+
+```{python}
+fit6 = pf.feols(
+  "Y ~ X1 + X2", 
+  data=df.dropna(subset=['f1', 'f2']), 
+  vcov={"CRV1": "f1 + f2"}
+)
+fit6.summary()
+```
+
+Note: This will not exactly match the output of the equivalent Stata command, which is
+
+```{stata}
+reg Y X1 X2, vce(cluster f1 f2)
+```
+
+this is because by default, `pyfixest` uses a small sample size correction that adjusts
+each clustering dimentsion by whichever dimension has the smallest number of clusters, 
+while in Stata the default is to adjust each dimension based on the number of clusters
+in that dimension. You can use the same correction as Stata through the `ssc` argument.
+
+```{python}
+fit7 = pf.feols(
+  "Y ~ X1 + X2", 
+  df.dropna(subset=['f1', 'f2']), 
+  vcov={"CRV1": "f1 + f2"}, 
+  ssc=pf.ssc(cluster_df="conventional")
+)
+fit7.summary()
+```
+
+For an excellent breakdown on small sample correction in the `pyfixest` package, please
+see [On Small Sample Correction](https://py-econometrics.github.io/pyfixest/ssc.html).
+
+# Fixed Effect Regressions
+
+To do a fixed effect regression with one fixed effect you could use
+
+```{python}
+fit8 = pf.feols("Y ~ X1 + X2 | f1", data=df, vcov="iid")
+fit8.summary()
+```
+
+which is equivalent to 
+
+```{stata}
+xtset f1
+xtreg Y X1 X2, fe
+```
+
+or
+
+```{stata}
+reghdfe Y X1 X2, absorb(f1)
+```
+
+Note: You need to specify `vcov="iid`.  This is because the default for `fixest` is to 
+cluster standard errors based on the first fixed effect.  So
+
+```{python}
+fit9 = pf.feols("Y ~ X1 + X2 | f1", data=df)
+fit9.summary()
+```
+
+is equivalent to 
+
+```{stata}
+xtset f1
+xtreg Y X1 X2, fe vce(cluster f1)
+```
+
+or
+
+```{stata}
+reghdfe Y X1 X2, absorb(f1) cluster(f1)
+```
+
+For multiple fixed effects you could do
+
+```{python}
+fit10 = pf.feols("Y ~ X1 + X2 | f1 + f2", data=df)
+fit10.summary()
+```
+
+which is equivalent to 
+
+```{stata}
+reghdfe Y X1 X2, absorb(f1 f2) cluster(f1)
+```
+
+Note: By default `pyfixest` will stull cluster standard errors just by the first group
+specified.  You can change this using the `vcov` argument.  See the `fit7` example above 
+for how to specify two way clustering.


### PR DESCRIPTION
.qmd file showing how to replicate common Stata results in PyFixest.

Note: I ran each part in both Stata and PyFixest and got the same results everywhere except for `fit4` where I show how to get HC3 standard errors.  For some reason the HC3 errors in PyFixest and Stata do not match.  I haven't had a chance to try to figure out why though.

If you know why, let me know and I can update the example.  If not, I can try to figure it out at a later date.  In the meantime we can remove that section or add a note that the HC3 standard errors do not match.