### PR TITLE
Prevent Casting Dependent Variable to Integer to Avoid Information Loss in Poisson Regression

### DIFF
--- a/pyfixest/estimation/fepois_.py
+++ b/pyfixest/estimation/fepois_.py
@@ -140,8 +140,6 @@ class Fepois(Feols):
         "Prepare model inputs for estimation."
         super().prepare_model_matrix()
 
-        # check if Y is a weakly positive integer
-        self._Y = _to_integer(self._Y)
         # check that self._Y is a weakly positive integer
         if np.any(self._Y < 0):
             raise ValueError(

--- a/pyfixest/estimation/fepois_.py
+++ b/pyfixest/estimation/fepois_.py
@@ -13,7 +13,7 @@ from pyfixest.estimation.demean_ import demean
 from pyfixest.estimation.feols_ import Feols, PredictionErrorOptions, PredictionType
 from pyfixest.estimation.FormulaParser import FixestFormula
 from pyfixest.estimation.solvers import solve_ols
-from pyfixest.utils.dev_utils import DataFrameType, _to_integer
+from pyfixest.utils.dev_utils import DataFrameType, _check_series_or_dataframe
 
 
 class Fepois(Feols):
@@ -139,6 +139,9 @@ class Fepois(Feols):
     def prepare_model_matrix(self):
         "Prepare model inputs for estimation."
         super().prepare_model_matrix()
+
+        # check that self._Y is a pandas Series or DataFrame
+        self._Y = _check_series_or_dataframe(self._Y)
 
         # check that self._Y is a weakly positive integer
         if np.any(self._Y < 0):

--- a/pyfixest/utils/dev_utils.py
+++ b/pyfixest/utils/dev_utils.py
@@ -115,22 +115,9 @@ def docstring_from(func, custom_doc=""):
     return decorator
 
 
-def _to_integer(x: Union[pd.Series, pd.DataFrame]):
+def _check_series_or_dataframe(x: Union[pd.Series, pd.DataFrame]):
     if not isinstance(x, (pd.Series, pd.DataFrame)):
         raise TypeError("Input must be a pandas Series or DataFrame")
-
-    if pd.api.types.is_integer_dtype(x):
-        return x
-
-    try:
-        x = x.astype("int64")
-    except ValueError as e:
-        raise ValueError(
-            """
-            Conversion of the dependent variable to integer is not possible.
-            Please do so manually.
-            """
-        ) from e
     else:
         return x
 


### PR DESCRIPTION
This pull request removes the line of code in `fepois_.py` that converts the dependent variable Y to an integer. Poisson regression can be applied to any non-negative outcomes, and there is no need to limit its use to non-negative integer outcomes by converting float Y values into integers. 

This makes the results more consistent with the `Fixest `package in R, where it does not perform this conversion either.

Additionally, it might be nice to add a non-negative non-integer generated dependant variable in the `get_data()` function in `utils.py`. This would demonstrate the versatility of Poisson regression beyond integer-only outcomes and provide users with a broader perspective on its application. 