### PR TITLE
Reorganize Tests against R

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -46,7 +46,7 @@ jobs:
         run: |
           R_LIB_PATH="${{ github.workspace }}/.pixi/envs/dev/lib/R/library"
           mkdir -p $R_LIB_PATH
-          Rscript -e ".libPaths('$R_LIB_PATH'); install.packages(c('did2s', 'wildrwolf', 'ivDiag', 'car'),  lib='/home/runner/work/pyfixest/pyfixest/.pixi/envs/dev/lib/R/library', repos = c('https://cran.rstudio.com', 'https://s3alfisc.r-universe.dev'))"
+          Rscript -e ".libPaths('$R_LIB_PATH'); install.packages(c('did2s', 'wildrwolf', 'ivDiag'),  lib='/home/runner/work/pyfixest/pyfixest/.pixi/envs/dev/lib/R/library', repos = c('https://cran.rstudio.com', 'https://s3alfisc.r-universe.dev'))"
           Rscript -e ".libPaths('$R_LIB_PATH'); install.packages('ritest', lib='/home/runner/work/pyfixest/pyfixest/.pixi/envs/dev/lib/R/library', repos = c('https://grantmcdermott.r-universe.dev'))"
       - name: Run 'regular' tests
         run: |
@@ -94,7 +94,7 @@ jobs:
         run: |
           R_LIB_PATH="${{ github.workspace }}/.pixi/envs/dev/lib/R/library"
           mkdir -p $R_LIB_PATH
-          Rscript -e ".libPaths('$R_LIB_PATH'); install.packages(c('did2s', 'wildrwolf', 'ivDiag', 'car'),  lib='/home/runner/work/pyfixest/pyfixest/.pixi/envs/dev/lib/R/library', repos = c('https://cran.rstudio.com', 'https://s3alfisc.r-universe.dev'))"
+          Rscript -e ".libPaths('$R_LIB_PATH'); install.packages(c('did2s', 'wildrwolf', 'ivDiag'),  lib='/home/runner/work/pyfixest/pyfixest/.pixi/envs/dev/lib/R/library', repos = c('https://cran.rstudio.com', 'https://s3alfisc.r-universe.dev'))"
           Rscript -e ".libPaths('$R_LIB_PATH'); install.packages('ritest', lib='/home/runner/work/pyfixest/pyfixest/.pixi/envs/dev/lib/R/library', repos = c('https://grantmcdermott.r-universe.dev'))"
       - name: Run tests against r
         run: |

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -46,7 +46,7 @@ jobs:
         run: |
           R_LIB_PATH="${{ github.workspace }}/.pixi/envs/dev/lib/R/library"
           mkdir -p $R_LIB_PATH
-          Rscript -e ".libPaths('$R_LIB_PATH'); install.packages(c('fixest', 'broom','did2s', 'wildrwolf', 'ivDiag', 'car'),  lib='/home/runner/work/pyfixest/pyfixest/.pixi/envs/dev/lib/R/library')"
+          Rscript -e ".libPaths('$R_LIB_PATH'); install.packages(c('did2s', 'wildrwolf', 'ivDiag', 'car'),  lib='/home/runner/work/pyfixest/pyfixest/.pixi/envs/dev/lib/R/library', repos = c('https://cran.rstudio.com', 'https://s3alfisc.r-universe.dev'))"
           Rscript -e ".libPaths('$R_LIB_PATH'); install.packages('ritest', lib='/home/runner/work/pyfixest/pyfixest/.pixi/envs/dev/lib/R/library', repos = c('https://grantmcdermott.r-universe.dev'))"
       - name: Run 'regular' tests
         run: |
@@ -94,11 +94,12 @@ jobs:
         run: |
           R_LIB_PATH="${{ github.workspace }}/.pixi/envs/dev/lib/R/library"
           mkdir -p $R_LIB_PATH
-          Rscript -e ".libPaths('$R_LIB_PATH'); install.packages(c('fixest', 'broom','did2s', 'wildrwolf', 'ivDiag', 'car'),  lib='/home/runner/work/pyfixest/pyfixest/.pixi/envs/dev/lib/R/library')"
+          Rscript -e ".libPaths('$R_LIB_PATH'); install.packages(c('did2s', 'wildrwolf', 'ivDiag', 'car'),  lib='/home/runner/work/pyfixest/pyfixest/.pixi/envs/dev/lib/R/library', repos = c('https://cran.rstudio.com', 'https://s3alfisc.r-universe.dev'))"
           Rscript -e ".libPaths('$R_LIB_PATH'); install.packages('ritest', lib='/home/runner/work/pyfixest/pyfixest/.pixi/envs/dev/lib/R/library', repos = c('https://grantmcdermott.r-universe.dev'))"
       - name: Run tests against r
         run: |
-          pixi run tests-against-r
+          pixi run tests-against-r-core
+          pixi run tests-against-r-extended
 
       - name: Upload coverage to Codecov (partial)
         uses: codecov/codecov-action@v4

--- a/.github/workflows/extended_tests.yaml
+++ b/.github/workflows/extended_tests.yaml
@@ -44,7 +44,7 @@ jobs:
         run: |
           R_LIB_PATH="${{ github.workspace }}/.pixi/envs/dev/lib/R/library"
           mkdir -p $R_LIB_PATH
-          Rscript -e ".libPaths('$R_LIB_PATH'); install.packages(c('did2s', 'wildrwolf', 'ivDiag', 'car'),  lib='/home/runner/work/pyfixest/pyfixest/.pixi/envs/dev/lib/R/library', repos = c('https://cran.rstudio.com', 'https://s3alfisc.r-universe.dev'))"
+          Rscript -e ".libPaths('$R_LIB_PATH'); install.packages(c('did2s', 'wildrwolf', 'ivDiag'),  lib='/home/runner/work/pyfixest/pyfixest/.pixi/envs/dev/lib/R/library', repos = c('https://cran.rstudio.com', 'https://s3alfisc.r-universe.dev'))"
           Rscript -e ".libPaths('$R_LIB_PATH'); install.packages('ritest', lib='/home/runner/work/pyfixest/pyfixest/.pixi/envs/dev/lib/R/library', repos = c('https://grantmcdermott.r-universe.dev'))"
       - name: Run long tests with coverage
         run: pixi run tests-extended

--- a/.github/workflows/extended_tests.yaml
+++ b/.github/workflows/extended_tests.yaml
@@ -44,10 +44,10 @@ jobs:
         run: |
           R_LIB_PATH="${{ github.workspace }}/.pixi/envs/dev/lib/R/library"
           mkdir -p $R_LIB_PATH
-          Rscript -e ".libPaths('$R_LIB_PATH'); install.packages(c('fixest', 'broom','did2s', 'wildrwolf', 'ivDiag', 'car'),  lib='/home/runner/work/pyfixest/pyfixest/.pixi/envs/dev/lib/R/library')"
+          Rscript -e ".libPaths('$R_LIB_PATH'); install.packages(c('did2s', 'wildrwolf', 'ivDiag', 'car'),  lib='/home/runner/work/pyfixest/pyfixest/.pixi/envs/dev/lib/R/library', repos = c('https://cran.rstudio.com', 'https://s3alfisc.r-universe.dev'))"
           Rscript -e ".libPaths('$R_LIB_PATH'); install.packages('ritest', lib='/home/runner/work/pyfixest/pyfixest/.pixi/envs/dev/lib/R/library', repos = c('https://grantmcdermott.r-universe.dev'))"
       - name: Run long tests with coverage
-        run: pixi r tests-extended
+        run: pixi run tests-extended
 
       - name: Upload coverage to Codecov (partial)
         uses: codecov/codecov-action@v4

--- a/docs/contributing.qmd
+++ b/docs/contributing.qmd
@@ -90,7 +90,7 @@ pixi run lint
 
 and you're ready to go! After installation, the task will run all linting rules via `ruff`.
 
-We’ve included other tasks to help with testing. Almost all the necessary dependencies to run tests are included in the dev environment, 
+We’ve included other tasks to help with testing. Almost all the necessary dependencies to run tests are included in the dev environment,
 except for R packages unavailable through conda-forge.
 ```{.bash .code-copy}
 # attempt to install non-conda R dependencies
@@ -135,8 +135,8 @@ winget install -e --id Python.Python.3.11
 
 ### Installing R
 
-Note that R and R dependencies available through conda-forge are installed by pixi to the local project if you use the dev environment. 
-Some extra R dependencies may require additional development tools not included in the environment, for example: 
+Note that R and R dependencies available through conda-forge are installed by pixi to the local project if you use the dev environment.
+Some extra R dependencies may require additional development tools not included in the environment, for example:
 
 Depending on your local set up, you may need to install additional libraries to compile those extra dependencies, like a version of `gcc` and `cmake`.
 

--- a/docs/contributing.qmd
+++ b/docs/contributing.qmd
@@ -90,14 +90,17 @@ pixi run lint
 
 and you're ready to go! After installation, the task will run all linting rules via `ruff`.
 
-We’ve included other tasks to help install the necessary R packages for running unit tests or to run different sets of tests:
+We’ve included other tasks to help with testing. Almost all the necessary dependencies to run tests are included in the dev environment, 
+except for R packages unavailable through conda-forge.
 ```{.bash .code-copy}
-# install all R development dependencies
-pixi run install-r
+# attempt to install non-conda R dependencies
+pixi run install-r-extended
 # run all tests via pytest
 pixi run tests
-# run all tests excluding very computationally demanding tests
+# run all tests excluding very computationally demanding tests or R-based tests
 pixi run tests-regular
+# run all tests that depend on the extra R dependencies
+pixi run tests-against-r-extended
 # rerun failed tests
 pixi run tests-rerun
 ```
@@ -132,26 +135,10 @@ winget install -e --id Python.Python.3.11
 
 ### Installing R
 
-Note that installing R and the R packages listed below is only necessary if you want to test against R in your local installation.
-You can also test against R by using github actions.
+Note that R and R dependencies available through conda-forge are installed by pixi to the local project if you use the dev environment. 
+Some extra R dependencies may require additional development tools not included in the environment, for example: 
 
-On Mac/Linux:
-```{.bash .code-copy}
-brew install r
-```
-
-Depending on your local set up, you may need to install additional libraries, for
-example:
-
-```{.bash .code-copy}
-sudo apt install gcc-11 cmake
-```
-
-On Windows using [Winget](https://winget.run/pkg/RProject/R):
-
-```{.bash .code-copy}
-winget install -e --id RProject.R
-```
+Depending on your local set up, you may need to install additional libraries to compile those extra dependencies, like a version of `gcc` and `cmake`.
 
 ### Installing Quarto
 

--- a/pixi.lock
+++ b/pixi.lock
@@ -541,7 +541,66 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.8-h9e4cc4f_1_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.12-5_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-4.3-r43hd8ed1ab_1008.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/r-backports-1.5.0-r43hb1dbf0f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/r-base-4.3.3-h5074ccb_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-boot-1.3_31-r43hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-broom-1.0.7-r43hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/r-class-7.3_23-r43h2b5f3a1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/r-cli-3.6.3-r43h0d4f4ea_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/r-cluster-2.1.8.1-r43hb67ce94_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-codetools-0.2_20-r43hc72bb7e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/r-colorspace-2.1_1-r43hdb488b9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-crayon-1.5.3-r43hc72bb7e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/r-dplyr-1.1.4-r43h0d4f4ea_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-dreamerr-1.4.0-r43hc72bb7e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/r-ellipsis-0.3.2-r43hb1dbf0f_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/r-fansi-1.0.6-r43hb1dbf0f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/r-farver-2.1.2-r43ha18555a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/r-fixest-0.12.1-r43h0d4f4ea_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/r-foreign-0.8_90-r43h2b5f3a1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-formula-1.2_5-r43hc72bb7e_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-generics-0.1.3-r43hc72bb7e_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-ggplot2-3.5.1-r43hc72bb7e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/r-glue-1.8.0-r43h2b5f3a1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-gtable-0.3.6-r43hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/r-isoband-0.2.7-r43ha18555a_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/r-kernsmooth-2.23_26-r43h8461fee_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-labeling-0.4.3-r43hc72bb7e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/r-lattice-0.22_6-r43hb1dbf0f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-lifecycle-1.0.4-r43hc72bb7e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/r-magrittr-2.0.3-r43hb1dbf0f_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/r-mass-7.3_60.0.1-r43hb1dbf0f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/r-matrix-1.6_5-r43he966344_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/r-mgcv-1.9_1-r43h0d28552_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-munsell-0.5.1-r43hc72bb7e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/r-nlme-3.1_165-r43hbcb9c34_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/r-nnet-7.3_20-r43h2b5f3a1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-numderiv-2016.8_1.1-r43hc72bb7e_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-pillar-1.10.1-r43hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-pkgconfig-2.0.3-r43hc72bb7e_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/r-purrr-1.0.2-r43hdb488b9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-r6-2.5.1-r43hc72bb7e_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-rcolorbrewer-1.1_3-r43h785f33e_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/r-rcpp-1.0.14-r43h93ab643_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-recommended-4.3-r43hd8ed1ab_1007.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/r-rlang-1.1.5-r43h93ab643_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/r-rpart-4.1.24-r43h2b5f3a1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-sandwich-3.1_1-r43hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-scales-1.3.0-r43hc72bb7e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/r-spatial-7.3_18-r43h2b5f3a1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/r-stringi-1.8.4-r43h33cde33_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/r-stringmagic-1.1.2-r43h0d4f4ea_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-stringr-1.5.1-r43h785f33e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/r-survival-3.8_3-r43h2b5f3a1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/r-tibble-3.2.1-r43hdb488b9_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/r-tidyr-1.3.1-r43h0d4f4ea_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-tidyselect-1.2.1-r43hc72bb7e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/r-utf8-1.2.4-r43hb1dbf0f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/r-vctrs-0.6.5-r43h0d4f4ea_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-viridislite-0.4.2-r43hc72bb7e_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-withr-3.0.2-r43hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/r-zoo-1.8_12-r43hb1dbf0f_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rpy2-3.5.11-py312r43hc7c0aa3_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sed-4.8-he412f7d_0.tar.bz2
@@ -739,7 +798,66 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.12.8-h9ccd52b_1_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.12-5_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-4.3-r43hd8ed1ab_1008.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/r-backports-1.5.0-r43h6b9d099_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/r-base-4.3.3-h11f04cc_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-boot-1.3_31-r43hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-broom-1.0.7-r43hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/r-class-7.3_23-r43h79f565e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/r-cli-3.6.3-r43h25d921d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/r-cluster-2.1.8.1-r43hb3c2f18_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-codetools-0.2_20-r43hc72bb7e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/r-colorspace-2.1_1-r43h6b9d099_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-crayon-1.5.3-r43hc72bb7e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/r-dplyr-1.1.4-r43h25d921d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-dreamerr-1.4.0-r43hc72bb7e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/r-ellipsis-0.3.2-r43h6b9d099_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/r-fansi-1.0.6-r43h6b9d099_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/r-farver-2.1.2-r43h25d921d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/r-fixest-0.12.1-r43hccab667_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/r-foreign-0.8_90-r43h79f565e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-formula-1.2_5-r43hc72bb7e_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-generics-0.1.3-r43hc72bb7e_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-ggplot2-3.5.1-r43hc72bb7e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/r-glue-1.8.0-r43h199b6f9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-gtable-0.3.6-r43hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/r-isoband-0.2.7-r43h25d921d_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/r-kernsmooth-2.23_26-r43hd6847f7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-labeling-0.4.3-r43hc72bb7e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/r-lattice-0.22_6-r43h6b9d099_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-lifecycle-1.0.4-r43hc72bb7e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/r-magrittr-2.0.3-r43h6b9d099_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/r-mass-7.3_60.0.1-r43h6b9d099_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/r-matrix-1.6_5-r43h9cf22e7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/r-mgcv-1.9_1-r43h374a70c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-munsell-0.5.1-r43hc72bb7e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/r-nlme-3.1_165-r43h9612530_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/r-nnet-7.3_20-r43h79f565e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-numderiv-2016.8_1.1-r43hc72bb7e_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-pillar-1.10.1-r43hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-pkgconfig-2.0.3-r43hc72bb7e_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/r-purrr-1.0.2-r43h6b9d099_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-r6-2.5.1-r43hc72bb7e_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-rcolorbrewer-1.1_3-r43h785f33e_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/r-rcpp-1.0.14-r43h2711daa_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-recommended-4.3-r43hd8ed1ab_1007.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/r-rlang-1.1.5-r43h2711daa_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/r-rpart-4.1.24-r43h79f565e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-sandwich-3.1_1-r43hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-scales-1.3.0-r43hc72bb7e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/r-spatial-7.3_18-r43h79f565e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/r-stringi-1.8.4-r43hf60abff_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/r-stringmagic-1.1.2-r43h25d921d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-stringr-1.5.1-r43h785f33e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/r-survival-3.8_3-r43h79f565e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/r-tibble-3.2.1-r43h6b9d099_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/r-tidyr-1.3.1-r43h25d921d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-tidyselect-1.2.1-r43hc72bb7e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/r-utf8-1.2.4-r43h6b9d099_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/r-vctrs-0.6.5-r43h25d921d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-viridislite-0.4.2-r43hc72bb7e_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-withr-3.0.2-r43hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/r-zoo-1.8_12-r43h6b9d099_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/readline-8.2-h9e318b2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/rpy2-3.5.11-py312r43h5d6a8aa_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/sigtool-0.1.3-h88f4db0_0.tar.bz2
@@ -931,7 +1049,66 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.8-hc22306f_1_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.12-5_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-4.3-r43hd8ed1ab_1008.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-backports-1.5.0-r43h07cda29_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-base-4.3.3-h527b63a_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-boot-1.3_31-r43hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-broom-1.0.7-r43hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-class-7.3_23-r43h570997c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-cli-3.6.3-r43hd76f289_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-cluster-2.1.8.1-r43he0ea626_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-codetools-0.2_20-r43hc72bb7e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-colorspace-2.1_1-r43h07cda29_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-crayon-1.5.3-r43hc72bb7e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-dplyr-1.1.4-r43hd76f289_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-dreamerr-1.4.0-r43hc72bb7e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-ellipsis-0.3.2-r43h07cda29_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-fansi-1.0.6-r43h07cda29_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-farver-2.1.2-r43hd76f289_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-fixest-0.12.1-r43h173a3d2_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-foreign-0.8_90-r43h570997c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-formula-1.2_5-r43hc72bb7e_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-generics-0.1.3-r43hc72bb7e_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-ggplot2-3.5.1-r43hc72bb7e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-glue-1.8.0-r43h0d9a900_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-gtable-0.3.6-r43hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-isoband-0.2.7-r43hd76f289_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-kernsmooth-2.23_26-r43h2c658ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-labeling-0.4.3-r43hc72bb7e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-lattice-0.22_6-r43h07cda29_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-lifecycle-1.0.4-r43hc72bb7e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-magrittr-2.0.3-r43h07cda29_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-mass-7.3_60.0.1-r43h07cda29_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-matrix-1.6_5-r43hded8dfa_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-mgcv-1.9_1-r43h83b88f1_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-munsell-0.5.1-r43hc72bb7e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-nlme-3.1_165-r43h7807725_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-nnet-7.3_20-r43h570997c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-numderiv-2016.8_1.1-r43hc72bb7e_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-pillar-1.10.1-r43hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-pkgconfig-2.0.3-r43hc72bb7e_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-purrr-1.0.2-r43h07cda29_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-r6-2.5.1-r43hc72bb7e_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-rcolorbrewer-1.1_3-r43h785f33e_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-rcpp-1.0.14-r43h31118f2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-recommended-4.3-r43hd8ed1ab_1007.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-rlang-1.1.5-r43h31118f2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-rpart-4.1.24-r43h570997c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-sandwich-3.1_1-r43hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-scales-1.3.0-r43hc72bb7e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-spatial-7.3_18-r43h570997c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-stringi-1.8.4-r43h428a9ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-stringmagic-1.1.2-r43hd76f289_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-stringr-1.5.1-r43h785f33e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-survival-3.8_3-r43h570997c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-tibble-3.2.1-r43h07cda29_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-tidyr-1.3.1-r43hd76f289_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-tidyselect-1.2.1-r43hc72bb7e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-utf8-1.2.4-r43h07cda29_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-vctrs-0.6.5-r43hd76f289_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-viridislite-0.4.2-r43hc72bb7e_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-withr-3.0.2-r43hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-zoo-1.8_12-r43h07cda29_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h92ec313_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rpy2-3.5.11-py312r43h3339331_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sigtool-0.1.3-h44b9a77_0.tar.bz2
@@ -1063,6 +1240,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-gettext-0.19.7-2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-gmp-6.1.0-2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-gsl-2.1-2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-icu-58.2-2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-libiconv-1.14-6.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-libjpeg-turbo-1.4.2-3.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-libogg-1.3.2-3.tar.bz2
@@ -1093,7 +1271,66 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2025.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.12-5_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-4.1-r41hd8ed1ab_1006.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-backports-1.5.0-r41h6c66454_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/r-base-4.1.3-h22dd5fe_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-boot-1.3_28.1-r41hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-broom-1.0.5-r41hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-class-7.3_22-r41h6d2157b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-cli-3.6.3-r41he75b88d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-cluster-2.1.6-r41he816bda_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-codetools-0.2_19-r41hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-colorspace-2.1_0-r41h6d2157b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-crayon-1.5.2-r41hc72bb7e_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-dplyr-1.1.4-r41ha856d6a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-dreamerr-1.4.0-r41hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-ellipsis-0.3.2-r41h6d2157b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-fansi-1.0.6-r41h6d2157b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-farver-2.1.2-r41he75b88d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-fixest-0.12.1-r41he75b88d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-foreign-0.8_87-r41h6c66454_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-formula-1.2_5-r41hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-generics-0.1.3-r41hc72bb7e_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-ggplot2-3.4.2-r41hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-glue-1.7.0-r41h6d2157b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-gtable-0.3.3-r41hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-isoband-0.2.7-r41ha856d6a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-kernsmooth-2.23_24-r41h5d8b4f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-labeling-0.4.2-r41hc72bb7e_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-lattice-0.22_6-r41h6d2157b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-lifecycle-1.0.3-r41hc72bb7e_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-magrittr-2.0.3-r41h6d2157b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-mass-7.3_58.3-r41h6d2157b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-matrix-1.6_5-r41hb9981e2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-mgcv-1.9_1-r41hb9981e2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-munsell-0.5.0-r41hc72bb7e_1005.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-nlme-3.1_165-r41hd63c432_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-nnet-7.3_19-r41h6d2157b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-numderiv-2016.8_1.1-r41hc72bb7e_4.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-pillar-1.9.0-r41hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-pkgconfig-2.0.3-r41hc72bb7e_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-purrr-1.0.2-r41h6d2157b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-r6-2.5.1-r41hc72bb7e_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-rcolorbrewer-1.1_3-r41h785f33e_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-rcpp-1.0.12-r41ha856d6a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-recommended-4.1-r41hd8ed1ab_1005.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-rlang-1.1.4-r41he75b88d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-rpart-4.1.23-r41h6d2157b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-sandwich-3.0_2-r41hc72bb7e_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-scales-1.2.1-r41hc72bb7e_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-spatial-7.3_17-r41h6d2157b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-stringi-1.8.4-r41h3f0a074_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-stringmagic-1.1.2-r41h3f0a074_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-stringr-1.5.0-r41h785f33e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-survival-3.7_0-r41h245b76f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-tibble-3.2.1-r41h6d2157b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-tidyr-1.3.1-r41ha856d6a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-tidyselect-1.2.0-r41h6addd8b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-utf8-1.2.4-r41h6d2157b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-vctrs-0.6.5-r41ha856d6a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-viridislite-0.4.1-r41hc72bb7e_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-withr-2.5.0-r41hc72bb7e_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-zoo-1.8_12-r41h6d2157b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/rpy2-3.5.11-py312r41hd0f9d78_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/simplegeneric-0.8.1-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.13.0-h62715c5_1.conda
@@ -1282,10 +1519,15 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.8-h9e4cc4f_1_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.12-5_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-4.3-r43hd8ed1ab_1008.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/r-backports-1.5.0-r43hb1dbf0f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/r-base-4.3.3-h5074ccb_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-boot-1.3_31-r43hc72bb7e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-broom-1.0.7-r43hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/r-class-7.3_23-r43h2b5f3a1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/r-cli-3.6.3-r43h0d4f4ea_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/r-cluster-2.1.8.1-r43hb67ce94_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-codetools-0.2_20-r43hc72bb7e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/r-colorspace-2.1_1-r43hdb488b9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-crayon-1.5.3-r43hc72bb7e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/r-dplyr-1.1.4-r43h0d4f4ea_1.conda
@@ -1294,12 +1536,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/r-fansi-1.0.6-r43hb1dbf0f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/r-farver-2.1.2-r43ha18555a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/r-fixest-0.12.1-r43h0d4f4ea_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/r-foreign-0.8_90-r43h2b5f3a1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-formula-1.2_5-r43hc72bb7e_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-generics-0.1.3-r43hc72bb7e_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-ggplot2-3.5.1-r43hc72bb7e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/r-glue-1.8.0-r43h2b5f3a1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-gtable-0.3.6-r43hc72bb7e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/r-isoband-0.2.7-r43ha18555a_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/r-kernsmooth-2.23_26-r43h8461fee_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-labeling-0.4.3-r43hc72bb7e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/r-lattice-0.22_6-r43hb1dbf0f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-lifecycle-1.0.4-r43hc72bb7e_1.conda
@@ -1309,6 +1553,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/r-mgcv-1.9_1-r43h0d28552_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-munsell-0.5.1-r43hc72bb7e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/r-nlme-3.1_165-r43hbcb9c34_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/r-nnet-7.3_20-r43h2b5f3a1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-numderiv-2016.8_1.1-r43hc72bb7e_6.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-pillar-1.10.1-r43hc72bb7e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-pkgconfig-2.0.3-r43hc72bb7e_4.conda
@@ -1316,12 +1561,16 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-r6-2.5.1-r43hc72bb7e_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-rcolorbrewer-1.1_3-r43h785f33e_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/r-rcpp-1.0.14-r43h93ab643_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-recommended-4.3-r43hd8ed1ab_1007.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/r-rlang-1.1.5-r43h93ab643_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/r-rpart-4.1.24-r43h2b5f3a1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-sandwich-3.1_1-r43hc72bb7e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-scales-1.3.0-r43hc72bb7e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/r-spatial-7.3_18-r43h2b5f3a1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/r-stringi-1.8.4-r43h33cde33_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/r-stringmagic-1.1.2-r43h0d4f4ea_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-stringr-1.5.1-r43h785f33e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/r-survival-3.8_3-r43h2b5f3a1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/r-tibble-3.2.1-r43hdb488b9_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/r-tidyr-1.3.1-r43h0d4f4ea_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-tidyselect-1.2.1-r43hc72bb7e_1.conda
@@ -1591,10 +1840,15 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.12.8-h9ccd52b_1_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.12-5_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-4.3-r43hd8ed1ab_1008.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/r-backports-1.5.0-r43h6b9d099_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/r-base-4.3.3-h11f04cc_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-boot-1.3_31-r43hc72bb7e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-broom-1.0.7-r43hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/r-class-7.3_23-r43h79f565e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/r-cli-3.6.3-r43h25d921d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/r-cluster-2.1.8.1-r43hb3c2f18_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-codetools-0.2_20-r43hc72bb7e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/r-colorspace-2.1_1-r43h6b9d099_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-crayon-1.5.3-r43hc72bb7e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/r-dplyr-1.1.4-r43h25d921d_1.conda
@@ -1603,12 +1857,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/r-fansi-1.0.6-r43h6b9d099_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/r-farver-2.1.2-r43h25d921d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/r-fixest-0.12.1-r43hccab667_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/r-foreign-0.8_90-r43h79f565e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-formula-1.2_5-r43hc72bb7e_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-generics-0.1.3-r43hc72bb7e_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-ggplot2-3.5.1-r43hc72bb7e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/r-glue-1.8.0-r43h199b6f9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-gtable-0.3.6-r43hc72bb7e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/r-isoband-0.2.7-r43h25d921d_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/r-kernsmooth-2.23_26-r43hd6847f7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-labeling-0.4.3-r43hc72bb7e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/r-lattice-0.22_6-r43h6b9d099_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-lifecycle-1.0.4-r43hc72bb7e_1.conda
@@ -1618,6 +1874,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/r-mgcv-1.9_1-r43h374a70c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-munsell-0.5.1-r43hc72bb7e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/r-nlme-3.1_165-r43h9612530_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/r-nnet-7.3_20-r43h79f565e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-numderiv-2016.8_1.1-r43hc72bb7e_6.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-pillar-1.10.1-r43hc72bb7e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-pkgconfig-2.0.3-r43hc72bb7e_4.conda
@@ -1625,12 +1882,16 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-r6-2.5.1-r43hc72bb7e_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-rcolorbrewer-1.1_3-r43h785f33e_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/r-rcpp-1.0.14-r43h2711daa_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-recommended-4.3-r43hd8ed1ab_1007.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/r-rlang-1.1.5-r43h2711daa_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/r-rpart-4.1.24-r43h79f565e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-sandwich-3.1_1-r43hc72bb7e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-scales-1.3.0-r43hc72bb7e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/r-spatial-7.3_18-r43h79f565e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/r-stringi-1.8.4-r43hf60abff_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/r-stringmagic-1.1.2-r43h25d921d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-stringr-1.5.1-r43h785f33e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/r-survival-3.8_3-r43h79f565e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/r-tibble-3.2.1-r43h6b9d099_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/r-tidyr-1.3.1-r43h25d921d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-tidyselect-1.2.1-r43hc72bb7e_1.conda
@@ -1894,10 +2155,15 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.8-hc22306f_1_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.12-5_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-4.3-r43hd8ed1ab_1008.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-backports-1.5.0-r43h07cda29_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-base-4.3.3-h527b63a_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-boot-1.3_31-r43hc72bb7e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-broom-1.0.7-r43hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-class-7.3_23-r43h570997c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-cli-3.6.3-r43hd76f289_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-cluster-2.1.8.1-r43he0ea626_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-codetools-0.2_20-r43hc72bb7e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-colorspace-2.1_1-r43h07cda29_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-crayon-1.5.3-r43hc72bb7e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-dplyr-1.1.4-r43hd76f289_1.conda
@@ -1906,12 +2172,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-fansi-1.0.6-r43h07cda29_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-farver-2.1.2-r43hd76f289_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-fixest-0.12.1-r43h173a3d2_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-foreign-0.8_90-r43h570997c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-formula-1.2_5-r43hc72bb7e_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-generics-0.1.3-r43hc72bb7e_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-ggplot2-3.5.1-r43hc72bb7e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-glue-1.8.0-r43h0d9a900_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-gtable-0.3.6-r43hc72bb7e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-isoband-0.2.7-r43hd76f289_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-kernsmooth-2.23_26-r43h2c658ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-labeling-0.4.3-r43hc72bb7e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-lattice-0.22_6-r43h07cda29_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-lifecycle-1.0.4-r43hc72bb7e_1.conda
@@ -1921,6 +2189,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-mgcv-1.9_1-r43h83b88f1_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-munsell-0.5.1-r43hc72bb7e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-nlme-3.1_165-r43h7807725_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-nnet-7.3_20-r43h570997c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-numderiv-2016.8_1.1-r43hc72bb7e_6.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-pillar-1.10.1-r43hc72bb7e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-pkgconfig-2.0.3-r43hc72bb7e_4.conda
@@ -1928,12 +2197,16 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-r6-2.5.1-r43hc72bb7e_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-rcolorbrewer-1.1_3-r43h785f33e_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-rcpp-1.0.14-r43h31118f2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-recommended-4.3-r43hd8ed1ab_1007.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-rlang-1.1.5-r43h31118f2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-rpart-4.1.24-r43h570997c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-sandwich-3.1_1-r43hc72bb7e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-scales-1.3.0-r43hc72bb7e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-spatial-7.3_18-r43h570997c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-stringi-1.8.4-r43h428a9ab_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-stringmagic-1.1.2-r43hd76f289_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-stringr-1.5.1-r43h785f33e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-survival-3.8_3-r43h570997c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-tibble-3.2.1-r43h07cda29_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-tidyr-1.3.1-r43hd76f289_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-tidyselect-1.2.1-r43hc72bb7e_1.conda
@@ -2167,10 +2440,15 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2025.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.12-5_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-4.1-r41hd8ed1ab_1006.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/r-backports-1.5.0-r41h6c66454_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/r-base-4.1.3-h22dd5fe_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-boot-1.3_28.1-r41hc72bb7e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-broom-1.0.5-r41hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-class-7.3_22-r41h6d2157b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/r-cli-3.6.3-r41he75b88d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-cluster-2.1.6-r41he816bda_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-codetools-0.2_19-r41hc72bb7e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/r-colorspace-2.1_0-r41h6d2157b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-crayon-1.5.2-r41hc72bb7e_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/r-dplyr-1.1.4-r41ha856d6a_0.conda
@@ -2179,12 +2457,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/r-fansi-1.0.6-r41h6d2157b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/r-farver-2.1.2-r41he75b88d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/r-fixest-0.12.1-r41he75b88d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-foreign-0.8_87-r41h6c66454_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-formula-1.2_5-r41hc72bb7e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-generics-0.1.3-r41hc72bb7e_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-ggplot2-3.4.2-r41hc72bb7e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/r-glue-1.7.0-r41h6d2157b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-gtable-0.3.3-r41hc72bb7e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/r-isoband-0.2.7-r41ha856d6a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-kernsmooth-2.23_24-r41h5d8b4f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-labeling-0.4.2-r41hc72bb7e_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/r-lattice-0.22_6-r41h6d2157b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-lifecycle-1.0.3-r41hc72bb7e_1.tar.bz2
@@ -2194,6 +2474,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/r-mgcv-1.9_1-r41hb9981e2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-munsell-0.5.0-r41hc72bb7e_1005.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/r-nlme-3.1_165-r41hd63c432_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-nnet-7.3_19-r41h6d2157b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-numderiv-2016.8_1.1-r41hc72bb7e_4.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-pillar-1.9.0-r41hc72bb7e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-pkgconfig-2.0.3-r41hc72bb7e_2.tar.bz2
@@ -2201,12 +2482,16 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-r6-2.5.1-r41hc72bb7e_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-rcolorbrewer-1.1_3-r41h785f33e_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/r-rcpp-1.0.12-r41ha856d6a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-recommended-4.1-r41hd8ed1ab_1005.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/r-rlang-1.1.4-r41he75b88d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-rpart-4.1.23-r41h6d2157b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-sandwich-3.0_2-r41hc72bb7e_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-scales-1.2.1-r41hc72bb7e_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-spatial-7.3_17-r41h6d2157b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/r-stringi-1.8.4-r41h3f0a074_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/r-stringmagic-1.1.2-r41h3f0a074_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-stringr-1.5.0-r41h785f33e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-survival-3.7_0-r41h245b76f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/r-tibble-3.2.1-r41h6d2157b_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/r-tidyr-1.3.1-r41ha856d6a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/r-tidyselect-1.2.0-r41h6addd8b_1.conda
@@ -9350,7 +9635,7 @@ packages:
 - pypi: .
   name: pyfixest
   version: 0.29.0
-  sha256: 9f9a4bee7e8f518ad77517955cdd47f619169975b133b3a7a51fdc920faf4dd5
+  sha256: 9e689c605bb5d7716a55d28dba9466e794eb8c66e5f1f6f658294ef3c6ea5eab
   requires_dist:
   - scipy>=1.6
   - formulaic>=1.1.0
@@ -9809,6 +10094,28 @@ packages:
   - syrupy ; extra == 'dev'
   - pre-commit ; extra == 'dev'
   requires_python: '>=3.9'
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-4.1-r41hd8ed1ab_1006.tar.bz2
+  sha256: da8c269a64c6d96e748e2b4014e84555f2f0676b800e632b13bc7422b68641c7
+  md5: 58ea4f356004f861a004f67e6c8beadb
+  depends:
+  - r-base >=4.1,<4.2.0a0
+  - r-recommended
+  license: GPL-3.0-only
+  license_family: GPL3
+  purls: []
+  size: 15902
+  timestamp: 1665621529082
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-4.3-r43hd8ed1ab_1008.conda
+  sha256: 08801b3fb5dac8a2e2dd3b0ee852703f2abadeaa62f51764e6cd5f948782fc2b
+  md5: 38ba77cf4c98a16550a61b415597a524
+  depends:
+  - r-base >=4.3,<4.4.0a0
+  - r-recommended
+  license: GPL-3.0-only
+  license_family: GPL3
+  purls: []
+  size: 17981
+  timestamp: 1722424618353
 - conda: https://conda.anaconda.org/conda-forge/linux-64/r-backports-1.5.0-r43hb1dbf0f_1.conda
   sha256: 1956bb988860b03d6b8d8a103a001af8b3e09f22c2f8417b5f23ee0f78891e15
   md5: 12431f6441e6e7b9181747123e88fe9e
@@ -10028,6 +10335,26 @@ packages:
   purls: []
   size: 56103327
   timestamp: 1734517537925
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-boot-1.3_28.1-r41hc72bb7e_0.conda
+  sha256: 0f85cde3a6a1dd13571681d701df75ad454fba91178b76f9f65ed0b4747b4011
+  md5: b2133512f437cb9b595e96fe76498e72
+  depends:
+  - r-base >=4.1,<4.2.0a0
+  license: Unlimited
+  license_family: MIT
+  purls: []
+  size: 626793
+  timestamp: 1669281500754
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-boot-1.3_31-r43hc72bb7e_0.conda
+  sha256: 630a7b2632cd69989de100375864e7a0a7605777bca663f8b8c7b3e9149404d9
+  md5: 3e3d3d9d6d06cd74b5574b01c7e65f1f
+  depends:
+  - r-base >=4.3,<4.4.0a0
+  license: Unlimited
+  license_family: Other
+  purls: []
+  size: 627950
+  timestamp: 1724870915770
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-broom-1.0.5-r41hc72bb7e_0.conda
   sha256: 48839189d1f17a8e12c74cd71999f82b4a459b33bb3545c56d038fdbcd08ad4c
   md5: d5d83f565f9b296447c82634b2a7f31d
@@ -10070,6 +10397,64 @@ packages:
   purls: []
   size: 1799810
   timestamp: 1727408326218
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-class-7.3_23-r43h2b5f3a1_0.conda
+  sha256: da6ad00ad49a2d24e0a382ff50add0ee176bd0ee02f2c943180b56c5afd14749
+  md5: f5a6207da238d9d499f2a3e0a7f84c8c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - r-base >=4.3,<4.4.0a0
+  - r-mass
+  arch: x86_64
+  platform: linux
+  license: GPL-2.0-or-later
+  license_family: GPL3
+  purls: []
+  size: 106860
+  timestamp: 1735734370275
+- conda: https://conda.anaconda.org/conda-forge/osx-64/r-class-7.3_23-r43h79f565e_0.conda
+  sha256: 5c9d857f2749f25decd019dcac8f8d3526d20b50dc8f9f0f4904f29414d70b48
+  md5: 4506bf30d832a746904260bf272a8476
+  depends:
+  - __osx >=10.13
+  - r-base >=4.3,<4.4.0a0
+  - r-mass
+  arch: x86_64
+  platform: osx
+  license: GPL-2.0-or-later
+  license_family: GPL3
+  purls: []
+  size: 107830
+  timestamp: 1735734507248
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-class-7.3_23-r43h570997c_0.conda
+  sha256: c623af53eef122ff5470e7f9cdc39163299419a397fb030cca4be306de191241
+  md5: 5c9989de6ee81afa5859f0d27cfb7cdb
+  depends:
+  - __osx >=11.0
+  - r-base >=4.3,<4.4.0a0
+  - r-mass
+  arch: arm64
+  platform: osx
+  license: GPL-2.0-or-later
+  license_family: GPL3
+  purls: []
+  size: 106172
+  timestamp: 1735734575470
+- conda: https://conda.anaconda.org/conda-forge/win-64/r-class-7.3_22-r41h6d2157b_1.conda
+  sha256: 72110a4a83f93581c3397426fea998343312c01d6f43db0bf1dc09dd36b15ef3
+  md5: a6909c9f544fcdbf5606f63842f012cc
+  depends:
+  - m2w64-gcc-libs
+  - m2w64-gcc-libs-core
+  - r-base >=4.1,<4.2.0a0
+  - r-mass
+  arch: x86_64
+  platform: win
+  license: GPL-2.0-or-later
+  license_family: GPL3
+  purls: []
+  size: 109723
+  timestamp: 1686765205726
 - conda: https://conda.anaconda.org/conda-forge/linux-64/r-cli-3.6.3-r43h0d4f4ea_1.conda
   sha256: bb244929c280e365cb1a0600c65dc243dcf7f9965a3df2d11774b5bc9941e6fc
   md5: ba1f08e0eab53429d77026adb68960a5
@@ -10119,6 +10504,86 @@ packages:
   purls: []
   size: 1256562
   timestamp: 1719055677971
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-cluster-2.1.8.1-r43hb67ce94_0.conda
+  sha256: 28b7379df902101a9626cd6d29628705f47988d4737ea7b185d10d9c0d476954
+  md5: 7e4d0cf4e3378df9847f3843b9a8e087
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libgfortran
+  - libgfortran5 >=13.3.0
+  - r-base >=4.3,<4.4.0a0
+  arch: x86_64
+  platform: linux
+  license: GPL-2.0-or-later
+  license_family: GPL3
+  purls: []
+  size: 575030
+  timestamp: 1742027889570
+- conda: https://conda.anaconda.org/conda-forge/osx-64/r-cluster-2.1.8.1-r43hb3c2f18_0.conda
+  sha256: bda14bf085fa4dfb98169bef36464a5c89bf5fbdf2f1002285d792a63dcfddde
+  md5: e46d7d30e516da91f79247592a05945c
+  depends:
+  - __osx >=10.13
+  - libgfortran 5.*
+  - libgfortran5 >=13.2.0
+  - r-base >=4.3,<4.4.0a0
+  arch: x86_64
+  platform: osx
+  license: GPL-2.0-or-later
+  license_family: GPL3
+  purls: []
+  size: 576136
+  timestamp: 1742028012436
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-cluster-2.1.8.1-r43he0ea626_0.conda
+  sha256: 36dd5ef861b8461a3065f1d73213e6765234c2693f16b947615fa5de65d754bd
+  md5: 64c1f89e8b4b59ac09f4d932b15abd97
+  depends:
+  - __osx >=11.0
+  - libgfortran 5.*
+  - libgfortran5 >=13.2.0
+  - r-base >=4.3,<4.4.0a0
+  arch: arm64
+  platform: osx
+  license: GPL-2.0-or-later
+  license_family: GPL3
+  purls: []
+  size: 567088
+  timestamp: 1742028163137
+- conda: https://conda.anaconda.org/conda-forge/win-64/r-cluster-2.1.6-r41he816bda_0.conda
+  sha256: 3fd2efad199bf850223e2f28462f7f5d676cb5def2234fc14dddacdf845590b3
+  md5: 4f6c0c330f35bf46105863b8ad673fe8
+  depends:
+  - m2w64-gcc-libs
+  - m2w64-gcc-libs-core
+  - r-base >=4.1,<4.2.0a0
+  arch: x86_64
+  platform: win
+  license: GPL-2.0-or-later
+  license_family: GPL3
+  purls: []
+  size: 574220
+  timestamp: 1701475472556
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-codetools-0.2_19-r41hc72bb7e_0.conda
+  sha256: 96aa7f1f7651ebc6c3349064574714a39115f97965aac9f6a4598d4065ff51b1
+  md5: 401ac0ee6310d69deac481b2d2148458
+  depends:
+  - r-base >=4.1,<4.2.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  purls: []
+  size: 108219
+  timestamp: 1675282332126
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-codetools-0.2_20-r43hc72bb7e_1.conda
+  sha256: 28b7c45b169e969a4074762f0a8a0587ac8810a40eff142f905d25bd843233b3
+  md5: f54a935134de901af63096b29a56697e
+  depends:
+  - r-base >=4.3,<4.4.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  purls: []
+  size: 108510
+  timestamp: 1719730978881
 - conda: https://conda.anaconda.org/conda-forge/linux-64/r-colorspace-2.1_1-r43hdb488b9_0.conda
   sha256: c1efd34c7e63f21f6cf615ecae5a2c07b8bd19006aae2904922fa3a0870178d7
   md5: 0c6d4c26ca41246a4053d79e1b4d78ff
@@ -10520,6 +10985,60 @@ packages:
   purls: []
   size: 3274531
   timestamp: 1718281652437
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-foreign-0.8_90-r43h2b5f3a1_0.conda
+  sha256: 9ca1c3cc5aeb2afc2326cb5f11ef0ab402d125104aee87b9cd0849b9c8375530
+  md5: 7ff7a440b0920a402edf83ddfa47ed7d
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - r-base >=4.3,<4.4.0a0
+  arch: x86_64
+  platform: linux
+  license: GPL-2.0-or-later
+  license_family: GPL2
+  purls: []
+  size: 267098
+  timestamp: 1743427611403
+- conda: https://conda.anaconda.org/conda-forge/osx-64/r-foreign-0.8_90-r43h79f565e_0.conda
+  sha256: a12aed962b2f0e14267a5ee20446700353f25dd9c6586971a099d7dba326a9f7
+  md5: 8668f9b542078915fd03dac8b100ba7b
+  depends:
+  - __osx >=10.13
+  - r-base >=4.3,<4.4.0a0
+  arch: x86_64
+  platform: osx
+  license: GPL-2.0-or-later
+  license_family: GPL2
+  purls: []
+  size: 263106
+  timestamp: 1743427639858
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-foreign-0.8_90-r43h570997c_0.conda
+  sha256: 149271214d43805f75cef943f69742d7445b9c5c85ce8e619f12dd5996e8a257
+  md5: a48a9f2f930ee7a18bb51f87dcaac3cc
+  depends:
+  - __osx >=11.0
+  - r-base >=4.3,<4.4.0a0
+  arch: arm64
+  platform: osx
+  license: GPL-2.0-or-later
+  license_family: GPL2
+  purls: []
+  size: 261386
+  timestamp: 1743427799200
+- conda: https://conda.anaconda.org/conda-forge/win-64/r-foreign-0.8_87-r41h6c66454_0.conda
+  sha256: 8d1535dcfef05a11c1c72945e64bde5ef36629578763bfdccfeedee349655eab
+  md5: 663dc0dc7495b45f2bed3bcc14ec4e08
+  depends:
+  - m2w64-gcc-libs
+  - m2w64-gcc-libs-core
+  - r-base >=4.1,<4.2.0a0
+  arch: x86_64
+  platform: win
+  license: GPL-2.0-or-later
+  license_family: GPL2
+  purls: []
+  size: 267282
+  timestamp: 1719411032603
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-formula-1.2_5-r41hc72bb7e_0.conda
   sha256: 5bd1cbf75c5c7802d5b32989d84e57a5da22d9e1fe4b35beb5e268ee536bda91
   md5: 81a77677dbc51bcb442ba9246dd84dee
@@ -10726,6 +11245,70 @@ packages:
   purls: []
   size: 1633084
   timestamp: 1686754054063
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-kernsmooth-2.23_26-r43h8461fee_0.conda
+  sha256: 20c119febcb77c48b00c17d5579da1a4106233406be6afb4e99afadfa36eda06
+  md5: b2d302f924fbb35cd56c909842f32163
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libblas >=3.9.0,<4.0a0
+  - libgcc >=13
+  - libgfortran
+  - libgfortran5 >=13.3.0
+  - r-base >=4.3,<4.4.0a0
+  arch: x86_64
+  platform: linux
+  license: Unlimited
+  license_family: MIT
+  purls: []
+  size: 100477
+  timestamp: 1735749275107
+- conda: https://conda.anaconda.org/conda-forge/osx-64/r-kernsmooth-2.23_26-r43hd6847f7_0.conda
+  sha256: a9c4c08259bd9afdf921aa9301af8d9f3c7b2217a69f5b8206b521e0c0e1ac7d
+  md5: be7d5a8b6a182bb5ba4a7f3a1fc07c6c
+  depends:
+  - __osx >=10.13
+  - libblas >=3.9.0,<4.0a0
+  - libgfortran 5.*
+  - libgfortran5 >=13.2.0
+  - r-base >=4.3,<4.4.0a0
+  arch: x86_64
+  platform: osx
+  license: Unlimited
+  license_family: MIT
+  purls: []
+  size: 98469
+  timestamp: 1735749333724
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-kernsmooth-2.23_26-r43h2c658ed_0.conda
+  sha256: 8f877373d6a052dd7c3ce0b3a682c402dfcc87ad3d66cb449fa69a050a699bf3
+  md5: 7e1b284235496923919081da66a23fc5
+  depends:
+  - __osx >=11.0
+  - libblas >=3.9.0,<4.0a0
+  - libgfortran 5.*
+  - libgfortran5 >=13.2.0
+  - r-base >=4.3,<4.4.0a0
+  arch: arm64
+  platform: osx
+  license: Unlimited
+  license_family: MIT
+  purls: []
+  size: 99044
+  timestamp: 1735749347272
+- conda: https://conda.anaconda.org/conda-forge/win-64/r-kernsmooth-2.23_24-r41h5d8b4f3_0.conda
+  sha256: 7e6d2c8cd2f063e277ae193a06b826d7a9a0d79b5e61142a93f83102486099a6
+  md5: d7d99e870df56ed61f36f2d0d757fb02
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - m2w64-gcc-libs
+  - m2w64-gcc-libs-core
+  - r-base >=4.1,<4.2.0a0
+  arch: x86_64
+  platform: win
+  license: Unlimited
+  license_family: MIT
+  purls: []
+  size: 103376
+  timestamp: 1715957249544
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-labeling-0.4.2-r41hc72bb7e_2.tar.bz2
   sha256: 0e68851a87aece39fe9cf6bc1bd659bf05b6eae1f1dd7e123b6645e0b459c0f1
   md5: 83807ad3d6daa0c5e88ad3f4e8df4758
@@ -11108,6 +11691,64 @@ packages:
   purls: []
   size: 2274213
   timestamp: 1717908793877
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-nnet-7.3_20-r43h2b5f3a1_0.conda
+  sha256: fa3c1e52c32c989d8fe0c64a72f248cf329ab705a3737bb2f3f271a62616089f
+  md5: c58e4fcb2f1e30872bbf3e11bdced351
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - r-base >=4.3,<4.4.0a0
+  - r-mass
+  arch: x86_64
+  platform: linux
+  license: GPL-2.0-or-later
+  license_family: GPL3
+  purls: []
+  size: 131322
+  timestamp: 1735754799939
+- conda: https://conda.anaconda.org/conda-forge/osx-64/r-nnet-7.3_20-r43h79f565e_0.conda
+  sha256: 2fdc8b31a731d2a5a0567b4a01b88d720b518e07a1308e60c706c32c496a952e
+  md5: edf1430c2fac76cc2a9b2d04574b3eae
+  depends:
+  - __osx >=10.13
+  - r-base >=4.3,<4.4.0a0
+  - r-mass
+  arch: x86_64
+  platform: osx
+  license: GPL-2.0-or-later
+  license_family: GPL3
+  purls: []
+  size: 132336
+  timestamp: 1735754880483
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-nnet-7.3_20-r43h570997c_0.conda
+  sha256: 8b23badc0b65665a6d4bb64fc52e93f45b1b60c4292a23ad5ab78be88dcc78d9
+  md5: 6f67af7704fd027bf52ba83fb695447d
+  depends:
+  - __osx >=11.0
+  - r-base >=4.3,<4.4.0a0
+  - r-mass
+  arch: arm64
+  platform: osx
+  license: GPL-2.0-or-later
+  license_family: GPL3
+  purls: []
+  size: 130625
+  timestamp: 1735754907096
+- conda: https://conda.anaconda.org/conda-forge/win-64/r-nnet-7.3_19-r41h6d2157b_1.conda
+  sha256: 8b99dcd59d0eb7dc7abf2ea014c00a87e2f686882610f5d6e2af71949f07c128
+  md5: 3a60afd8c545fd3485d070ffb5e64de5
+  depends:
+  - m2w64-gcc-libs
+  - m2w64-gcc-libs-core
+  - r-base >=4.1,<4.2.0a0
+  - r-mass
+  arch: x86_64
+  platform: win
+  license: GPL-2.0-or-later
+  license_family: GPL3
+  purls: []
+  size: 134603
+  timestamp: 1686765878883
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-numderiv-2016.8_1.1-r41hc72bb7e_4.tar.bz2
   sha256: 9311a2f788932515f79f4a44296a93fb47abcd00c51526313988f968aca49eae
   md5: 03509dfcd8e88d8b1c9939a4fff0b50b
@@ -11339,6 +11980,56 @@ packages:
   purls: []
   size: 1978060
   timestamp: 1704797173468
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-recommended-4.1-r41hd8ed1ab_1005.tar.bz2
+  sha256: 1f4595f3c43d26a80796371fd67ec469e39186ba9117386c4c7fd3f6ca1288af
+  md5: ee9c21634725576901145a899b519f05
+  depends:
+  - r-base >=4.1,<4.2.0a0
+  - r-boot
+  - r-class
+  - r-cluster
+  - r-codetools
+  - r-foreign
+  - r-kernsmooth
+  - r-lattice
+  - r-mass
+  - r-matrix
+  - r-mgcv
+  - r-nlme
+  - r-nnet
+  - r-rpart
+  - r-spatial
+  - r-survival
+  license: GPL-3.0-or-later
+  license_family: GPL
+  purls: []
+  size: 15892
+  timestamp: 1665528824384
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-recommended-4.3-r43hd8ed1ab_1007.conda
+  sha256: 4f0d76416f62c3268ff5abbe048ec1fef415bf6c03cda2e0e43d3041d8b03c7e
+  md5: 155476b8e32f752569a111dd3032c3ee
+  depends:
+  - r-base >=4.3,<4.4.0a0
+  - r-boot
+  - r-class
+  - r-cluster
+  - r-codetools
+  - r-foreign
+  - r-kernsmooth
+  - r-lattice
+  - r-mass
+  - r-matrix
+  - r-mgcv
+  - r-nlme
+  - r-nnet
+  - r-rpart
+  - r-spatial
+  - r-survival
+  license: GPL-3.0-or-later
+  license_family: GPL
+  purls: []
+  size: 18027
+  timestamp: 1722411963859
 - conda: https://conda.anaconda.org/conda-forge/linux-64/r-rlang-1.1.5-r43h93ab643_0.conda
   sha256: 9c725e3e033d27729973a1bc35b7341f8902631b3dc76d9d3adb1c14660751b7
   md5: 8c1a8d3063031b4d795a8a43fcc2ee3c
@@ -11388,6 +12079,60 @@ packages:
   purls: []
   size: 1542637
   timestamp: 1717507318700
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-rpart-4.1.24-r43h2b5f3a1_0.conda
+  sha256: 47aa5c0e8469147607b0b50a01c17dd01929fcf42d08e7f4534882dec63091dc
+  md5: f350255d8dfffecfc079a7e3f79a2db2
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - r-base >=4.3,<4.4.0a0
+  arch: x86_64
+  platform: linux
+  license: GPL-2.0-or-later
+  license_family: GPL3
+  purls: []
+  size: 700897
+  timestamp: 1736242441730
+- conda: https://conda.anaconda.org/conda-forge/osx-64/r-rpart-4.1.24-r43h79f565e_0.conda
+  sha256: f37e524b48a241d74826c2ce60bb96945585072029536da2a1dbd9aa6501383c
+  md5: 7e0104dbf9cd89b9706ff83496880841
+  depends:
+  - __osx >=10.13
+  - r-base >=4.3,<4.4.0a0
+  arch: x86_64
+  platform: osx
+  license: GPL-2.0-or-later
+  license_family: GPL3
+  purls: []
+  size: 700502
+  timestamp: 1736242603346
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-rpart-4.1.24-r43h570997c_0.conda
+  sha256: 2ca70eef90b73d839243a6ffcfb4fc98bf41111037cf51d3da33ae8f7fee9da3
+  md5: 9f566d82aa65dc7252fa08ac2aaebbf7
+  depends:
+  - __osx >=11.0
+  - r-base >=4.3,<4.4.0a0
+  arch: arm64
+  platform: osx
+  license: GPL-2.0-or-later
+  license_family: GPL3
+  purls: []
+  size: 695333
+  timestamp: 1736242729388
+- conda: https://conda.anaconda.org/conda-forge/win-64/r-rpart-4.1.23-r41h6d2157b_0.conda
+  sha256: 533db0eec64a68e9cbd952bb1ac105f163c1b21e24d74cc528678c972e3ac86e
+  md5: a0fd5872fcb10e46da89167e527e5309
+  depends:
+  - m2w64-gcc-libs
+  - m2w64-gcc-libs-core
+  - r-base >=4.1,<4.2.0a0
+  arch: x86_64
+  platform: win
+  license: GPL-2.0-or-later
+  license_family: GPL3
+  purls: []
+  size: 701212
+  timestamp: 1701826919990
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-sandwich-3.0_2-r41hc72bb7e_1.tar.bz2
   sha256: bedf767006b5093a724b0dbaaf231d59d823bc25cce19f6f21553756f0d6305d
   md5: dc9c7055f096ae0432607548e11003e0
@@ -11444,6 +12189,60 @@ packages:
   purls: []
   size: 657227
   timestamp: 1721190112402
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-spatial-7.3_18-r43h2b5f3a1_0.conda
+  sha256: 6e562bd973181c95c7d95bb748d95fc0cd471bd9f8a800b7a840b44be807caba
+  md5: c7e699fe0b6df04ce8ebf71705c676ea
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - r-base >=4.3,<4.4.0a0
+  arch: x86_64
+  platform: linux
+  license: GPL-2.0-or-later
+  license_family: GPL3
+  purls: []
+  size: 153221
+  timestamp: 1735775944694
+- conda: https://conda.anaconda.org/conda-forge/osx-64/r-spatial-7.3_18-r43h79f565e_0.conda
+  sha256: 904d5d4c21f8f46a79a218084c2ec3758a33edf8a7b020b3eaf9fb1b1785100c
+  md5: 51cd9c6f28d28635b6ebf75f35c5b544
+  depends:
+  - __osx >=10.13
+  - r-base >=4.3,<4.4.0a0
+  arch: x86_64
+  platform: osx
+  license: GPL-2.0-or-later
+  license_family: GPL3
+  purls: []
+  size: 153639
+  timestamp: 1735776095016
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-spatial-7.3_18-r43h570997c_0.conda
+  sha256: 3f6f3f76afd743a81312108b6fb182adb59a6b206a7b1b37f978f747cc2f22e3
+  md5: 8a02c97ae26fbe0587ee409219c974f5
+  depends:
+  - __osx >=11.0
+  - r-base >=4.3,<4.4.0a0
+  arch: arm64
+  platform: osx
+  license: GPL-2.0-or-later
+  license_family: GPL3
+  purls: []
+  size: 152428
+  timestamp: 1735776108869
+- conda: https://conda.anaconda.org/conda-forge/win-64/r-spatial-7.3_17-r41h6d2157b_0.conda
+  sha256: f9a1d94e0bc364749a99275d11719f179ab8e7edfa6555b3d0946dca5ccccbc5
+  md5: 796486eb2597f2c7327006c6cd4ae083
+  depends:
+  - m2w64-gcc-libs
+  - m2w64-gcc-libs-core
+  - r-base >=4.1,<4.2.0a0
+  arch: x86_64
+  platform: win
+  license: GPL-2.0-or-later
+  license_family: GPL3
+  purls: []
+  size: 157155
+  timestamp: 1689908821867
 - conda: https://conda.anaconda.org/conda-forge/linux-64/r-stringi-1.8.4-r43h33cde33_3.conda
   sha256: 613fddb570c4f74ff1ba06006fe1da67ed0b162a737e93bfe67fdb5c174eb68a
   md5: 827bd9c9e7a678acee9c6a2d5b0586a6
@@ -11590,6 +12389,67 @@ packages:
   purls: []
   size: 295942
   timestamp: 1721222784194
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-survival-3.8_3-r43h2b5f3a1_0.conda
+  sha256: e06c607398fa5a44a84fe700d79f0bf3eea3b79875d96b2c56f88a592e60a079
+  md5: e0310ee9becb6ac350695e7e8c42c2e9
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - r-base >=4.3,<4.4.0a0
+  - r-matrix
+  arch: x86_64
+  platform: linux
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  purls: []
+  size: 8287460
+  timestamp: 1734545495873
+- conda: https://conda.anaconda.org/conda-forge/osx-64/r-survival-3.8_3-r43h79f565e_0.conda
+  sha256: fd6f0980365bde409fdf71c361af2d0aa1ef6eb3b012ba4a161bca38998d7e56
+  md5: 4efdad6a1df616150e78b1256915e1ed
+  depends:
+  - __osx >=10.13
+  - r-base >=4.3,<4.4.0a0
+  - r-matrix
+  arch: x86_64
+  platform: osx
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  purls: []
+  size: 8292214
+  timestamp: 1734545560967
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-survival-3.8_3-r43h570997c_0.conda
+  sha256: f163a6ec82c5d6001752ff55ca781c44fa7b57f00aee59521086f83e19fde7c3
+  md5: de2f94c0df112fc80cf331f4870c4ec8
+  depends:
+  - __osx >=11.0
+  - r-base >=4.3,<4.4.0a0
+  - r-matrix
+  arch: arm64
+  platform: osx
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  purls: []
+  size: 8252005
+  timestamp: 1734545770905
+- conda: https://conda.anaconda.org/conda-forge/win-64/r-survival-3.7_0-r41h245b76f_0.conda
+  sha256: 7044679d4a37dabe33d350eff76fe0a560523f654a0a7da02eff09fbc9f46921
+  md5: 936fed59eafa099e3879fc69b5bf4ea6
+  depends:
+  - m2w64-gcc-libs
+  - m2w64-gcc-libs-core
+  - r-base >=4.1,<4.2.0a0
+  - r-matrix
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.38.33135
+  arch: x86_64
+  platform: win
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  purls: []
+  size: 6314052
+  timestamp: 1717657370442
 - conda: https://conda.anaconda.org/conda-forge/linux-64/r-tibble-3.2.1-r43hdb488b9_3.conda
   sha256: add63c6a08182f6a4e1ba93d7fe54aab7a7a661d679b42d19af30f195b1b11a3
   md5: 3e78c6ee2205ef56c165cbf2c166fdf6

--- a/pixi.lock
+++ b/pixi.lock
@@ -14,23 +14,32 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.6.1-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.43-h712a8e2_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-26_linux64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-26_linux64_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.6.4-h5888daf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-14.2.0-h77fa898_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-14.2.0-h69a702a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-14.2.0-h69a702a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-14.2.0-hd5240d6_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-14.2.0-h77fa898_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-26_linux64_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.6.3-hb9d3cd8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.28-pthreads_h94d23a6_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.48.0-hee588c1_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-14.2.0-hc0a3c3a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.2.6-py312h72c5963_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.4.0-h7b32b05_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyproject_hooks-1.2.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.8-h9e4cc4f_1_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-build-1.2.2.post1-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.12-5_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
@@ -54,8 +63,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/cb/da/8341fd3056419441286c8e26bf436923021005ece0bff5f41906476ae514/llvmlite-0.44.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/a7/b2/d872fc3d753516870d520595ddd8ce4dd44fa797a240999f125f58521ad7/matplotlib-3.10.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/38/13/23b73a1f300521613f967763ef4ada4737474f9d5b620b7e5ba9e4857ee7/narwhals-1.23.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/18/74/6a9f0e6c76c088f8a6aa702eab31734068061dca5cc0f34e8bc1eb447de1/numba-0.61.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/9e/3e/3757f304c704f2f0294a6b8340fcf2be244038be07da4cccf390fa678a9f/numpy-2.1.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/9a/2d/e518df036feab381c23a624dac47f8445ac55686ec7f11083655eb707da3/numba-0.61.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/38/f8/d8fddee9ed0d0c0f4a2132c1dfcf0e3e53265055da8df952a53e7eaf178c/pandas-2.2.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/38/0d/84200ed6a871ce386ddc82904bfadc0c6b28b0c0ec78176871a4679e40b3/pillow-11.1.0-cp312-cp312-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/1c/a7/c8a2d361bf89c0d9577c934ebb7421b25dc84bf3a8e3ac0a40aed9acc547/pyparsing-3.2.1-py3-none-any.whl
@@ -68,23 +76,33 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0f/dd/84f10e23edd882c6f968c21c2434fe67bd4a528967067515feca9e611e5e/tzdata-2025.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2a/5a/04cde32b07a7431d4ed0553a76fdb7a61270e78c5fd5a603e190ac389f14/wrapt-1.17.2-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-      - pypi: .
+      - pypi: ./
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-hfdf4475_7.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2024.12.14-h8857fd0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.6.1-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.9.0-26_osx64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.9.0-26_osx64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-19.1.7-hf95d169_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.6.4-h240833e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.4.2-h0d85af4_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-5.0.0-13_2_0_h97931a8_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-13.2.0-h2873a65_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.9.0-26_osx64_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/liblzma-5.6.3-hd471939_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.28-openmp_hbf64a52_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.48.0-hdb6dae5_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.1-hd23fc13_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-19.1.7-ha54dae1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.5-h0622a9a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-2.2.6-py312h6693b03_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.4.0-hc426f3f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyproject_hooks-1.2.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.12.8-h9ccd52b_1_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-build-1.2.2.post1-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.12-5_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/readline-8.2-h9e318b2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h1abcd95_1.conda
@@ -108,8 +126,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/15/86/e3c3195b92e6e492458f16d233e58a1a812aa2bfbef9bdd0fbafcec85c60/llvmlite-0.44.0-cp312-cp312-macosx_10_14_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/44/c7/6b2d8cb7cc251d53c976799cacd3200add56351c175ba89ab9cbd7c1e68a/matplotlib-3.10.0-cp312-cp312-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/38/13/23b73a1f300521613f967763ef4ada4737474f9d5b620b7e5ba9e4857ee7/narwhals-1.23.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/63/c9/c61881e7f2e253e745209f078bbd428ce23b6cf901f7d93afe166720ff95/numba-0.61.0-cp312-cp312-macosx_10_14_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/8a/f0/385eb9970309643cbca4fc6eebc8bb16e560de129c91258dfaa18498da8b/numpy-2.1.3-cp312-cp312-macosx_10_13_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/b4/a0/c6b7b9c615cfa3b98c4c63f4316e3f6b3bbe2387740277006551784218cd/numba-0.61.2-cp312-cp312-macosx_10_14_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/17/a3/fb2734118db0af37ea7433f57f722c0a56687e14b14690edff0cdb4b7e58/pandas-2.2.3-cp312-cp312-macosx_10_9_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/95/20/9ce6ed62c91c073fcaa23d216e68289e19d95fb8188b9fb7a63d36771db8/pillow-11.1.0-cp312-cp312-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/1c/a7/c8a2d361bf89c0d9577c934ebb7421b25dc84bf3a8e3ac0a40aed9acc547/pyparsing-3.2.1-py3-none-any.whl
@@ -122,23 +139,33 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0f/dd/84f10e23edd882c6f968c21c2434fe67bd4a528967067515feca9e611e5e/tzdata-2025.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/53/18/75ddc64c3f63988f5a1d7e10fb204ffe5762bc663f8023f18ecaf31a332e/wrapt-1.17.2-cp312-cp312-macosx_10_13_x86_64.whl
-      - pypi: .
+      - pypi: ./
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h99b78c6_7.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2024.12.14-hf0a4a13_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.6.1-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-26_osxarm64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-26_osxarm64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-19.1.7-ha82da77_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.6.4-h286801f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.2-h3422bc3_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-5.0.0-13_2_0_hd922786_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-13.2.0-hf226fd6_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-26_osxarm64_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.6.3-h39f12f2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.28-openmp_hf332438_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.48.0-h3f77e49_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-19.1.7-hdb05f8b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h5e97a16_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.2.6-py312h7c1f314_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.4.0-h81ee809_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyproject_hooks-1.2.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.8-hc22306f_1_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-build-1.2.2.post1-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.12-5_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h92ec313_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h5083fa2_1.conda
@@ -162,8 +189,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/d6/53/373b6b8be67b9221d12b24125fd0ec56b1078b660eeae266ec388a6ac9a0/llvmlite-0.44.0-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/42/2a/6d66d0fba41e13e9ca6512a0a51170f43e7e7ed3a8dfa036324100775612/matplotlib-3.10.0-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/38/13/23b73a1f300521613f967763ef4ada4737474f9d5b620b7e5ba9e4857ee7/narwhals-1.23.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/e1/28/ddec0147a4933f86ceaca580aa9bb767d5632ecdb1ece6cfb3eab4ac78e5/numba-0.61.0-cp312-cp312-macosx_11_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/54/4a/765b4607f0fecbb239638d610d04ec0a0ded9b4951c56dc68cef79026abf/numpy-2.1.3-cp312-cp312-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/92/4a/fe4e3c2ecad72d88f5f8cd04e7f7cff49e718398a2fac02d2947480a00ca/numba-0.61.2-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/e1/0c/ad295fd74bfac85358fd579e271cded3ac969de81f62dd0142c426b9da91/pandas-2.2.3-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/b9/d8/f6004d98579a2596c098d1e30d10b248798cceff82d2b77aa914875bfea1/pillow-11.1.0-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/1c/a7/c8a2d361bf89c0d9577c934ebb7421b25dc84bf3a8e3ac0a40aed9acc547/pyparsing-3.2.1-py3-none-any.whl
@@ -176,7 +202,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0f/dd/84f10e23edd882c6f968c21c2434fe67bd4a528967067515feca9e611e5e/tzdata-2025.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/48/2a/97928387d6ed1c1ebbfd4efc4133a0633546bec8481a2dd5ec961313a1c7/wrapt-1.17.2-cp312-cp312-macosx_11_0_arm64.whl
-      - pypi: .
+      - pypi: ./
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h2466b09_7.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2024.12.14-h56e8100_0.conda
@@ -232,7 +258,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/15/06/1dbf478ea45c03e78a6a8c4be4fdc3c3bddea5c8de8a93bc971415e47f0f/wrapt-1.17.2-cp312-cp312-win_amd64.whl
-      - pypi: .
+      - pypi: ./
   default:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
@@ -246,21 +272,30 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2024.12.14-hbcca054_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.6.1-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.43-h712a8e2_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-26_linux64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-26_linux64_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.6.4-h5888daf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-14.2.0-h77fa898_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-14.2.0-h69a702a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-14.2.0-h69a702a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-14.2.0-hd5240d6_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-14.2.0-h77fa898_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-26_linux64_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.6.3-hb9d3cd8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.28-pthreads_h94d23a6_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.48.0-hee588c1_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-14.2.0-hc0a3c3a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.2.6-py312h72c5963_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.4.0-h7b32b05_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.8-h9e4cc4f_1_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.12-5_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
@@ -283,8 +318,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/cb/da/8341fd3056419441286c8e26bf436923021005ece0bff5f41906476ae514/llvmlite-0.44.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/a7/b2/d872fc3d753516870d520595ddd8ce4dd44fa797a240999f125f58521ad7/matplotlib-3.10.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/38/13/23b73a1f300521613f967763ef4ada4737474f9d5b620b7e5ba9e4857ee7/narwhals-1.23.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/18/74/6a9f0e6c76c088f8a6aa702eab31734068061dca5cc0f34e8bc1eb447de1/numba-0.61.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/9e/3e/3757f304c704f2f0294a6b8340fcf2be244038be07da4cccf390fa678a9f/numpy-2.1.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/9a/2d/e518df036feab381c23a624dac47f8445ac55686ec7f11083655eb707da3/numba-0.61.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/38/f8/d8fddee9ed0d0c0f4a2132c1dfcf0e3e53265055da8df952a53e7eaf178c/pandas-2.2.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/38/0d/84200ed6a871ce386ddc82904bfadc0c6b28b0c0ec78176871a4679e40b3/pillow-11.1.0-cp312-cp312-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/1c/a7/c8a2d361bf89c0d9577c934ebb7421b25dc84bf3a8e3ac0a40aed9acc547/pyparsing-3.2.1-py3-none-any.whl
@@ -297,20 +331,30 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0f/dd/84f10e23edd882c6f968c21c2434fe67bd4a528967067515feca9e611e5e/tzdata-2025.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2a/5a/04cde32b07a7431d4ed0553a76fdb7a61270e78c5fd5a603e190ac389f14/wrapt-1.17.2-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-      - pypi: .
+      - pypi: ./
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-hfdf4475_7.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2024.12.14-h8857fd0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.6.1-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.9.0-26_osx64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.9.0-26_osx64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-19.1.7-hf95d169_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.6.4-h240833e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.4.2-h0d85af4_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-5.0.0-13_2_0_h97931a8_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-13.2.0-h2873a65_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.9.0-26_osx64_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/liblzma-5.6.3-hd471939_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.28-openmp_hbf64a52_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.48.0-hdb6dae5_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.1-hd23fc13_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-19.1.7-ha54dae1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.5-h0622a9a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-2.2.6-py312h6693b03_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.4.0-hc426f3f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.12.8-h9ccd52b_1_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.12-5_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/readline-8.2-h9e318b2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h1abcd95_1.conda
@@ -333,8 +377,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/15/86/e3c3195b92e6e492458f16d233e58a1a812aa2bfbef9bdd0fbafcec85c60/llvmlite-0.44.0-cp312-cp312-macosx_10_14_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/44/c7/6b2d8cb7cc251d53c976799cacd3200add56351c175ba89ab9cbd7c1e68a/matplotlib-3.10.0-cp312-cp312-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/38/13/23b73a1f300521613f967763ef4ada4737474f9d5b620b7e5ba9e4857ee7/narwhals-1.23.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/63/c9/c61881e7f2e253e745209f078bbd428ce23b6cf901f7d93afe166720ff95/numba-0.61.0-cp312-cp312-macosx_10_14_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/8a/f0/385eb9970309643cbca4fc6eebc8bb16e560de129c91258dfaa18498da8b/numpy-2.1.3-cp312-cp312-macosx_10_13_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/b4/a0/c6b7b9c615cfa3b98c4c63f4316e3f6b3bbe2387740277006551784218cd/numba-0.61.2-cp312-cp312-macosx_10_14_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/17/a3/fb2734118db0af37ea7433f57f722c0a56687e14b14690edff0cdb4b7e58/pandas-2.2.3-cp312-cp312-macosx_10_9_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/95/20/9ce6ed62c91c073fcaa23d216e68289e19d95fb8188b9fb7a63d36771db8/pillow-11.1.0-cp312-cp312-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/1c/a7/c8a2d361bf89c0d9577c934ebb7421b25dc84bf3a8e3ac0a40aed9acc547/pyparsing-3.2.1-py3-none-any.whl
@@ -347,20 +390,30 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0f/dd/84f10e23edd882c6f968c21c2434fe67bd4a528967067515feca9e611e5e/tzdata-2025.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/53/18/75ddc64c3f63988f5a1d7e10fb204ffe5762bc663f8023f18ecaf31a332e/wrapt-1.17.2-cp312-cp312-macosx_10_13_x86_64.whl
-      - pypi: .
+      - pypi: ./
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h99b78c6_7.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2024.12.14-hf0a4a13_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.6.1-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-26_osxarm64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-26_osxarm64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-19.1.7-ha82da77_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.6.4-h286801f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.2-h3422bc3_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-5.0.0-13_2_0_hd922786_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-13.2.0-hf226fd6_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-26_osxarm64_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.6.3-h39f12f2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.28-openmp_hf332438_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.48.0-h3f77e49_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-19.1.7-hdb05f8b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h5e97a16_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.2.6-py312h7c1f314_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.4.0-h81ee809_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.8-hc22306f_1_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.12-5_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h92ec313_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h5083fa2_1.conda
@@ -383,8 +436,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/d6/53/373b6b8be67b9221d12b24125fd0ec56b1078b660eeae266ec388a6ac9a0/llvmlite-0.44.0-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/42/2a/6d66d0fba41e13e9ca6512a0a51170f43e7e7ed3a8dfa036324100775612/matplotlib-3.10.0-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/38/13/23b73a1f300521613f967763ef4ada4737474f9d5b620b7e5ba9e4857ee7/narwhals-1.23.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/e1/28/ddec0147a4933f86ceaca580aa9bb767d5632ecdb1ece6cfb3eab4ac78e5/numba-0.61.0-cp312-cp312-macosx_11_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/54/4a/765b4607f0fecbb239638d610d04ec0a0ded9b4951c56dc68cef79026abf/numpy-2.1.3-cp312-cp312-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/92/4a/fe4e3c2ecad72d88f5f8cd04e7f7cff49e718398a2fac02d2947480a00ca/numba-0.61.2-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/e1/0c/ad295fd74bfac85358fd579e271cded3ac969de81f62dd0142c426b9da91/pandas-2.2.3-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/b9/d8/f6004d98579a2596c098d1e30d10b248798cceff82d2b77aa914875bfea1/pillow-11.1.0-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/1c/a7/c8a2d361bf89c0d9577c934ebb7421b25dc84bf3a8e3ac0a40aed9acc547/pyparsing-3.2.1-py3-none-any.whl
@@ -397,7 +449,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0f/dd/84f10e23edd882c6f968c21c2434fe67bd4a528967067515feca9e611e5e/tzdata-2025.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/48/2a/97928387d6ed1c1ebbfd4efc4133a0633546bec8481a2dd5ec961313a1c7/wrapt-1.17.2-cp312-cp312-macosx_11_0_arm64.whl
-      - pypi: .
+      - pypi: ./
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h2466b09_7.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2024.12.14-h56e8100_0.conda
@@ -450,7 +502,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/15/06/1dbf478ea45c03e78a6a8c4be4fdc3c3bddea5c8de8a93bc971415e47f0f/wrapt-1.17.2-cp312-cp312-win_amd64.whl
-      - pypi: .
+      - pypi: ./
   dev:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
@@ -527,10 +579,13 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.5.0-h851e524_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.13.5-h8d12d68_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/make-4.4.1-hb9d3cd8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.2-py312h178313f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/nlopt-2.9.0-py312h1d0b465_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.2.6-py312h72c5963_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.4.0-h7b32b05_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pango-1.56.1-h861ebed_0.conda
@@ -542,53 +597,106 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.12-5_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-4.3-r43hd8ed1ab_1008.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-abind-1.4_5-r43hc72bb7e_1006.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/r-backports-1.5.0-r43hb1dbf0f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/r-base-4.3.3-h5074ccb_16.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-boot-1.3_31-r43hc72bb7e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-broom-1.0.7-r43hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-car-3.1_3-r43hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-cardata-3.0_5-r43hc72bb7e_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/r-caret-6.0_94-r43hdb488b9_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/r-class-7.3_23-r43h2b5f3a1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/r-cli-3.6.3-r43h0d4f4ea_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/r-clock-0.7.1-r43h0d4f4ea_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/r-cluster-2.1.8.1-r43hb67ce94_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-codetools-0.2_20-r43hc72bb7e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/r-colorspace-2.1_1-r43hdb488b9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/r-conquer-1.3.3-r43hb424bfc_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-cowplot-1.1.3-r43hc72bb7e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-cpp11-0.5.2-r43h785f33e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-crayon-1.5.3-r43hc72bb7e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/r-data.table-1.17.2-r43he23165d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-deriv-4.1.6-r43hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-diagram-1.6.5-r43ha770c72_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/r-digest-0.6.37-r43h0d4f4ea_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-doby-4.6.27-r43hc72bb7e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/r-dplyr-1.1.4-r43h0d4f4ea_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-dreamerr-1.4.0-r43hc72bb7e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/r-e1071-1.7_16-r43h93ab643_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/r-ellipsis-0.3.2-r43hb1dbf0f_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/r-fansi-1.0.6-r43hb1dbf0f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/r-farver-2.1.2-r43ha18555a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/r-fixest-0.12.1-r43h0d4f4ea_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-foreach-1.5.2-r43hc72bb7e_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/r-foreign-0.8_90-r43h2b5f3a1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-formula-1.2_5-r43hc72bb7e_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-future-1.49.0-r43h785f33e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-future.apply-1.11.3-r43hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-gbrd-0.4.12-r43hc72bb7e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-generics-0.1.3-r43hc72bb7e_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-ggplot2-3.5.1-r43hc72bb7e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-globals-0.18.0-r43hc72bb7e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/r-glue-1.8.0-r43h2b5f3a1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/r-gower-1.0.1-r43hb1dbf0f_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-gtable-0.3.6-r43hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-hardhat-1.4.1-r43hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/r-ipred-0.9_15-r43hdb488b9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/r-isoband-0.2.7-r43ha18555a_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-iterators-1.0.14-r43hc72bb7e_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/r-kernsmooth-2.23_26-r43h8461fee_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-labeling-0.4.3-r43hc72bb7e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/r-lattice-0.22_6-r43hb1dbf0f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-lava-1.8.1-r43hc72bb7e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-lifecycle-1.0.4-r43hc72bb7e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-listenv-0.9.1-r43hc72bb7e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/r-lme4-1.1_37-r43h93ab643_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/r-lubridate-1.9.4-r43h2b5f3a1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/r-magrittr-2.0.3-r43hb1dbf0f_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/r-mass-7.3_60.0.1-r43hb1dbf0f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/r-matrix-1.6_5-r43he966344_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-matrixmodels-0.5_4-r43hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/r-matrixstats-1.5.0-r43h2b5f3a1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/r-mgcv-1.9_1-r43h0d28552_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/r-microbenchmark-1.5.0-r43h2b5f3a1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/r-minqa-1.2.8-r43ha936806_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/r-modelmetrics-1.2.2.2-r43h0d4f4ea_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-modelr-0.1.11-r43hc72bb7e_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-munsell-0.5.1-r43hc72bb7e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/r-nlme-3.1_165-r43hbcb9c34_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/r-nloptr-2.2.1-r43hb8c4c88_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/r-nnet-7.3_20-r43h2b5f3a1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-numderiv-2016.8_1.1-r43hc72bb7e_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/r-parallelly-1.44.0-r43h2b5f3a1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-pbkrtest-0.5.4-r43hc72bb7e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-pillar-1.10.1-r43hc72bb7e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-pkgconfig-2.0.3-r43hc72bb7e_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/r-plyr-1.8.9-r43ha18555a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/r-proc-1.18.5-r43ha18555a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/r-prodlim-2025.04.28-r43h93ab643_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-progressr-0.15.1-r43hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/r-proxy-0.4_27-r43hb1dbf0f_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/r-purrr-1.0.2-r43hdb488b9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/r-quantreg-6.1-r43h012206f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-r6-2.5.1-r43hc72bb7e_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/r-rbibutils-2.3-r43h2b5f3a1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-rcolorbrewer-1.1_3-r43h785f33e_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/r-rcpp-1.0.14-r43h93ab643_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/r-rcpparmadillo-14.4.2_1-r43hc2d650c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/r-rcppeigen-0.3.4.0.2-r43hb79369c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-rdpack-2.6.4-r43hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-recipes-1.3.0-r43hc72bb7e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-recommended-4.3-r43hd8ed1ab_1007.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-reformulas-0.4.1-r43hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/r-reshape2-1.4.4-r43h0d4f4ea_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/r-rlang-1.1.5-r43h93ab643_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/r-rpart-4.1.24-r43h2b5f3a1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-sandwich-3.1_1-r43hc72bb7e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-scales-1.3.0-r43hc72bb7e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-shape-1.4.6.1-r43ha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/r-sparsem-1.84_2-r43hc4980d5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/r-sparsevctrs-0.3.3-r43h2b5f3a1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/r-spatial-7.3_18-r43h2b5f3a1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-squarem-2021.1-r43hc72bb7e_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/r-stringi-1.8.4-r43h33cde33_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/r-stringmagic-1.1.2-r43h0d4f4ea_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-stringr-1.5.1-r43h785f33e_1.conda
@@ -596,10 +704,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/r-tibble-3.2.1-r43hdb488b9_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/r-tidyr-1.3.1-r43h0d4f4ea_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-tidyselect-1.2.1-r43hc72bb7e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/r-timechange-0.3.0-r43ha18555a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-timedate-4041.110-r43hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/r-tzdb-0.5.0-r43h93ab643_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/r-utf8-1.2.4-r43hb1dbf0f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/r-vctrs-0.6.5-r43h0d4f4ea_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-viridislite-0.4.2-r43hc72bb7e_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-withr-3.0.2-r43hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/r-xml2-1.3.6-r43h8194278_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/r-zoo-1.8_12-r43hb1dbf0f_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rpy2-3.5.11-py312r43hc7c0aa3_3.conda
@@ -662,8 +774,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/38/13/23b73a1f300521613f967763ef4ada4737474f9d5b620b7e5ba9e4857ee7/narwhals-1.23.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d2/1d/1b658dbd2b9fa9c4c9f32accbfc0205d532c8c6194dc0f2a4c0428e7128a/nodeenv-1.9.1-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/18/74/6a9f0e6c76c088f8a6aa702eab31734068061dca5cc0f34e8bc1eb447de1/numba-0.61.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/9e/3e/3757f304c704f2f0294a6b8340fcf2be244038be07da4cccf390fa678a9f/numpy-2.1.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/9a/2d/e518df036feab381c23a624dac47f8445ac55686ec7f11083655eb707da3/numba-0.61.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/23/cd/066e86230ae37ed0be70aae89aabf03ca8d9f39c8aea0dec8029455b5540/opt_einsum-3.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/38/f8/d8fddee9ed0d0c0f4a2132c1dfcf0e3e53265055da8df952a53e7eaf178c/pandas-2.2.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/c6/ac/dac4a63f978e4dcb3c6d3a78c4d8e0192a113d288502a1216950c41b1027/parso-0.8.4-py2.py3-none-any.whl
@@ -707,7 +818,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/fd/84/fd2ba7aafacbad3c4201d395674fc6348826569da3c0937e75505ead3528/wcwidth-0.2.13-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b2/75/419e54d92b1b97128a12f8dcd53b40b5144a33a69026496287a3ab7557e4/wildboottest-0.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2a/5a/04cde32b07a7431d4ed0553a76fdb7a61270e78c5fd5a603e190ac389f14/wrapt-1.17.2-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-      - pypi: .
+      - pypi: ./
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/_r-mutex-1.0.1-anacondar_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/bwidget-1.10.1-h694c41f_0.conda
@@ -789,6 +900,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/mpc-1.3.1-h9d8efa1_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/mpfr-4.2.1-haed47dc_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.5-h0622a9a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/nlopt-2.9.0-py312hb87d94a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-2.2.6-py312h6693b03_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.4.0-hc426f3f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pango-1.56.1-hf94f63b_0.conda
@@ -799,53 +912,106 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.12-5_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-4.3-r43hd8ed1ab_1008.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-abind-1.4_5-r43hc72bb7e_1006.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/r-backports-1.5.0-r43h6b9d099_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/r-base-4.3.3-h11f04cc_16.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-boot-1.3_31-r43hc72bb7e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-broom-1.0.7-r43hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-car-3.1_3-r43hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-cardata-3.0_5-r43hc72bb7e_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/r-caret-6.0_94-r43h6b9d099_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/r-class-7.3_23-r43h79f565e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/r-cli-3.6.3-r43h25d921d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/r-clock-0.7.1-r43h25d921d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/r-cluster-2.1.8.1-r43hb3c2f18_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-codetools-0.2_20-r43hc72bb7e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/r-colorspace-2.1_1-r43h6b9d099_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/r-conquer-1.3.3-r43h6a638e2_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-cowplot-1.1.3-r43hc72bb7e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-cpp11-0.5.2-r43h785f33e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-crayon-1.5.3-r43hc72bb7e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/r-data.table-1.17.2-r43h3ffa6c1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-deriv-4.1.6-r43hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-diagram-1.6.5-r43ha770c72_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/r-digest-0.6.37-r43h25d921d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-doby-4.6.27-r43hc72bb7e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/r-dplyr-1.1.4-r43h25d921d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-dreamerr-1.4.0-r43hc72bb7e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/r-e1071-1.7_16-r43hc83a2cd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/r-ellipsis-0.3.2-r43h6b9d099_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/r-fansi-1.0.6-r43h6b9d099_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/r-farver-2.1.2-r43h25d921d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/r-fixest-0.12.1-r43hccab667_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-foreach-1.5.2-r43hc72bb7e_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/r-foreign-0.8_90-r43h79f565e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-formula-1.2_5-r43hc72bb7e_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-future-1.49.0-r43h785f33e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-future.apply-1.11.3-r43hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-gbrd-0.4.12-r43hc72bb7e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-generics-0.1.3-r43hc72bb7e_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-ggplot2-3.5.1-r43hc72bb7e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-globals-0.18.0-r43hc72bb7e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/r-glue-1.8.0-r43h199b6f9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/r-gower-1.0.1-r43h6b9d099_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-gtable-0.3.6-r43hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-hardhat-1.4.1-r43hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/r-ipred-0.9_15-r43h6b9d099_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/r-isoband-0.2.7-r43h25d921d_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-iterators-1.0.14-r43hc72bb7e_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/r-kernsmooth-2.23_26-r43hd6847f7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-labeling-0.4.3-r43hc72bb7e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/r-lattice-0.22_6-r43h6b9d099_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-lava-1.8.1-r43hc72bb7e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-lifecycle-1.0.4-r43hc72bb7e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-listenv-0.9.1-r43hc72bb7e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/r-lme4-1.1_37-r43h2711daa_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/r-lubridate-1.9.4-r43h79f565e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/r-magrittr-2.0.3-r43h6b9d099_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/r-mass-7.3_60.0.1-r43h6b9d099_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/r-matrix-1.6_5-r43h9cf22e7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-matrixmodels-0.5_4-r43hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/r-matrixstats-1.5.0-r43h79f565e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/r-mgcv-1.9_1-r43h374a70c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/r-microbenchmark-1.5.0-r43h199b6f9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/r-minqa-1.2.8-r43hc1e73ce_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/r-modelmetrics-1.2.2.2-r43hccab667_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-modelr-0.1.11-r43hc72bb7e_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-munsell-0.5.1-r43hc72bb7e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/r-nlme-3.1_165-r43h9612530_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/r-nloptr-2.2.1-r43h1fbd797_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/r-nnet-7.3_20-r43h79f565e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-numderiv-2016.8_1.1-r43hc72bb7e_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/r-parallelly-1.44.0-r43h79f565e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-pbkrtest-0.5.4-r43hc72bb7e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-pillar-1.10.1-r43hc72bb7e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-pkgconfig-2.0.3-r43hc72bb7e_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/r-plyr-1.8.9-r43h25d921d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/r-proc-1.18.5-r43h25d921d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/r-prodlim-2025.04.28-r43h2711daa_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-progressr-0.15.1-r43hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/r-proxy-0.4_27-r43h6b9d099_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/r-purrr-1.0.2-r43h6b9d099_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/r-quantreg-6.1-r43hfe2c0ad_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-r6-2.5.1-r43hc72bb7e_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/r-rbibutils-2.3-r43h199b6f9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-rcolorbrewer-1.1_3-r43h785f33e_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/r-rcpp-1.0.14-r43h2711daa_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/r-rcpparmadillo-14.4.2_1-r43hda2d453_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/r-rcppeigen-0.3.4.0.2-r43haa2a3db_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-rdpack-2.6.4-r43hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-recipes-1.3.0-r43hc72bb7e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-recommended-4.3-r43hd8ed1ab_1007.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-reformulas-0.4.1-r43hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/r-reshape2-1.4.4-r43h25d921d_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/r-rlang-1.1.5-r43h2711daa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/r-rpart-4.1.24-r43h79f565e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-sandwich-3.1_1-r43hc72bb7e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-scales-1.3.0-r43hc72bb7e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-shape-1.4.6.1-r43ha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/r-sparsem-1.84_2-r43h9612530_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/r-sparsevctrs-0.3.3-r43h79f565e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/r-spatial-7.3_18-r43h79f565e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-squarem-2021.1-r43hc72bb7e_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/r-stringi-1.8.4-r43hf60abff_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/r-stringmagic-1.1.2-r43h25d921d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-stringr-1.5.1-r43h785f33e_1.conda
@@ -853,10 +1019,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/r-tibble-3.2.1-r43h6b9d099_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/r-tidyr-1.3.1-r43h25d921d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-tidyselect-1.2.1-r43hc72bb7e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/r-timechange-0.3.0-r43h25d921d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-timedate-4041.110-r43hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/r-tzdb-0.5.0-r43h2711daa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/r-utf8-1.2.4-r43h6b9d099_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/r-vctrs-0.6.5-r43h25d921d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-viridislite-0.4.2-r43hc72bb7e_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-withr-3.0.2-r43hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/r-xml2-1.3.6-r43h0ea9301_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/r-zoo-1.8_12-r43h6b9d099_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/readline-8.2-h9e318b2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/rpy2-3.5.11-py312r43h5d6a8aa_3.conda
@@ -913,8 +1083,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/38/13/23b73a1f300521613f967763ef4ada4737474f9d5b620b7e5ba9e4857ee7/narwhals-1.23.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d2/1d/1b658dbd2b9fa9c4c9f32accbfc0205d532c8c6194dc0f2a4c0428e7128a/nodeenv-1.9.1-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/63/c9/c61881e7f2e253e745209f078bbd428ce23b6cf901f7d93afe166720ff95/numba-0.61.0-cp312-cp312-macosx_10_14_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/8a/f0/385eb9970309643cbca4fc6eebc8bb16e560de129c91258dfaa18498da8b/numpy-2.1.3-cp312-cp312-macosx_10_13_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/b4/a0/c6b7b9c615cfa3b98c4c63f4316e3f6b3bbe2387740277006551784218cd/numba-0.61.2-cp312-cp312-macosx_10_14_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/23/cd/066e86230ae37ed0be70aae89aabf03ca8d9f39c8aea0dec8029455b5540/opt_einsum-3.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/17/a3/fb2734118db0af37ea7433f57f722c0a56687e14b14690edff0cdb4b7e58/pandas-2.2.3-cp312-cp312-macosx_10_9_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/c6/ac/dac4a63f978e4dcb3c6d3a78c4d8e0192a113d288502a1216950c41b1027/parso-0.8.4-py2.py3-none-any.whl
@@ -958,7 +1127,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/fd/84/fd2ba7aafacbad3c4201d395674fc6348826569da3c0937e75505ead3528/wcwidth-0.2.13-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b2/75/419e54d92b1b97128a12f8dcd53b40b5144a33a69026496287a3ab7557e4/wildboottest-0.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/53/18/75ddc64c3f63988f5a1d7e10fb204ffe5762bc663f8023f18ecaf31a332e/wrapt-1.17.2-cp312-cp312-macosx_10_13_x86_64.whl
-      - pypi: .
+      - pypi: ./
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/_r-mutex-1.0.1-anacondar_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bwidget-1.10.1-hce30654_0.conda
@@ -1040,6 +1209,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mpc-1.3.1-h8f1351a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mpfr-4.2.1-hb693164_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h5e97a16_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/nlopt-2.9.0-py312hace9f44_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.2.6-py312h7c1f314_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.4.0-h81ee809_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pango-1.56.1-h73f1e88_0.conda
@@ -1050,53 +1221,106 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.12-5_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-4.3-r43hd8ed1ab_1008.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-abind-1.4_5-r43hc72bb7e_1006.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-backports-1.5.0-r43h07cda29_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-base-4.3.3-h527b63a_16.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-boot-1.3_31-r43hc72bb7e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-broom-1.0.7-r43hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-car-3.1_3-r43hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-cardata-3.0_5-r43hc72bb7e_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-caret-6.0_94-r43h07cda29_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-class-7.3_23-r43h570997c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-cli-3.6.3-r43hd76f289_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-clock-0.7.1-r43hd76f289_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-cluster-2.1.8.1-r43he0ea626_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-codetools-0.2_20-r43hc72bb7e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-colorspace-2.1_1-r43h07cda29_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-conquer-1.3.3-r43h2743ada_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-cowplot-1.1.3-r43hc72bb7e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-cpp11-0.5.2-r43h785f33e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-crayon-1.5.3-r43hc72bb7e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-data.table-1.17.2-r43h28c71e1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-deriv-4.1.6-r43hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-diagram-1.6.5-r43ha770c72_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-digest-0.6.37-r43hd76f289_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-doby-4.6.27-r43hc72bb7e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-dplyr-1.1.4-r43hd76f289_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-dreamerr-1.4.0-r43hc72bb7e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-e1071-1.7_16-r43hdd833ad_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-ellipsis-0.3.2-r43h07cda29_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-fansi-1.0.6-r43h07cda29_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-farver-2.1.2-r43hd76f289_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-fixest-0.12.1-r43h173a3d2_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-foreach-1.5.2-r43hc72bb7e_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-foreign-0.8_90-r43h570997c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-formula-1.2_5-r43hc72bb7e_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-future-1.49.0-r43h785f33e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-future.apply-1.11.3-r43hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-gbrd-0.4.12-r43hc72bb7e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-generics-0.1.3-r43hc72bb7e_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-ggplot2-3.5.1-r43hc72bb7e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-globals-0.18.0-r43hc72bb7e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-glue-1.8.0-r43h0d9a900_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-gower-1.0.1-r43h07cda29_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-gtable-0.3.6-r43hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-hardhat-1.4.1-r43hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-ipred-0.9_15-r43h07cda29_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-isoband-0.2.7-r43hd76f289_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-iterators-1.0.14-r43hc72bb7e_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-kernsmooth-2.23_26-r43h2c658ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-labeling-0.4.3-r43hc72bb7e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-lattice-0.22_6-r43h07cda29_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-lava-1.8.1-r43hc72bb7e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-lifecycle-1.0.4-r43hc72bb7e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-listenv-0.9.1-r43hc72bb7e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-lme4-1.1_37-r43h31118f2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-lubridate-1.9.4-r43h570997c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-magrittr-2.0.3-r43h07cda29_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-mass-7.3_60.0.1-r43h07cda29_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-matrix-1.6_5-r43hded8dfa_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-matrixmodels-0.5_4-r43hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-matrixstats-1.5.0-r43h570997c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-mgcv-1.9_1-r43h83b88f1_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-microbenchmark-1.5.0-r43h0d9a900_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-minqa-1.2.8-r43ha0027a1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-modelmetrics-1.2.2.2-r43h173a3d2_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-modelr-0.1.11-r43hc72bb7e_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-munsell-0.5.1-r43hc72bb7e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-nlme-3.1_165-r43h7807725_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-nloptr-2.2.1-r43h0873fe7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-nnet-7.3_20-r43h570997c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-numderiv-2016.8_1.1-r43hc72bb7e_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-parallelly-1.44.0-r43h570997c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-pbkrtest-0.5.4-r43hc72bb7e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-pillar-1.10.1-r43hc72bb7e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-pkgconfig-2.0.3-r43hc72bb7e_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-plyr-1.8.9-r43hd76f289_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-proc-1.18.5-r43hd76f289_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-prodlim-2025.04.28-r43h31118f2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-progressr-0.15.1-r43hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-proxy-0.4_27-r43h07cda29_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-purrr-1.0.2-r43h07cda29_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-quantreg-6.1-r43h0c5c079_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-r6-2.5.1-r43hc72bb7e_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-rbibutils-2.3-r43h0d9a900_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-rcolorbrewer-1.1_3-r43h785f33e_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-rcpp-1.0.14-r43h31118f2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-rcpparmadillo-14.4.2_1-r43h9618d43_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-rcppeigen-0.3.4.0.2-r43h8c6f55f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-rdpack-2.6.4-r43hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-recipes-1.3.0-r43hc72bb7e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-recommended-4.3-r43hd8ed1ab_1007.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-reformulas-0.4.1-r43hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-reshape2-1.4.4-r43hd76f289_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-rlang-1.1.5-r43h31118f2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-rpart-4.1.24-r43h570997c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-sandwich-3.1_1-r43hc72bb7e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-scales-1.3.0-r43hc72bb7e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-shape-1.4.6.1-r43ha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-sparsem-1.84_2-r43h7807725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-sparsevctrs-0.3.3-r43h570997c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-spatial-7.3_18-r43h570997c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-squarem-2021.1-r43hc72bb7e_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-stringi-1.8.4-r43h428a9ab_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-stringmagic-1.1.2-r43hd76f289_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-stringr-1.5.1-r43h785f33e_1.conda
@@ -1104,10 +1328,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-tibble-3.2.1-r43h07cda29_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-tidyr-1.3.1-r43hd76f289_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-tidyselect-1.2.1-r43hc72bb7e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-timechange-0.3.0-r43hd76f289_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-timedate-4041.110-r43hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-tzdb-0.5.0-r43h31118f2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-utf8-1.2.4-r43h07cda29_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-vctrs-0.6.5-r43hd76f289_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-viridislite-0.4.2-r43hc72bb7e_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-withr-3.0.2-r43hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-xml2-1.3.6-r43hdac5c33_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-zoo-1.8_12-r43h07cda29_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h92ec313_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rpy2-3.5.11-py312r43h3339331_3.conda
@@ -1164,8 +1392,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/38/13/23b73a1f300521613f967763ef4ada4737474f9d5b620b7e5ba9e4857ee7/narwhals-1.23.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d2/1d/1b658dbd2b9fa9c4c9f32accbfc0205d532c8c6194dc0f2a4c0428e7128a/nodeenv-1.9.1-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/e1/28/ddec0147a4933f86ceaca580aa9bb767d5632ecdb1ece6cfb3eab4ac78e5/numba-0.61.0-cp312-cp312-macosx_11_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/54/4a/765b4607f0fecbb239638d610d04ec0a0ded9b4951c56dc68cef79026abf/numpy-2.1.3-cp312-cp312-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/92/4a/fe4e3c2ecad72d88f5f8cd04e7f7cff49e718398a2fac02d2947480a00ca/numba-0.61.2-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/23/cd/066e86230ae37ed0be70aae89aabf03ca8d9f39c8aea0dec8029455b5540/opt_einsum-3.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e1/0c/ad295fd74bfac85358fd579e271cded3ac969de81f62dd0142c426b9da91/pandas-2.2.3-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/c6/ac/dac4a63f978e4dcb3c6d3a78c4d8e0192a113d288502a1216950c41b1027/parso-0.8.4-py2.py3-none-any.whl
@@ -1209,7 +1436,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/fd/84/fd2ba7aafacbad3c4201d395674fc6348826569da3c0937e75505ead3528/wcwidth-0.2.13-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b2/75/419e54d92b1b97128a12f8dcd53b40b5144a33a69026496287a3ab7557e4/wildboottest-0.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/48/2a/97928387d6ed1c1ebbfd4efc4133a0633546bec8481a2dd5ec961313a1c7/wrapt-1.17.2-cp312-cp312-macosx_11_0_arm64.whl
-      - pypi: .
+      - pypi: ./
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/_r-mutex-1.0.1-anacondar_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h2466b09_7.conda
@@ -1251,6 +1478,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-libwinpthread-git-5.0.0.4634.697f757-2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-libxml2-2.9.3-3.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-mpfr-3.1.4-4.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-nlopt-2.4.2-3.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-pcre2-10.34-0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-speex-1.2rc2-3.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-speexdsp-1.2rc3-3.tar.bz2
@@ -1272,53 +1500,117 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.12-5_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-4.1-r41hd8ed1ab_1006.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-abind-1.4_5-r41hc72bb7e_1004.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-assertthat-0.2.1-r41hc72bb7e_3.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/r-backports-1.5.0-r41h6c66454_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/r-base-4.1.3-h22dd5fe_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-bit-4.0.5-r41h6d2157b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-bit64-4.0.5-r41h6d2157b_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-boot-1.3_28.1-r41hc72bb7e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-broom-1.0.5-r41hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-car-3.1_2-r41hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-cardata-3.0_5-r41hc72bb7e_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-caret-6.0_94-r41h6d2157b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-cellranger-1.1.0-r41hc72bb7e_1005.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/r-class-7.3_22-r41h6d2157b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/r-cli-3.6.3-r41he75b88d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-clipr-0.8.0-r41hc72bb7e_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-clock-0.7.0-r41ha856d6a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/r-cluster-2.1.6-r41he816bda_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-codetools-0.2_19-r41hc72bb7e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/r-colorspace-2.1_0-r41h6d2157b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-conquer-1.3.3-r41h3c88c7c_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-cpp11-0.5.2-r41hc72bb7e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-crayon-1.5.2-r41hc72bb7e_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-curl-4.3.3-r41h6d2157b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-data.table-1.15.4-r41h6d2157b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-diagram-1.6.5-r41ha770c72_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-digest-0.6.36-r41he75b88d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/r-dplyr-1.1.4-r41ha856d6a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-dreamerr-1.4.0-r41hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-e1071-1.7_14-r41ha856d6a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/r-ellipsis-0.3.2-r41h6d2157b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-evaluate-0.21-r41hc72bb7e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/r-fansi-1.0.6-r41h6d2157b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/r-farver-2.1.2-r41he75b88d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/r-fixest-0.12.1-r41he75b88d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-forcats-1.0.0-r41hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-foreach-1.5.2-r41hc72bb7e_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/r-foreign-0.8_87-r41h6c66454_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-formula-1.2_5-r41hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-future-1.32.0-r41hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-future.apply-1.11.0-r41hc72bb7e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-generics-0.1.3-r41hc72bb7e_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-ggplot2-3.4.2-r41hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-globals-0.16.2-r41hc72bb7e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/r-glue-1.7.0-r41h6d2157b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-gower-1.0.1-r41h6d2157b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-gtable-0.3.3-r41hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-hardhat-1.3.0-r41hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-haven-2.5.4-r41ha856d6a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-highr-0.10-r41hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-hms-1.1.3-r41hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-ipred-0.9_15-r41h6c66454_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/r-isoband-0.2.7-r41ha856d6a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-iterators-1.0.14-r41hc72bb7e_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/r-kernsmooth-2.23_24-r41h5d8b4f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-knitr-1.43-r41hc72bb7e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-labeling-0.4.2-r41hc72bb7e_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/r-lattice-0.22_6-r41h6d2157b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-lava-1.7.2.1-r41hc72bb7e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-lifecycle-1.0.3-r41hc72bb7e_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-listenv-0.9.0-r41hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-lme4-1.1_35.5-r41he75b88d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-lubridate-1.9.3-r41h6d2157b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/r-magrittr-2.0.3-r41h6d2157b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-maptools-1.1_8-r41h6d2157b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/r-mass-7.3_58.3-r41h6d2157b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/r-matrix-1.6_5-r41hb9981e2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-matrixmodels-0.5_1-r41hc72bb7e_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-matrixstats-1.3.0-r41h6d2157b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/r-mgcv-1.9_1-r41hb9981e2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-minqa-1.2.7-r41h92b2e5c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-modelmetrics-1.2.2.2-r41ha856d6a_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-munsell-0.5.0-r41hc72bb7e_1005.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/r-nlme-3.1_165-r41hd63c432_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-nloptr-2.0.3-r41h96779af_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/r-nnet-7.3_19-r41h6d2157b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-numderiv-2016.8_1.1-r41hc72bb7e_4.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-openxlsx-4.2.5.2-r41ha856d6a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-parallelly-1.37.1-r41h6d2157b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-pbkrtest-0.5.2-r41hc72bb7e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-pillar-1.9.0-r41hc72bb7e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-pkgconfig-2.0.3-r41hc72bb7e_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-plyr-1.8.9-r41ha856d6a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-prettyunits-1.1.1-r41hc72bb7e_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-proc-1.18.5-r41ha856d6a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-prodlim-2024.06.25-r41he75b88d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-progress-1.2.2-r41hc72bb7e_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-progressr-0.13.0-r41hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-proxy-0.4_27-r41h6d2157b_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/r-purrr-1.0.2-r41h6d2157b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-quantreg-5.98-r41h9b73d3e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-r6-2.5.1-r41hc72bb7e_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-rcolorbrewer-1.1_3-r41h785f33e_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/r-rcpp-1.0.12-r41ha856d6a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-rcpparmadillo-0.12.6.4.0-r41h78deb2a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-rcppeigen-0.3.4.0.0-r41h78deb2a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-readr-2.1.5-r41ha856d6a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-readxl-1.4.3-r41h1c2d66b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-recipes-1.0.6-r41hc72bb7e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-recommended-4.1-r41hd8ed1ab_1005.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-rematch-1.0.1-r41hc72bb7e_1005.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-reshape2-1.4.4-r41ha856d6a_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-rio-0.5.29-r41hc72bb7e_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/r-rlang-1.1.4-r41he75b88d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/r-rpart-4.1.23-r41h6d2157b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-sandwich-3.0_2-r41hc72bb7e_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-scales-1.2.1-r41hc72bb7e_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-shape-1.4.6-r41ha770c72_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-sp-2.1_4-r41h245b76f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-sparsem-1.84-r41hd63c432_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/r-spatial-7.3_17-r41h6d2157b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-squarem-2021.1-r41hc72bb7e_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/r-stringi-1.8.4-r41h3f0a074_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/r-stringmagic-1.1.2-r41h3f0a074_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-stringr-1.5.0-r41h785f33e_0.conda
@@ -1326,10 +1618,17 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/r-tibble-3.2.1-r41h6d2157b_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/r-tidyr-1.3.1-r41ha856d6a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/r-tidyselect-1.2.0-r41h6addd8b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-timechange-0.3.0-r41ha856d6a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/r-timedate-4022.108-r41hc72bb7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-tzdb-0.4.0-r41ha856d6a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/r-utf8-1.2.4-r41h6d2157b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/r-vctrs-0.6.5-r41ha856d6a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-viridislite-0.4.1-r41hc72bb7e_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-vroom-1.6.5-r41ha856d6a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/r-withr-2.5.0-r41hc72bb7e_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-xfun-0.45-r41he75b88d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-yaml-2.3.8-r41h6d2157b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/r-zip-2.3.1-r41h6d2157b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/r-zoo-1.8_12-r41h6d2157b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/rpy2-3.5.11-py312r41hd0f9d78_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/simplegeneric-0.8.1-pyhd8ed1ab_2.conda
@@ -1427,7 +1726,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/fd/84/fd2ba7aafacbad3c4201d395674fc6348826569da3c0937e75505ead3528/wcwidth-0.2.13-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b2/75/419e54d92b1b97128a12f8dcd53b40b5144a33a69026496287a3ab7557e4/wildboottest-0.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/15/06/1dbf478ea45c03e78a6a8c4be4fdc3c3bddea5c8de8a93bc971415e47f0f/wrapt-1.17.2-cp312-cp312-win_amd64.whl
-      - pypi: .
+      - pypi: ./
   docs:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
@@ -1509,6 +1808,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/make-4.4.1-hb9d3cd8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.2-py312h178313f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.2.6-py312h72c5963_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.4.0-h7b32b05_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pango-1.56.1-h861ebed_0.conda
@@ -1678,8 +1978,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/a9/82/0340caa499416c78e5d8f5f05947ae4bc3cba53c9f038ab6e9ed964e22f1/nbformat-5.10.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f9/33/bd5b9137445ea4b680023eb0469b2bb969d61303dedb2aac6560ff3d14a1/notebook_shim-0.2.4-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/18/74/6a9f0e6c76c088f8a6aa702eab31734068061dca5cc0f34e8bc1eb447de1/numba-0.61.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/9e/3e/3757f304c704f2f0294a6b8340fcf2be244038be07da4cccf390fa678a9f/numpy-2.1.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/9a/2d/e518df036feab381c23a624dac47f8445ac55686ec7f11083655eb707da3/numba-0.61.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/23/cd/066e86230ae37ed0be70aae89aabf03ca8d9f39c8aea0dec8029455b5540/opt_einsum-3.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/33/55/af02708f230eb77084a299d7b08175cff006dea4f2721074b92cdb0296c0/ordered_set-4.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2c/ab/fc8290c6a4c722e5514d80f62b2dc4c4df1a68a41d1364e625c35990fcf3/overrides-7.7.0-py3-none-any.whl
@@ -1748,7 +2047,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/5a/84/44687a29792a70e111c5c477230a72c4b957d88d16141199bf9acb7537a3/websocket_client-1.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b2/75/419e54d92b1b97128a12f8dcd53b40b5144a33a69026496287a3ab7557e4/wildboottest-0.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2a/5a/04cde32b07a7431d4ed0553a76fdb7a61270e78c5fd5a603e190ac389f14/wrapt-1.17.2-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-      - pypi: .
+      - pypi: ./
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/_r-mutex-1.0.1-anacondar_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/bwidget-1.10.1-h694c41f_0.conda
@@ -1831,6 +2130,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/mpc-1.3.1-h9d8efa1_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/mpfr-4.2.1-haed47dc_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.5-h0622a9a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-2.2.6-py312h6693b03_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.4.0-hc426f3f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pango-1.56.1-hf94f63b_0.conda
@@ -1993,8 +2293,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/a9/82/0340caa499416c78e5d8f5f05947ae4bc3cba53c9f038ab6e9ed964e22f1/nbformat-5.10.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f9/33/bd5b9137445ea4b680023eb0469b2bb969d61303dedb2aac6560ff3d14a1/notebook_shim-0.2.4-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/63/c9/c61881e7f2e253e745209f078bbd428ce23b6cf901f7d93afe166720ff95/numba-0.61.0-cp312-cp312-macosx_10_14_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/8a/f0/385eb9970309643cbca4fc6eebc8bb16e560de129c91258dfaa18498da8b/numpy-2.1.3-cp312-cp312-macosx_10_13_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/b4/a0/c6b7b9c615cfa3b98c4c63f4316e3f6b3bbe2387740277006551784218cd/numba-0.61.2-cp312-cp312-macosx_10_14_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/23/cd/066e86230ae37ed0be70aae89aabf03ca8d9f39c8aea0dec8029455b5540/opt_einsum-3.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/33/55/af02708f230eb77084a299d7b08175cff006dea4f2721074b92cdb0296c0/ordered_set-4.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2c/ab/fc8290c6a4c722e5514d80f62b2dc4c4df1a68a41d1364e625c35990fcf3/overrides-7.7.0-py3-none-any.whl
@@ -2063,7 +2362,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/5a/84/44687a29792a70e111c5c477230a72c4b957d88d16141199bf9acb7537a3/websocket_client-1.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b2/75/419e54d92b1b97128a12f8dcd53b40b5144a33a69026496287a3ab7557e4/wildboottest-0.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/53/18/75ddc64c3f63988f5a1d7e10fb204ffe5762bc663f8023f18ecaf31a332e/wrapt-1.17.2-cp312-cp312-macosx_10_13_x86_64.whl
-      - pypi: .
+      - pypi: ./
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/_r-mutex-1.0.1-anacondar_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bwidget-1.10.1-hce30654_0.conda
@@ -2146,6 +2445,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mpc-1.3.1-h8f1351a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mpfr-4.2.1-hb693164_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h5e97a16_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.2.6-py312h7c1f314_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.4.0-h81ee809_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pango-1.56.1-h73f1e88_0.conda
@@ -2308,8 +2608,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/a9/82/0340caa499416c78e5d8f5f05947ae4bc3cba53c9f038ab6e9ed964e22f1/nbformat-5.10.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f9/33/bd5b9137445ea4b680023eb0469b2bb969d61303dedb2aac6560ff3d14a1/notebook_shim-0.2.4-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/e1/28/ddec0147a4933f86ceaca580aa9bb767d5632ecdb1ece6cfb3eab4ac78e5/numba-0.61.0-cp312-cp312-macosx_11_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/54/4a/765b4607f0fecbb239638d610d04ec0a0ded9b4951c56dc68cef79026abf/numpy-2.1.3-cp312-cp312-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/92/4a/fe4e3c2ecad72d88f5f8cd04e7f7cff49e718398a2fac02d2947480a00ca/numba-0.61.2-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/23/cd/066e86230ae37ed0be70aae89aabf03ca8d9f39c8aea0dec8029455b5540/opt_einsum-3.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/33/55/af02708f230eb77084a299d7b08175cff006dea4f2721074b92cdb0296c0/ordered_set-4.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2c/ab/fc8290c6a4c722e5514d80f62b2dc4c4df1a68a41d1364e625c35990fcf3/overrides-7.7.0-py3-none-any.whl
@@ -2378,7 +2677,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/5a/84/44687a29792a70e111c5c477230a72c4b957d88d16141199bf9acb7537a3/websocket_client-1.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b2/75/419e54d92b1b97128a12f8dcd53b40b5144a33a69026496287a3ab7557e4/wildboottest-0.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/48/2a/97928387d6ed1c1ebbfd4efc4133a0633546bec8481a2dd5ec961313a1c7/wrapt-1.17.2-cp312-cp312-macosx_11_0_arm64.whl
-      - pypi: .
+      - pypi: ./
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/_r-mutex-1.0.1-anacondar_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h2466b09_7.conda
@@ -2660,7 +2959,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/5a/84/44687a29792a70e111c5c477230a72c4b957d88d16141199bf9acb7537a3/websocket_client-1.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b2/75/419e54d92b1b97128a12f8dcd53b40b5144a33a69026496287a3ab7557e4/wildboottest-0.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/15/06/1dbf478ea45c03e78a6a8c4be4fdc3c3bddea5c8de8a93bc971415e47f0f/wrapt-1.17.2-cp312-cp312-win_amd64.whl
-      - pypi: .
+      - pypi: ./
   jax:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
@@ -2674,21 +2973,30 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2024.12.14-hbcca054_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.6.1-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.43-h712a8e2_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-26_linux64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-26_linux64_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.6.4-h5888daf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-14.2.0-h77fa898_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-14.2.0-h69a702a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-14.2.0-h69a702a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-14.2.0-hd5240d6_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-14.2.0-h77fa898_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-26_linux64_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.6.3-hb9d3cd8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.28-pthreads_h94d23a6_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.48.0-hee588c1_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-14.2.0-hc0a3c3a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.2.6-py312h72c5963_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.4.0-h7b32b05_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.8-h9e4cc4f_1_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.12-5_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
@@ -2714,8 +3022,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/a7/b2/d872fc3d753516870d520595ddd8ce4dd44fa797a240999f125f58521ad7/matplotlib-3.10.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/08/57/5d58fad4124192b1be42f68bd0c0ddaa26e44a730ff8c9337adade2f5632/ml_dtypes-0.5.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/38/13/23b73a1f300521613f967763ef4ada4737474f9d5b620b7e5ba9e4857ee7/narwhals-1.23.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/18/74/6a9f0e6c76c088f8a6aa702eab31734068061dca5cc0f34e8bc1eb447de1/numba-0.61.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/9e/3e/3757f304c704f2f0294a6b8340fcf2be244038be07da4cccf390fa678a9f/numpy-2.1.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/9a/2d/e518df036feab381c23a624dac47f8445ac55686ec7f11083655eb707da3/numba-0.61.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/23/cd/066e86230ae37ed0be70aae89aabf03ca8d9f39c8aea0dec8029455b5540/opt_einsum-3.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/38/f8/d8fddee9ed0d0c0f4a2132c1dfcf0e3e53265055da8df952a53e7eaf178c/pandas-2.2.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/38/0d/84200ed6a871ce386ddc82904bfadc0c6b28b0c0ec78176871a4679e40b3/pillow-11.1.0-cp312-cp312-manylinux_2_28_x86_64.whl
@@ -2729,20 +3036,30 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0f/dd/84f10e23edd882c6f968c21c2434fe67bd4a528967067515feca9e611e5e/tzdata-2025.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2a/5a/04cde32b07a7431d4ed0553a76fdb7a61270e78c5fd5a603e190ac389f14/wrapt-1.17.2-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-      - pypi: .
+      - pypi: ./
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-hfdf4475_7.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2024.12.14-h8857fd0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.6.1-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.9.0-26_osx64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.9.0-26_osx64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-19.1.7-hf95d169_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.6.4-h240833e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.4.2-h0d85af4_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-5.0.0-13_2_0_h97931a8_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-13.2.0-h2873a65_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.9.0-26_osx64_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/liblzma-5.6.3-hd471939_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.28-openmp_hbf64a52_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.48.0-hdb6dae5_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.1-hd23fc13_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-19.1.7-ha54dae1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.5-h0622a9a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-2.2.6-py312h6693b03_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.4.0-hc426f3f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.12.8-h9ccd52b_1_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.12-5_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/readline-8.2-h9e318b2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h1abcd95_1.conda
@@ -2768,8 +3085,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/44/c7/6b2d8cb7cc251d53c976799cacd3200add56351c175ba89ab9cbd7c1e68a/matplotlib-3.10.0-cp312-cp312-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/47/56/1bb21218e1e692506c220ffabd456af9733fba7aa1b14f73899979f4cc20/ml_dtypes-0.5.1-cp312-cp312-macosx_10_9_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/38/13/23b73a1f300521613f967763ef4ada4737474f9d5b620b7e5ba9e4857ee7/narwhals-1.23.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/63/c9/c61881e7f2e253e745209f078bbd428ce23b6cf901f7d93afe166720ff95/numba-0.61.0-cp312-cp312-macosx_10_14_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/8a/f0/385eb9970309643cbca4fc6eebc8bb16e560de129c91258dfaa18498da8b/numpy-2.1.3-cp312-cp312-macosx_10_13_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/b4/a0/c6b7b9c615cfa3b98c4c63f4316e3f6b3bbe2387740277006551784218cd/numba-0.61.2-cp312-cp312-macosx_10_14_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/23/cd/066e86230ae37ed0be70aae89aabf03ca8d9f39c8aea0dec8029455b5540/opt_einsum-3.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/17/a3/fb2734118db0af37ea7433f57f722c0a56687e14b14690edff0cdb4b7e58/pandas-2.2.3-cp312-cp312-macosx_10_9_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/95/20/9ce6ed62c91c073fcaa23d216e68289e19d95fb8188b9fb7a63d36771db8/pillow-11.1.0-cp312-cp312-macosx_10_13_x86_64.whl
@@ -2783,20 +3099,30 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0f/dd/84f10e23edd882c6f968c21c2434fe67bd4a528967067515feca9e611e5e/tzdata-2025.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/53/18/75ddc64c3f63988f5a1d7e10fb204ffe5762bc663f8023f18ecaf31a332e/wrapt-1.17.2-cp312-cp312-macosx_10_13_x86_64.whl
-      - pypi: .
+      - pypi: ./
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h99b78c6_7.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2024.12.14-hf0a4a13_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.6.1-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-26_osxarm64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-26_osxarm64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-19.1.7-ha82da77_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.6.4-h286801f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.2-h3422bc3_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-5.0.0-13_2_0_hd922786_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-13.2.0-hf226fd6_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-26_osxarm64_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.6.3-h39f12f2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.28-openmp_hf332438_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.48.0-h3f77e49_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-19.1.7-hdb05f8b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h5e97a16_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.2.6-py312h7c1f314_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.4.0-h81ee809_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.8-hc22306f_1_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.12-5_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h92ec313_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h5083fa2_1.conda
@@ -2822,8 +3148,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/42/2a/6d66d0fba41e13e9ca6512a0a51170f43e7e7ed3a8dfa036324100775612/matplotlib-3.10.0-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/47/56/1bb21218e1e692506c220ffabd456af9733fba7aa1b14f73899979f4cc20/ml_dtypes-0.5.1-cp312-cp312-macosx_10_9_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/38/13/23b73a1f300521613f967763ef4ada4737474f9d5b620b7e5ba9e4857ee7/narwhals-1.23.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/e1/28/ddec0147a4933f86ceaca580aa9bb767d5632ecdb1ece6cfb3eab4ac78e5/numba-0.61.0-cp312-cp312-macosx_11_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/54/4a/765b4607f0fecbb239638d610d04ec0a0ded9b4951c56dc68cef79026abf/numpy-2.1.3-cp312-cp312-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/92/4a/fe4e3c2ecad72d88f5f8cd04e7f7cff49e718398a2fac02d2947480a00ca/numba-0.61.2-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/23/cd/066e86230ae37ed0be70aae89aabf03ca8d9f39c8aea0dec8029455b5540/opt_einsum-3.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e1/0c/ad295fd74bfac85358fd579e271cded3ac969de81f62dd0142c426b9da91/pandas-2.2.3-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/b9/d8/f6004d98579a2596c098d1e30d10b248798cceff82d2b77aa914875bfea1/pillow-11.1.0-cp312-cp312-macosx_11_0_arm64.whl
@@ -2837,7 +3162,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0f/dd/84f10e23edd882c6f968c21c2434fe67bd4a528967067515feca9e611e5e/tzdata-2025.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/48/2a/97928387d6ed1c1ebbfd4efc4133a0633546bec8481a2dd5ec961313a1c7/wrapt-1.17.2-cp312-cp312-macosx_11_0_arm64.whl
-      - pypi: .
+      - pypi: ./
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h2466b09_7.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2024.12.14-h56e8100_0.conda
@@ -2894,7 +3219,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/15/06/1dbf478ea45c03e78a6a8c4be4fdc3c3bddea5c8de8a93bc971415e47f0f/wrapt-1.17.2-cp312-cp312-win_amd64.whl
-      - pypi: .
+      - pypi: ./
   plots:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
@@ -2908,21 +3233,30 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2024.12.14-hbcca054_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.6.1-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.43-h712a8e2_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-26_linux64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-26_linux64_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.6.4-h5888daf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-14.2.0-h77fa898_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-14.2.0-h69a702a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-14.2.0-h69a702a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-14.2.0-hd5240d6_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-14.2.0-h77fa898_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-26_linux64_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.6.3-hb9d3cd8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.28-pthreads_h94d23a6_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.48.0-hee588c1_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-14.2.0-hc0a3c3a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.2.6-py312h72c5963_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.4.0-h7b32b05_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.8-h9e4cc4f_1_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.12-5_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
@@ -2946,8 +3280,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/cb/da/8341fd3056419441286c8e26bf436923021005ece0bff5f41906476ae514/llvmlite-0.44.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/a7/b2/d872fc3d753516870d520595ddd8ce4dd44fa797a240999f125f58521ad7/matplotlib-3.10.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/38/13/23b73a1f300521613f967763ef4ada4737474f9d5b620b7e5ba9e4857ee7/narwhals-1.23.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/18/74/6a9f0e6c76c088f8a6aa702eab31734068061dca5cc0f34e8bc1eb447de1/numba-0.61.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/9e/3e/3757f304c704f2f0294a6b8340fcf2be244038be07da4cccf390fa678a9f/numpy-2.1.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/9a/2d/e518df036feab381c23a624dac47f8445ac55686ec7f11083655eb707da3/numba-0.61.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/cf/f7/3367feadd4ab56783b0971c9b7edfbdd68e0c70ce877949a5dd2117ed4a0/palettable-3.3.3-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/38/f8/d8fddee9ed0d0c0f4a2132c1dfcf0e3e53265055da8df952a53e7eaf178c/pandas-2.2.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/38/0d/84200ed6a871ce386ddc82904bfadc0c6b28b0c0ec78176871a4679e40b3/pillow-11.1.0-cp312-cp312-manylinux_2_28_x86_64.whl
@@ -2962,20 +3295,30 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0f/dd/84f10e23edd882c6f968c21c2434fe67bd4a528967067515feca9e611e5e/tzdata-2025.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2a/5a/04cde32b07a7431d4ed0553a76fdb7a61270e78c5fd5a603e190ac389f14/wrapt-1.17.2-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-      - pypi: .
+      - pypi: ./
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-hfdf4475_7.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2024.12.14-h8857fd0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.6.1-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.9.0-26_osx64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.9.0-26_osx64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-19.1.7-hf95d169_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.6.4-h240833e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.4.2-h0d85af4_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-5.0.0-13_2_0_h97931a8_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-13.2.0-h2873a65_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.9.0-26_osx64_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/liblzma-5.6.3-hd471939_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.28-openmp_hbf64a52_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.48.0-hdb6dae5_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.1-hd23fc13_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-19.1.7-ha54dae1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.5-h0622a9a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-2.2.6-py312h6693b03_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.4.0-hc426f3f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.12.8-h9ccd52b_1_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.12-5_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/readline-8.2-h9e318b2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h1abcd95_1.conda
@@ -2999,8 +3342,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/15/86/e3c3195b92e6e492458f16d233e58a1a812aa2bfbef9bdd0fbafcec85c60/llvmlite-0.44.0-cp312-cp312-macosx_10_14_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/44/c7/6b2d8cb7cc251d53c976799cacd3200add56351c175ba89ab9cbd7c1e68a/matplotlib-3.10.0-cp312-cp312-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/38/13/23b73a1f300521613f967763ef4ada4737474f9d5b620b7e5ba9e4857ee7/narwhals-1.23.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/63/c9/c61881e7f2e253e745209f078bbd428ce23b6cf901f7d93afe166720ff95/numba-0.61.0-cp312-cp312-macosx_10_14_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/8a/f0/385eb9970309643cbca4fc6eebc8bb16e560de129c91258dfaa18498da8b/numpy-2.1.3-cp312-cp312-macosx_10_13_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/b4/a0/c6b7b9c615cfa3b98c4c63f4316e3f6b3bbe2387740277006551784218cd/numba-0.61.2-cp312-cp312-macosx_10_14_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/cf/f7/3367feadd4ab56783b0971c9b7edfbdd68e0c70ce877949a5dd2117ed4a0/palettable-3.3.3-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/17/a3/fb2734118db0af37ea7433f57f722c0a56687e14b14690edff0cdb4b7e58/pandas-2.2.3-cp312-cp312-macosx_10_9_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/95/20/9ce6ed62c91c073fcaa23d216e68289e19d95fb8188b9fb7a63d36771db8/pillow-11.1.0-cp312-cp312-macosx_10_13_x86_64.whl
@@ -3015,20 +3357,30 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0f/dd/84f10e23edd882c6f968c21c2434fe67bd4a528967067515feca9e611e5e/tzdata-2025.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/53/18/75ddc64c3f63988f5a1d7e10fb204ffe5762bc663f8023f18ecaf31a332e/wrapt-1.17.2-cp312-cp312-macosx_10_13_x86_64.whl
-      - pypi: .
+      - pypi: ./
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h99b78c6_7.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2024.12.14-hf0a4a13_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.6.1-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-26_osxarm64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-26_osxarm64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-19.1.7-ha82da77_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.6.4-h286801f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.2-h3422bc3_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-5.0.0-13_2_0_hd922786_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-13.2.0-hf226fd6_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-26_osxarm64_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.6.3-h39f12f2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.28-openmp_hf332438_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.48.0-h3f77e49_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-19.1.7-hdb05f8b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h5e97a16_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.2.6-py312h7c1f314_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.4.0-h81ee809_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.8-hc22306f_1_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.12-5_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h92ec313_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h5083fa2_1.conda
@@ -3052,8 +3404,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/d6/53/373b6b8be67b9221d12b24125fd0ec56b1078b660eeae266ec388a6ac9a0/llvmlite-0.44.0-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/42/2a/6d66d0fba41e13e9ca6512a0a51170f43e7e7ed3a8dfa036324100775612/matplotlib-3.10.0-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/38/13/23b73a1f300521613f967763ef4ada4737474f9d5b620b7e5ba9e4857ee7/narwhals-1.23.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/e1/28/ddec0147a4933f86ceaca580aa9bb767d5632ecdb1ece6cfb3eab4ac78e5/numba-0.61.0-cp312-cp312-macosx_11_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/54/4a/765b4607f0fecbb239638d610d04ec0a0ded9b4951c56dc68cef79026abf/numpy-2.1.3-cp312-cp312-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/92/4a/fe4e3c2ecad72d88f5f8cd04e7f7cff49e718398a2fac02d2947480a00ca/numba-0.61.2-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/cf/f7/3367feadd4ab56783b0971c9b7edfbdd68e0c70ce877949a5dd2117ed4a0/palettable-3.3.3-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e1/0c/ad295fd74bfac85358fd579e271cded3ac969de81f62dd0142c426b9da91/pandas-2.2.3-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/b9/d8/f6004d98579a2596c098d1e30d10b248798cceff82d2b77aa914875bfea1/pillow-11.1.0-cp312-cp312-macosx_11_0_arm64.whl
@@ -3068,7 +3419,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0f/dd/84f10e23edd882c6f968c21c2434fe67bd4a528967067515feca9e611e5e/tzdata-2025.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/48/2a/97928387d6ed1c1ebbfd4efc4133a0633546bec8481a2dd5ec961313a1c7/wrapt-1.17.2-cp312-cp312-macosx_11_0_arm64.whl
-      - pypi: .
+      - pypi: ./
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h2466b09_7.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2024.12.14-h56e8100_0.conda
@@ -3124,7 +3475,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/15/06/1dbf478ea45c03e78a6a8c4be4fdc3c3bddea5c8de8a93bc971415e47f0f/wrapt-1.17.2-cp312-cp312-win_amd64.whl
-      - pypi: .
+      - pypi: ./
 packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
   sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
@@ -3179,7 +3530,7 @@ packages:
   - pytest>=7.0 ; extra == 'test'
   - trustme ; extra == 'test'
   - truststore>=0.9.1 ; python_full_version >= '3.10' and extra == 'test'
-  - uvloop>=0.21 ; python_full_version < '3.14' and platform_python_implementation == 'CPython' and platform_system != 'Windows' and extra == 'test'
+  - uvloop>=0.21 ; python_full_version < '3.14' and platform_python_implementation == 'CPython' and sys_platform != 'win32' and extra == 'test'
   - packaging ; extra == 'doc'
   - sphinx~=7.4 ; extra == 'doc'
   - sphinx-rtd-theme ; extra == 'doc'
@@ -3993,7 +4344,7 @@ packages:
   version: 8.1.8
   sha256: 63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2
   requires_dist:
-  - colorama ; platform_system == 'Windows'
+  - colorama ; sys_platform == 'win32'
   - importlib-metadata ; python_full_version < '3.8'
   requires_python: '>=3.7'
 - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
@@ -5177,7 +5528,7 @@ packages:
   version: 6.29.5
   sha256: afdb66ba5aa354b09b91379bac28ae4afebbb30e8b39510c9690afb7a10421b5
   requires_dist:
-  - appnope ; platform_system == 'Darwin'
+  - appnope ; sys_platform == 'darwin'
   - comm>=0.1.1
   - debugpy>=1.6.5
   - ipython>=7.23.1
@@ -7233,6 +7584,21 @@ packages:
   purls: []
   size: 100393
   timestamp: 1702724383534
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.13.5-h8d12d68_1.conda
+  sha256: c3b05bdc40d27a9249f0bb60f3f71718f94104b8bcd200163a6c9d4ade7aa052
+  md5: 1a21e49e190d1ffe58531a81b6e400e1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - icu >=75.1,<76.0a0
+  - libgcc >=13
+  - libiconv >=1.17,<2.0a0
+  - liblzma >=5.6.3,<6.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 690589
+  timestamp: 1733443667823
 - conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.13.5-hebb159f_1.conda
   sha256: b9332bd8d47a72b7b8fa2ae13c24387ed4f5fd4e1f7ecf0031068c6a755267ae
   md5: 23c629eba5239465a34bca0ed9c0b5d3
@@ -7667,6 +8033,15 @@ packages:
   purls: []
   size: 301114
   timestamp: 1608166207763
+- conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-nlopt-2.4.2-3.tar.bz2
+  sha256: f9d5dc98a9f897032b27792b67504512a9697ea110c8641f0db01611c38c5e88
+  md5: 884adad87155bba07dcf2f2f9652a217
+  depends:
+  - msys2-conda-epoch ==20160418
+  license: LGPLv2.1+
+  purls: []
+  size: 465823
+  timestamp: 1608166299311
 - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-pcre2-10.34-0.tar.bz2
   sha256: 99ac81e44f7f5b8931848972bb7198c1fdd5921b065e587b09ccee249f5274ce
   md5: f6ca05c091543bd4c526a2598fbf2467
@@ -8024,7 +8399,7 @@ packages:
   - numpy>=1.23.5
   - scipy>=1.8.0
   - pandas>=2.2.0
-  - tzdata ; platform_system == 'Emscripten' or platform_system == 'Windows'
+  - tzdata ; sys_platform == 'emscripten' or sys_platform == 'win32'
   - mizani[doc] ; extra == 'all'
   - mizani[build] ; extra == 'all'
   - mizani[lint] ; extra == 'all'
@@ -8342,6 +8717,50 @@ packages:
   version: 1.6.0
   sha256: 87af6efd6b5e897c81050477ef65c62e2b2f35d51703cae01aff2905b1852e1c
   requires_python: '>=3.5'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/nlopt-2.9.0-py312h1d0b465_0.conda
+  sha256: 8b7b12966321ba52202a33afa57cf1fdc352a85c23254f748347af9c8787ce96
+  md5: 80fd033d649e06f8dedd58921d858ef4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - numpy >=1.19,<3
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: LGPL-2.1-or-later
+  purls:
+  - pkg:pypi/nlopt?source=hash-mapping
+  size: 409877
+  timestamp: 1731404210333
+- conda: https://conda.anaconda.org/conda-forge/osx-64/nlopt-2.9.0-py312hb87d94a_0.conda
+  sha256: ac0a11b4f7deb615674b99efe027a5b1bb72a8d5324a2d8488621808bb80188c
+  md5: 0b2c885da5d4547cbee129f6fa0d1ce6
+  depends:
+  - __osx >=10.13
+  - libcxx >=18
+  - numpy >=1.19,<3
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: LGPL-2.1-or-later
+  purls:
+  - pkg:pypi/nlopt?source=hash-mapping
+  size: 387804
+  timestamp: 1731404271809
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/nlopt-2.9.0-py312hace9f44_0.conda
+  sha256: 03eb36d02b37a37b975f7bb52ee29c7cb86cd85ec8cf0e59abf9d168c916369b
+  md5: e4c56549b1942916c11f8801f0369beb
+  depends:
+  - __osx >=11.0
+  - libcxx >=18
+  - numpy >=1.19,<3
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  license: LGPL-2.1-or-later
+  purls:
+  - pkg:pypi/nlopt?source=hash-mapping
+  size: 325827
+  timestamp: 1731404450371
 - pypi: https://files.pythonhosted.org/packages/d2/1d/1b658dbd2b9fa9c4c9f32accbfc0205d532c8c6194dc0f2a4c0428e7128a/nodeenv-1.9.1-py2.py3-none-any.whl
   name: nodeenv
   version: 1.9.1
@@ -8358,22 +8777,6 @@ packages:
   - pytest-jupyter ; extra == 'test'
   - pytest-tornasync ; extra == 'test'
   requires_python: '>=3.7'
-- pypi: https://files.pythonhosted.org/packages/18/74/6a9f0e6c76c088f8a6aa702eab31734068061dca5cc0f34e8bc1eb447de1/numba-0.61.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
-  name: numba
-  version: 0.61.0
-  sha256: ffe9fe373ed30638d6e20a0269f817b2c75d447141f55a675bfcf2d1fe2e87fb
-  requires_dist:
-  - llvmlite>=0.44.0.dev0,<0.45
-  - numpy>=1.24,<2.2
-  requires_python: '>=3.10'
-- pypi: https://files.pythonhosted.org/packages/63/c9/c61881e7f2e253e745209f078bbd428ce23b6cf901f7d93afe166720ff95/numba-0.61.0-cp312-cp312-macosx_10_14_x86_64.whl
-  name: numba
-  version: 0.61.0
-  sha256: 152146ecdbb8d8176f294e9f755411e6f270103a11c3ff50cecc413f794e52c8
-  requires_dist:
-  - llvmlite>=0.44.0.dev0,<0.45
-  - numpy>=1.24,<2.2
-  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/94/4f/8357a99a14f331b865a42cb4756ae37da85599b9c95e01277ea10361e91a/numba-0.61.0-cp312-cp312-win_amd64.whl
   name: numba
   version: 0.61.0
@@ -8382,34 +8785,94 @@ packages:
   - llvmlite>=0.44.0.dev0,<0.45
   - numpy>=1.24,<2.2
   requires_python: '>=3.10'
-- pypi: https://files.pythonhosted.org/packages/e1/28/ddec0147a4933f86ceaca580aa9bb767d5632ecdb1ece6cfb3eab4ac78e5/numba-0.61.0-cp312-cp312-macosx_11_0_arm64.whl
+- pypi: https://files.pythonhosted.org/packages/92/4a/fe4e3c2ecad72d88f5f8cd04e7f7cff49e718398a2fac02d2947480a00ca/numba-0.61.2-cp312-cp312-macosx_11_0_arm64.whl
   name: numba
-  version: 0.61.0
-  sha256: 5cafa6095716fcb081618c28a8d27bf7c001e09696f595b41836dec114be2905
+  version: 0.61.2
+  sha256: 4ddce10009bc097b080fc96876d14c051cc0c7679e99de3e0af59014dab7dfe8
   requires_dist:
   - llvmlite>=0.44.0.dev0,<0.45
-  - numpy>=1.24,<2.2
+  - numpy>=1.24,<2.3
   requires_python: '>=3.10'
-- pypi: https://files.pythonhosted.org/packages/54/4a/765b4607f0fecbb239638d610d04ec0a0ded9b4951c56dc68cef79026abf/numpy-2.1.3-cp312-cp312-macosx_11_0_arm64.whl
-  name: numpy
-  version: 2.1.3
-  sha256: 13138eadd4f4da03074851a698ffa7e405f41a0845a6b1ad135b81596e4e9958
+- pypi: https://files.pythonhosted.org/packages/9a/2d/e518df036feab381c23a624dac47f8445ac55686ec7f11083655eb707da3/numba-0.61.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+  name: numba
+  version: 0.61.2
+  sha256: 5b1bb509d01f23d70325d3a5a0e237cbc9544dd50e50588bc581ba860c213546
+  requires_dist:
+  - llvmlite>=0.44.0.dev0,<0.45
+  - numpy>=1.24,<2.3
   requires_python: '>=3.10'
-- pypi: https://files.pythonhosted.org/packages/8a/f0/385eb9970309643cbca4fc6eebc8bb16e560de129c91258dfaa18498da8b/numpy-2.1.3-cp312-cp312-macosx_10_13_x86_64.whl
-  name: numpy
-  version: 2.1.3
-  sha256: f55ba01150f52b1027829b50d70ef1dafd9821ea82905b63936668403c3b471e
-  requires_python: '>=3.10'
-- pypi: https://files.pythonhosted.org/packages/9e/3e/3757f304c704f2f0294a6b8340fcf2be244038be07da4cccf390fa678a9f/numpy-2.1.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-  name: numpy
-  version: 2.1.3
-  sha256: 2312b2aa89e1f43ecea6da6ea9a810d06aae08321609d8dc0d0eda6d946a541b
+- pypi: https://files.pythonhosted.org/packages/b4/a0/c6b7b9c615cfa3b98c4c63f4316e3f6b3bbe2387740277006551784218cd/numba-0.61.2-cp312-cp312-macosx_10_14_x86_64.whl
+  name: numba
+  version: 0.61.2
+  sha256: 34fba9406078bac7ab052efbf0d13939426c753ad72946baaa5bf9ae0ebb8dd2
+  requires_dist:
+  - llvmlite>=0.44.0.dev0,<0.45
+  - numpy>=1.24,<2.3
   requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/a6/84/fa11dad3404b7634aaab50733581ce11e5350383311ea7a7010f464c0170/numpy-2.1.3-cp312-cp312-win_amd64.whl
   name: numpy
   version: 2.1.3
   sha256: 0d30c543f02e84e92c4b1f415b7c6b5326cbe45ee7882b6b77db7195fb971e3a
   requires_python: '>=3.10'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.2.6-py312h72c5963_0.conda
+  sha256: c3b3ff686c86ed3ec7a2cc38053fd6234260b64286c2bd573e436156f39d14a7
+  md5: 17fac9db62daa5c810091c2882b28f45
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libgcc >=13
+  - liblapack >=3.9.0,<4.0a0
+  - libstdcxx >=13
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/numpy?source=hash-mapping
+  size: 8490501
+  timestamp: 1747545073507
+- conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-2.2.6-py312h6693b03_0.conda
+  sha256: 22bc6d7ac48df0a3130a24b9426a004977cb5dc8b5edbb3f3d2579a478121cbd
+  md5: 486e149e3648cbf8b92b0512db99bce3
+  depends:
+  - __osx >=10.13
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=18
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/numpy?source=hash-mapping
+  size: 7691449
+  timestamp: 1747545110970
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.2.6-py312h7c1f314_0.conda
+  sha256: f5d69838c10a6c34a6de8b643b1795bf6fa9b22642ede5fc296d5673eabc344e
+  md5: fff7ab22b4f5c7036d3c2e1f92632fa4
+  depends:
+  - __osx >=11.0
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=18
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/numpy?source=hash-mapping
+  size: 6437085
+  timestamp: 1747545094808
 - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.4.0-h7b32b05_1.conda
   sha256: f62f6bca4a33ca5109b6d571b052a394d836956d21b25b7ffd03376abf7a481f
   md5: 4ce6875f75469b2757a65e10a5d05e31
@@ -9258,7 +9721,7 @@ packages:
   - matplotlib ; extra == 'graph'
   - altair>=5.4.0 ; extra == 'plot'
   - great-tables>=0.8.0 ; extra == 'style'
-  - tzdata ; platform_system == 'Windows' and extra == 'timezone'
+  - tzdata ; sys_platform == 'win32' and extra == 'timezone'
   - cudf-polars-cu12 ; extra == 'gpu'
   - polars[async,cloudpickle,database,deltalake,excel,fsspec,graph,iceberg,numpy,pandas,plot,pyarrow,pydantic,style,timezone] ; extra == 'all'
   requires_python: '>=3.9'
@@ -9292,7 +9755,7 @@ packages:
   - matplotlib ; extra == 'graph'
   - altair>=5.4.0 ; extra == 'plot'
   - great-tables>=0.8.0 ; extra == 'style'
-  - tzdata ; platform_system == 'Windows' and extra == 'timezone'
+  - tzdata ; sys_platform == 'win32' and extra == 'timezone'
   - cudf-polars-cu12 ; extra == 'gpu'
   - polars[async,cloudpickle,database,deltalake,excel,fsspec,graph,iceberg,numpy,pandas,plot,pyarrow,pydantic,style,timezone] ; extra == 'all'
   requires_python: '>=3.9'
@@ -9326,7 +9789,7 @@ packages:
   - matplotlib ; extra == 'graph'
   - altair>=5.4.0 ; extra == 'plot'
   - great-tables>=0.8.0 ; extra == 'style'
-  - tzdata ; platform_system == 'Windows' and extra == 'timezone'
+  - tzdata ; sys_platform == 'win32' and extra == 'timezone'
   - cudf-polars-cu12 ; extra == 'gpu'
   - polars[async,cloudpickle,database,deltalake,excel,fsspec,graph,iceberg,numpy,pandas,plot,pyarrow,pydantic,style,timezone] ; extra == 'all'
   requires_python: '>=3.9'
@@ -9360,7 +9823,7 @@ packages:
   - matplotlib ; extra == 'graph'
   - altair>=5.4.0 ; extra == 'plot'
   - great-tables>=0.8.0 ; extra == 'style'
-  - tzdata ; platform_system == 'Windows' and extra == 'timezone'
+  - tzdata ; sys_platform == 'win32' and extra == 'timezone'
   - cudf-polars-cu12 ; extra == 'gpu'
   - polars[async,cloudpickle,database,deltalake,excel,fsspec,graph,iceberg,numpy,pandas,plot,pyarrow,pydantic,style,timezone] ; extra == 'all'
   requires_python: '>=3.9'
@@ -9602,7 +10065,7 @@ packages:
   - pydantic-core==2.27.2
   - typing-extensions>=4.12.2
   - email-validator>=2.0.0 ; extra == 'email'
-  - tzdata ; python_full_version >= '3.9' and platform_system == 'Windows' and extra == 'timezone'
+  - tzdata ; python_full_version >= '3.9' and sys_platform == 'win32' and extra == 'timezone'
   requires_python: '>=3.8'
 - pypi: https://files.pythonhosted.org/packages/1f/ea/cd7209a889163b8dcca139fe32b9687dd05249161a3edda62860430457a5/pydantic_core-2.27.2-cp312-cp312-win_amd64.whl
   name: pydantic-core
@@ -9632,10 +10095,10 @@ packages:
   requires_dist:
   - typing-extensions>=4.6.0,!=4.7.0
   requires_python: '>=3.8'
-- pypi: .
+- pypi: ./
   name: pyfixest
   version: 0.29.0
-  sha256: 9e689c605bb5d7716a55d28dba9466e794eb8c66e5f1f6f658294ef3c6ea5eab
+  sha256: 51ec4b84fe2035483ba10a708f81cd98c87d8e164111b846638b34c631b49198
   requires_dist:
   - scipy>=1.6
   - formulaic>=1.1.0
@@ -9708,26 +10171,12 @@ packages:
   sha256: bb7b21bec57ecdba3f6f44c856ebebdf6549fd6e80661bd44fd5094236729242
   requires_dist:
   - ordered-set
-  - markupsafe==2.0.1 ; extra == 'all'
-  - matplotlib ; extra == 'all'
-  - sphinx ; extra == 'all'
-  - coverage ; extra == 'all'
-  - pytest-cov ; extra == 'all'
-  - black ; extra == 'all'
-  - quantities ; extra == 'all'
-  - alabaster<0.7.12 ; extra == 'all'
-  - isort ; extra == 'all'
-  - twine ; extra == 'all'
-  - pytest>=4.6 ; extra == 'all'
-  - jinja2<3.0 ; extra == 'all'
-  - numpy ; extra == 'all'
   - sphinx ; extra == 'docs'
   - jinja2<3.0 ; extra == 'docs'
   - markupsafe==2.0.1 ; extra == 'docs'
   - alabaster<0.7.12 ; extra == 'docs'
-  - matplotlib ; extra == 'matplotlib'
   - numpy ; extra == 'matrices'
-  - twine ; extra == 'packaging'
+  - matplotlib ; extra == 'matplotlib'
   - quantities ; extra == 'quantities'
   - numpy ; extra == 'quantities'
   - pytest>=4.6 ; extra == 'testing'
@@ -9735,6 +10184,20 @@ packages:
   - pytest-cov ; extra == 'testing'
   - black ; extra == 'testing'
   - isort ; extra == 'testing'
+  - twine ; extra == 'packaging'
+  - pytest>=4.6 ; extra == 'all'
+  - markupsafe==2.0.1 ; extra == 'all'
+  - alabaster<0.7.12 ; extra == 'all'
+  - jinja2<3.0 ; extra == 'all'
+  - sphinx ; extra == 'all'
+  - quantities ; extra == 'all'
+  - matplotlib ; extra == 'all'
+  - numpy ; extra == 'all'
+  - black ; extra == 'all'
+  - coverage ; extra == 'all'
+  - pytest-cov ; extra == 'all'
+  - isort ; extra == 'all'
+  - twine ; extra == 'all'
 - pypi: https://files.pythonhosted.org/packages/1c/a7/c8a2d361bf89c0d9577c934ebb7421b25dc84bf3a8e3ac0a40aed9acc547/pyparsing-3.2.1-py3-none-any.whl
   name: pyparsing
   version: 3.2.1
@@ -10116,6 +10579,36 @@ packages:
   purls: []
   size: 17981
   timestamp: 1722424618353
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-abind-1.4_5-r41hc72bb7e_1004.tar.bz2
+  sha256: f9ee7b288962935fff488a03f28f8df4ddee5d2a2d4b72a3ccbac28609f28da3
+  md5: 831186670e5786df30f8ddeb5a623c5a
+  depends:
+  - r-base >=4.1,<4.2.0a0
+  license: LGPL (>= 2)
+  license_family: LGPL
+  purls: []
+  size: 79290
+  timestamp: 1665193706296
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-abind-1.4_5-r43hc72bb7e_1006.conda
+  sha256: c70b75fbc7f7b30937b6f3f2faeb036a9105b39a0bca025ca5bef915eb17ac29
+  md5: 75d26096ffa98e1cde7b27b9530899a1
+  depends:
+  - r-base >=4.3,<4.4.0a0
+  license: LGPL (>= 2)
+  license_family: LGPL
+  purls: []
+  size: 78350
+  timestamp: 1719758967315
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-assertthat-0.2.1-r41hc72bb7e_3.tar.bz2
+  sha256: 357b1d5fe3528af7830cdccc4c7c5b2b1b0e3c6fb26f71c7f5a4fd2cf5a7d193
+  md5: 222e349b4a7c1fe7eee85277254770a7
+  depends:
+  - r-base >=4.1,<4.2.0a0
+  license: GPL-3
+  license_family: GPL3
+  purls: []
+  size: 73108
+  timestamp: 1665186028341
 - conda: https://conda.anaconda.org/conda-forge/linux-64/r-backports-1.5.0-r43hb1dbf0f_1.conda
   sha256: 1956bb988860b03d6b8d8a103a001af8b3e09f22c2f8417b5f23ee0f78891e15
   md5: 12431f6441e6e7b9181747123e88fe9e
@@ -10335,6 +10828,31 @@ packages:
   purls: []
   size: 56103327
   timestamp: 1734517537925
+- conda: https://conda.anaconda.org/conda-forge/win-64/r-bit-4.0.5-r41h6d2157b_1.conda
+  sha256: 0b38e863d0db9ec7945b69a7354aa33082d1ad38f74972e709228df179b12b0b
+  md5: aadf7f6f494952b4fa0daac7a4c5cde3
+  depends:
+  - m2w64-gcc-libs
+  - m2w64-gcc-libs-core
+  - r-base >=4.1,<4.2.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL2
+  purls: []
+  size: 1077407
+  timestamp: 1686754349911
+- conda: https://conda.anaconda.org/conda-forge/win-64/r-bit64-4.0.5-r41h6d2157b_2.conda
+  sha256: fd81d8484e529491a9a7bc3013cf478671bf068a9a8759f98f7ac434b2b638d5
+  md5: 0c4bf40b64e911dd39df72778f22bad0
+  depends:
+  - m2w64-gcc-libs
+  - m2w64-gcc-libs-core
+  - r-base >=4.1,<4.2.0a0
+  - r-bit >=4.0.0
+  license: GPL-2.0-only
+  license_family: GPL2
+  purls: []
+  size: 492879
+  timestamp: 1686764928403
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-boot-1.3_28.1-r41hc72bb7e_0.conda
   sha256: 0f85cde3a6a1dd13571681d701df75ad454fba91178b76f9f65ed0b4747b4011
   md5: b2133512f437cb9b595e96fe76498e72
@@ -10397,6 +10915,170 @@ packages:
   purls: []
   size: 1799810
   timestamp: 1727408326218
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-car-3.1_2-r41hc72bb7e_0.conda
+  sha256: 003bb19190b6cd199ee474ffab8fd68258902dba0bc023568534cfb019406468
+  md5: e6e2964d4eddd1c4ebd720bbb262d027
+  depends:
+  - r-abind
+  - r-base >=4.1,<4.2.0a0
+  - r-cardata >=3.0_0
+  - r-lme4
+  - r-maptools
+  - r-mass
+  - r-mgcv
+  - r-nlme
+  - r-nnet
+  - r-pbkrtest >=0.4_4
+  - r-quantreg
+  - r-rio
+  license: GPL-2.0-or-later
+  license_family: GPL2
+  purls: []
+  size: 1713196
+  timestamp: 1680176389201
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-car-3.1_3-r43hc72bb7e_0.conda
+  sha256: 88b9d02b51a24c384187e0834724291be2f8382b808c64f803bfc16b5d0bcce1
+  md5: 57adea13a63a6edd35accd59edb00292
+  depends:
+  - r-abind
+  - r-base >=4.3,<4.4.0a0
+  - r-cardata >=3.0_0
+  - r-formula
+  - r-lme4 >=1.1_27.1
+  - r-mass
+  - r-mgcv
+  - r-nlme
+  - r-nnet
+  - r-pbkrtest >=0.4_4
+  - r-quantreg
+  - r-scales
+  license: GPL-2.0-or-later
+  license_family: GPL2
+  purls: []
+  size: 1518150
+  timestamp: 1727640066099
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-cardata-3.0_5-r41hc72bb7e_1.tar.bz2
+  sha256: 653aceff7a48b459eed0dce6d5ca5491d61adbb6aaea9daed53c60f5ddf61568
+  md5: b1a4625a136faf64f1b06d7d7df8202a
+  depends:
+  - r-base >=4.1,<4.2.0a0
+  license: GPL (>= 2)
+  license_family: GPL3
+  purls: []
+  size: 1916451
+  timestamp: 1665200176948
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-cardata-3.0_5-r43hc72bb7e_3.conda
+  sha256: 0f4e4866fa0c7d801a82a485e4dcf27ed1640dcba0b50f1d33f553614613a5eb
+  md5: 41a58b866ab063e558805e7da172288c
+  depends:
+  - r-base >=4.3,<4.4.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL3
+  purls: []
+  size: 1829507
+  timestamp: 1719780216058
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-caret-6.0_94-r43hdb488b9_2.conda
+  sha256: a574f59339d841321d27b590b589436d80d21b9fe292e17db6f98137468569a5
+  md5: 17362d3b7f9ea633d976c021dbb89b3d
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  - r-base >=4.3,<4.4.0a0
+  - r-e1071
+  - r-foreach
+  - r-ggplot2
+  - r-lattice >=0.20
+  - r-modelmetrics >=1.2.2.2
+  - r-nlme
+  - r-plyr
+  - r-proc
+  - r-recipes >=0.1.10
+  - r-reshape2
+  - r-withr >=2.0.0
+  license: GPL-2.0-or-later
+  license_family: GPL2
+  purls: []
+  size: 3566406
+  timestamp: 1722170719919
+- conda: https://conda.anaconda.org/conda-forge/osx-64/r-caret-6.0_94-r43h6b9d099_2.conda
+  sha256: d5b5abf4e7ed37d4f971d79daff53e2390ef34deba74a3067ae70cdcf5a16222
+  md5: 8d004d63eadb19626bb0d575b707e14f
+  depends:
+  - __osx >=10.13
+  - r-base >=4.3,<4.4.0a0
+  - r-e1071
+  - r-foreach
+  - r-ggplot2
+  - r-lattice >=0.20
+  - r-modelmetrics >=1.2.2.2
+  - r-nlme
+  - r-plyr
+  - r-proc
+  - r-recipes >=0.1.10
+  - r-reshape2
+  - r-withr >=2.0.0
+  license: GPL-2.0-or-later
+  license_family: GPL2
+  purls: []
+  size: 3563841
+  timestamp: 1722170824858
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-caret-6.0_94-r43h07cda29_2.conda
+  sha256: a8aad7042b1179fcfbe40da6d606a4415f7491d838b9e405189c1848ee1fc08d
+  md5: 57004b1b6b0e1c94877c90a1eb3a998e
+  depends:
+  - __osx >=11.0
+  - r-base >=4.3,<4.4.0a0
+  - r-e1071
+  - r-foreach
+  - r-ggplot2
+  - r-lattice >=0.20
+  - r-modelmetrics >=1.2.2.2
+  - r-nlme
+  - r-plyr
+  - r-proc
+  - r-recipes >=0.1.10
+  - r-reshape2
+  - r-withr >=2.0.0
+  license: GPL-2.0-or-later
+  license_family: GPL2
+  purls: []
+  size: 3566290
+  timestamp: 1722170917157
+- conda: https://conda.anaconda.org/conda-forge/win-64/r-caret-6.0_94-r41h6d2157b_1.conda
+  sha256: 7654b4b5b7762141bb146e47b3a62050d6b58f7a62cf964434108e3cacb2d390
+  md5: 4d9af19170ff22d919817547d4fb8612
+  depends:
+  - m2w64-gcc-libs
+  - m2w64-gcc-libs-core
+  - r-base >=4.1,<4.2.0a0
+  - r-e1071
+  - r-foreach
+  - r-ggplot2
+  - r-lattice >=0.20
+  - r-modelmetrics >=1.2.2.2
+  - r-nlme
+  - r-plyr
+  - r-proc
+  - r-recipes >=0.1.10
+  - r-reshape2
+  - r-withr >=2.0.0
+  license: GPL-2.0-or-later
+  license_family: GPL2
+  purls: []
+  size: 3567619
+  timestamp: 1687729498048
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-cellranger-1.1.0-r41hc72bb7e_1005.tar.bz2
+  sha256: 3da55fd29eeaac5e523e4e70e73b507d62b3e51c107108f290b87d8c33bab484
+  md5: 3adc15341fd416febf7168a2fe895e30
+  depends:
+  - r-base >=4.1,<4.2.0a0
+  - r-rematch
+  - r-tibble
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 111990
+  timestamp: 1665205837360
 - conda: https://conda.anaconda.org/conda-forge/linux-64/r-class-7.3_23-r43h2b5f3a1_0.conda
   sha256: da6ad00ad49a2d24e0a382ff50add0ee176bd0ee02f2c943180b56c5afd14749
   md5: f5a6207da238d9d499f2a3e0a7f84c8c
@@ -10405,8 +11087,6 @@ packages:
   - libgcc >=13
   - r-base >=4.3,<4.4.0a0
   - r-mass
-  arch: x86_64
-  platform: linux
   license: GPL-2.0-or-later
   license_family: GPL3
   purls: []
@@ -10419,8 +11099,6 @@ packages:
   - __osx >=10.13
   - r-base >=4.3,<4.4.0a0
   - r-mass
-  arch: x86_64
-  platform: osx
   license: GPL-2.0-or-later
   license_family: GPL3
   purls: []
@@ -10433,8 +11111,6 @@ packages:
   - __osx >=11.0
   - r-base >=4.3,<4.4.0a0
   - r-mass
-  arch: arm64
-  platform: osx
   license: GPL-2.0-or-later
   license_family: GPL3
   purls: []
@@ -10448,8 +11124,6 @@ packages:
   - m2w64-gcc-libs-core
   - r-base >=4.1,<4.2.0a0
   - r-mass
-  arch: x86_64
-  platform: win
   license: GPL-2.0-or-later
   license_family: GPL3
   purls: []
@@ -10504,6 +11178,85 @@ packages:
   purls: []
   size: 1256562
   timestamp: 1719055677971
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-clipr-0.8.0-r41hc72bb7e_1.tar.bz2
+  sha256: 57500da241002cebfa781dbd1d0a8f04b0a17d0fddcba0a000bde6913cfbaadc
+  md5: 150a902aa834ca07fc74967b4e653207
+  depends:
+  - r-base >=4.1,<4.2.0a0
+  license: GPL-3.0-only
+  license_family: GPL3
+  purls: []
+  size: 69801
+  timestamp: 1665193624393
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-clock-0.7.1-r43h0d4f4ea_0.conda
+  sha256: dcb2cca29817a5164718014d3b026f25d599e7fe5fa76d60f539869be562c3d0
+  md5: fd4e0a0df212a19bd7849de734b0e9c6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - r-base >=4.3,<4.4.0a0
+  - r-cpp11 >=0.4.0
+  - r-ellipsis >=0.3.1
+  - r-rlang >=0.4.10
+  - r-tzdb >=0.2.0
+  - r-vctrs >=0.3.7
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 1682058
+  timestamp: 1721465099562
+- conda: https://conda.anaconda.org/conda-forge/osx-64/r-clock-0.7.1-r43h25d921d_0.conda
+  sha256: 99be494b6b98ebb0995da79d77a0350aea6d8b8dd5fbc1754a0c05dd486001e9
+  md5: 5ca0204886a554ad2165468a91cd38b5
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  - r-base >=4.3,<4.4.0a0
+  - r-cpp11 >=0.4.0
+  - r-ellipsis >=0.3.1
+  - r-rlang >=0.4.10
+  - r-tzdb >=0.2.0
+  - r-vctrs >=0.3.7
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 1631052
+  timestamp: 1721465205439
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-clock-0.7.1-r43hd76f289_0.conda
+  sha256: 059b19dae3fb99865b74417762e910322370e9ca5dfb8c5962e7afa3eef07401
+  md5: 2326e5e5988dd4ad2c4dac23bcc29119
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  - r-base >=4.3,<4.4.0a0
+  - r-cpp11 >=0.4.0
+  - r-ellipsis >=0.3.1
+  - r-rlang >=0.4.10
+  - r-tzdb >=0.2.0
+  - r-vctrs >=0.3.7
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 1640411
+  timestamp: 1721465276588
+- conda: https://conda.anaconda.org/conda-forge/win-64/r-clock-0.7.0-r41ha856d6a_1.conda
+  sha256: 62db861fae0f003544f0ce006749dfad856eb8f4155d74b2a04e91cb49315975
+  md5: 515fadc993d206c838e079969b71184b
+  depends:
+  - m2w64-gcc-libs
+  - m2w64-gcc-libs-core
+  - r-base >=4.1,<4.2.0a0
+  - r-cpp11 >=0.4.0
+  - r-ellipsis >=0.3.1
+  - r-rlang >=0.4.10
+  - r-tzdb >=0.2.0
+  - r-vctrs >=0.3.7
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 1618275
+  timestamp: 1686899976102
 - conda: https://conda.anaconda.org/conda-forge/linux-64/r-cluster-2.1.8.1-r43hb67ce94_0.conda
   sha256: 28b7379df902101a9626cd6d29628705f47988d4737ea7b185d10d9c0d476954
   md5: 7e4d0cf4e3378df9847f3843b9a8e087
@@ -10513,8 +11266,6 @@ packages:
   - libgfortran
   - libgfortran5 >=13.3.0
   - r-base >=4.3,<4.4.0a0
-  arch: x86_64
-  platform: linux
   license: GPL-2.0-or-later
   license_family: GPL3
   purls: []
@@ -10528,8 +11279,6 @@ packages:
   - libgfortran 5.*
   - libgfortran5 >=13.2.0
   - r-base >=4.3,<4.4.0a0
-  arch: x86_64
-  platform: osx
   license: GPL-2.0-or-later
   license_family: GPL3
   purls: []
@@ -10543,8 +11292,6 @@ packages:
   - libgfortran 5.*
   - libgfortran5 >=13.2.0
   - r-base >=4.3,<4.4.0a0
-  arch: arm64
-  platform: osx
   license: GPL-2.0-or-later
   license_family: GPL3
   purls: []
@@ -10557,8 +11304,6 @@ packages:
   - m2w64-gcc-libs
   - m2w64-gcc-libs-core
   - r-base >=4.1,<4.2.0a0
-  arch: x86_64
-  platform: win
   license: GPL-2.0-or-later
   license_family: GPL3
   purls: []
@@ -10630,6 +11375,120 @@ packages:
   purls: []
   size: 2498387
   timestamp: 1686753970050
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-conquer-1.3.3-r43hb424bfc_4.conda
+  sha256: 1c51fc99e73638e2d50676798c4eaf6a4db644404ae4feb9fd56b770aedae237
+  md5: f679546860ca8c4a8a492e9985d729aa
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - _openmp_mutex >=4.5
+  - libblas >=3.9.0,<4.0a0
+  - libgcc-ng >=12
+  - liblapack >=3.9.0,<4.0a0
+  - libstdcxx-ng >=12
+  - r-base >=4.3,<4.4.0a0
+  - r-caret
+  - r-matrix
+  - r-matrixstats
+  - r-rcpp >=1.0.3
+  - r-rcpparmadillo >=0.9.850.1.0
+  license: GPL-3.0-only
+  license_family: GPL3
+  purls: []
+  size: 539912
+  timestamp: 1722713305471
+- conda: https://conda.anaconda.org/conda-forge/osx-64/r-conquer-1.3.3-r43h6a638e2_4.conda
+  sha256: 9a748199896d4f4f888d5172a599dc8a05c88570e39cb0c92262724c38c4e742
+  md5: 2dc29f51e111f9bfe9077f92fd3c09bd
+  depends:
+  - __osx >=10.13
+  - libblas >=3.9.0,<4.0a0
+  - libcxx >=16
+  - liblapack >=3.9.0,<4.0a0
+  - llvm-openmp >=16.0.6
+  - r-base >=4.3,<4.4.0a0
+  - r-caret
+  - r-matrix
+  - r-matrixstats
+  - r-rcpp >=1.0.3
+  - r-rcpparmadillo >=0.9.850.1.0
+  license: GPL-3.0-only
+  license_family: GPL3
+  purls: []
+  size: 538358
+  timestamp: 1722713366470
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-conquer-1.3.3-r43h2743ada_4.conda
+  sha256: 80600d118678701a2ced5bf29c5b33b31d9eb408b2970ae7ea69f62f94b37f84
+  md5: ecd4a1fa01b3cc01727d05dac556691a
+  depends:
+  - __osx >=11.0
+  - libblas >=3.9.0,<4.0a0
+  - libcxx >=16
+  - liblapack >=3.9.0,<4.0a0
+  - llvm-openmp >=16.0.6
+  - r-base >=4.3,<4.4.0a0
+  - r-caret
+  - r-matrix
+  - r-matrixstats
+  - r-rcpp >=1.0.3
+  - r-rcpparmadillo >=0.9.850.1.0
+  license: GPL-3.0-only
+  license_family: GPL3
+  purls: []
+  size: 500379
+  timestamp: 1722713513783
+- conda: https://conda.anaconda.org/conda-forge/win-64/r-conquer-1.3.3-r41h3c88c7c_3.conda
+  sha256: 14187481714afaf7d449fa6eb5fe81812a2c90f9ce4632d3f255eab6662bda0b
+  md5: d151462e9bafa65c505016d426041b15
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - m2w64-gcc-libs
+  - m2w64-gcc-libs-core
+  - r-base >=4.1,<4.2.0a0
+  - r-caret
+  - r-matrix
+  - r-matrixstats
+  - r-rcpp >=1.0.3
+  - r-rcpparmadillo >=0.9.850.1.0
+  license: GPL-3.0-only
+  license_family: GPL3
+  purls: []
+  size: 471978
+  timestamp: 1722326811531
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-cowplot-1.1.3-r43hc72bb7e_1.conda
+  sha256: 95f686d7ab521846cefdb9390b18927df859610bece8ec3f0e605a384780f008
+  md5: 2f20d2368e1258a42227b1af7b1f7270
+  depends:
+  - r-base >=4.3,<4.4.0a0
+  - r-ggplot2 >2.2.1
+  - r-gtable
+  - r-rlang
+  - r-scales
+  license: GPL-2.0-only
+  license_family: GPL2
+  purls: []
+  size: 1309065
+  timestamp: 1721319126328
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-cpp11-0.5.2-r41hc72bb7e_0.conda
+  sha256: 043f25857856b0d1547685b75687504a375ba8d0b0426892979bceca14af7652
+  md5: 9a7ef5185e0a6e97a7aa81264127ead0
+  depends:
+  - r-base >=4.1,<4.2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 233762
+  timestamp: 1741126110416
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-cpp11-0.5.2-r43h785f33e_1.conda
+  sha256: df0f798533937a024c560406275d718adf1b063b7ac748449417099d0aec96cb
+  md5: 7bc23dbad7c6015d9b2b9c59bb3e5d85
+  depends:
+  - r-base >=4.3,<4.4.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 234214
+  timestamp: 1742373558016
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-crayon-1.5.2-r41hc72bb7e_1.tar.bz2
   sha256: c1bcd0e430790ecdd7f1d7dbd263eec9645e898a9c914a0618e0834469858e86
   md5: 8cf94f6451aaadf3aa1119b29115b0c7
@@ -10650,6 +11509,177 @@ packages:
   purls: []
   size: 166200
   timestamp: 1719730621224
+- conda: https://conda.anaconda.org/conda-forge/win-64/r-curl-4.3.3-r41h6d2157b_2.conda
+  sha256: ab7169f745ecd1668d2b211e47e8a69dd17ab31c282940cf93eeeda8ba5af979
+  md5: a878e579429c6618f5439405d966da00
+  depends:
+  - m2w64-gcc-libs
+  - m2w64-gcc-libs-core
+  - m2w64-libwinpthread-git
+  - m2w64-zlib
+  - r-base >=4.1,<4.2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 1912298
+  timestamp: 1684155798927
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-data.table-1.17.2-r43he23165d_0.conda
+  sha256: df8b0a0f5ec7e79b1ee0121cc1489d7ae5d1502cfaa503da5f9b3b82c86ba344
+  md5: 3d6c42d448bb232d2a4e449bcbf66fdf
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - _openmp_mutex >=4.5
+  - libgcc >=13
+  - libzlib >=1.3.1,<2.0a0
+  - r-base >=4.3,<4.4.0a0
+  license: MPL-2.0
+  license_family: OTHER
+  purls: []
+  size: 2311663
+  timestamp: 1747067466360
+- conda: https://conda.anaconda.org/conda-forge/osx-64/r-data.table-1.17.2-r43h3ffa6c1_0.conda
+  sha256: 52d2697a083a48e9ad8c745896bafb1a6ab0a4e7c02e36659af9c36ec72abf37
+  md5: a3fc287c8be6be818e5eb2092ac5cded
+  depends:
+  - __osx >=10.13
+  - libzlib >=1.3.1,<2.0a0
+  - llvm-openmp >=18.1.8
+  - r-base >=4.3,<4.4.0a0
+  license: MPL-2.0
+  license_family: OTHER
+  purls: []
+  size: 2301224
+  timestamp: 1747067629507
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-data.table-1.17.2-r43h28c71e1_0.conda
+  sha256: 6f33499f60989eafea43618bae4df2a3a6c91964db0fb01ba8d6abfc4c02e923
+  md5: ef7a15e9798924e417ba48a0d5869a7e
+  depends:
+  - __osx >=11.0
+  - libzlib >=1.3.1,<2.0a0
+  - llvm-openmp >=18.1.8
+  - r-base >=4.3,<4.4.0a0
+  license: MPL-2.0
+  license_family: OTHER
+  purls: []
+  size: 2267792
+  timestamp: 1747067537289
+- conda: https://conda.anaconda.org/conda-forge/win-64/r-data.table-1.15.4-r41h6d2157b_0.conda
+  sha256: 88de25b017d19499d946eff501db048dba8a66a6fe1192ddd93597ecab903c89
+  md5: 325962e235030833882937207d160086
+  depends:
+  - m2w64-gcc-libs
+  - m2w64-gcc-libs-core
+  - m2w64-zlib
+  - r-base >=4.1,<4.2.0a0
+  license: MPL-2.0
+  license_family: OTHER
+  purls: []
+  size: 2029445
+  timestamp: 1717845111694
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-deriv-4.1.6-r43hc72bb7e_0.conda
+  sha256: e91b0f0436b48dba17fb5dc7c7d38f7cf9cfacd7ff1f03014dc8224b13627260
+  md5: ac16122071af739dc821d3dde77ce6c0
+  depends:
+  - r-base >=4.3,<4.4.0a0
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  purls: []
+  size: 168144
+  timestamp: 1726236020907
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-diagram-1.6.5-r41ha770c72_1.tar.bz2
+  sha256: 30b8f01422e27a3cc8ba150004d3b0e10c05d2b33a8dc9bef38a920fad3ca606
+  md5: 415ccc46dc37d8986b4320c363e252be
+  depends:
+  - r-base >=4.1,<4.2.0a0
+  - r-shape
+  license: GPL-2.0-or-later
+  license_family: GPL3
+  purls: []
+  size: 695305
+  timestamp: 1665404923467
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-diagram-1.6.5-r43ha770c72_3.conda
+  sha256: 7c55e1843a64f1c1b163db82c8821796d69ac2269e5893e45b1465e16cfa5426
+  md5: bbb01e34de1b65e7161e39cbaae2171e
+  depends:
+  - r-base >=4.3,<4.4.0a0
+  - r-shape
+  license: GPL-2.0-or-later
+  license_family: GPL3
+  purls: []
+  size: 670898
+  timestamp: 1719771686903
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-digest-0.6.37-r43h0d4f4ea_0.conda
+  sha256: fa6b14abad4345d72adecf5b7e80948ead2d85a511bf6962014c758614f74868
+  md5: edcd201672d47f522666954cc7b25e0d
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - r-base >=4.3,<4.4.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL2
+  purls: []
+  size: 215185
+  timestamp: 1724100194332
+- conda: https://conda.anaconda.org/conda-forge/osx-64/r-digest-0.6.37-r43h25d921d_0.conda
+  sha256: 48c04ba806a9bc541add3c958a2dc64f768ff364da832cc4634bdd0046c4144f
+  md5: e5f5fe851f7abbbc85a9be4d1fadb319
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  - r-base >=4.3,<4.4.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL2
+  purls: []
+  size: 209207
+  timestamp: 1724100285309
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-digest-0.6.37-r43hd76f289_0.conda
+  sha256: 371c4e5ee0fbf2136e47899b88f611e964b7649be24ae4036da760d9e1610c91
+  md5: c277fd2d8fb8e83bde1db156b608f57a
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  - r-base >=4.3,<4.4.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL2
+  purls: []
+  size: 203888
+  timestamp: 1724100405404
+- conda: https://conda.anaconda.org/conda-forge/win-64/r-digest-0.6.36-r41he75b88d_0.conda
+  sha256: b80d81489937a542ec2320a93ff726495f3e5e9ea06124a9bfdb32e085f0a048
+  md5: 08ce1e823e955f3ba7cd2c73f69fe5a4
+  depends:
+  - m2w64-gcc-libs
+  - m2w64-gcc-libs-core
+  - r-base >=4.1,<4.2.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL2
+  purls: []
+  size: 206907
+  timestamp: 1719173523820
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-doby-4.6.27-r43hc72bb7e_0.conda
+  sha256: 3c60c4f63bd0800d08a7606d8dfa81bb77c8a1c3da4b869ef1d5e219b92a2e24
+  md5: 6d86883c2a95554436d4d4c13cd7d94e
+  depends:
+  - r-base >=4.3,<4.4.0a0
+  - r-boot
+  - r-broom
+  - r-cowplot
+  - r-deriv
+  - r-dplyr
+  - r-ggplot2
+  - r-mass
+  - r-matrix
+  - r-microbenchmark
+  - r-modelr
+  - r-rlang
+  - r-tibble
+  - r-tidyr
+  license: GPL-2.0-or-later
+  license_family: GPL2
+  purls: []
+  size: 4824064
+  timestamp: 1747412077497
 - conda: https://conda.anaconda.org/conda-forge/linux-64/r-dplyr-1.1.4-r43h0d4f4ea_1.conda
   sha256: 7b0d0477b5d35f1a0fa552d82566ede4e2a0256685b6f8fb8b1ed6bce1365452
   md5: ab942d9107cdd78e74410f9ec48e50c7
@@ -10767,6 +11797,63 @@ packages:
   purls: []
   size: 957232
   timestamp: 1720051905117
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-e1071-1.7_16-r43h93ab643_0.conda
+  sha256: 4cd5c67da0d8e70617540b79354e3542c1c238ba83d9fa2cfe5d535cc7f59851
+  md5: deec964f274f54c0e4f83bd5b7be5de6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - r-base >=4.3,<4.4.0a0
+  - r-class
+  - r-proxy
+  license: GPL-2.0-or-later
+  license_family: GPL3
+  purls: []
+  size: 579753
+  timestamp: 1726495251077
+- conda: https://conda.anaconda.org/conda-forge/osx-64/r-e1071-1.7_16-r43hc83a2cd_0.conda
+  sha256: 7d32acb7ee1ee50f5515e1225397448b9944765350873cde9d3689175fa97d25
+  md5: 068fa4a349ce289dabf00a870d832b67
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  - r-base >=4.3,<4.4.0a0
+  - r-class
+  - r-proxy
+  license: GPL-2.0-or-later
+  license_family: GPL3
+  purls: []
+  size: 580169
+  timestamp: 1726495327781
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-e1071-1.7_16-r43hdd833ad_0.conda
+  sha256: edeb9167b145a125f49e54d56c10c7df975fc8bf8f5f059011bf3a2d5c678c4e
+  md5: 73631c7e5e055785896f2df1d341c3e9
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - r-base >=4.3,<4.4.0a0
+  - r-class
+  - r-proxy
+  license: GPL-2.0-or-later
+  license_family: GPL3
+  purls: []
+  size: 572994
+  timestamp: 1726495573239
+- conda: https://conda.anaconda.org/conda-forge/win-64/r-e1071-1.7_14-r41ha856d6a_0.conda
+  sha256: 12d89b316f5a9e1ad88959f06afd84d5aa83006eaf932ff6b37a307cbff90744
+  md5: e7fbfa0dd12a24bc4ba8b0514a43f68a
+  depends:
+  - m2w64-gcc-libs
+  - m2w64-gcc-libs-core
+  - r-base >=4.1,<4.2.0a0
+  - r-class
+  - r-proxy
+  license: GPL-2.0-or-later
+  license_family: GPL3
+  purls: []
+  size: 602545
+  timestamp: 1701863793897
 - conda: https://conda.anaconda.org/conda-forge/linux-64/r-ellipsis-0.3.2-r43hb1dbf0f_3.conda
   sha256: f9c29817821721080e1995b9db966b6618372f9c5167e33742289ae97ace35a7
   md5: b8349582a31b17184a7674f4c847a5ad
@@ -10816,6 +11903,16 @@ packages:
   purls: []
   size: 47135
   timestamp: 1686667495850
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-evaluate-0.21-r41hc72bb7e_0.conda
+  sha256: 4ecd9f4e2395a5be9c5c3d7a45c8600a799fba12268dd0e80cece8f67ea979b5
+  md5: c45a9a35d32b9d0f08298e3324ef15fe
+  depends:
+  - r-base >=4.1,<4.2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 89432
+  timestamp: 1683337192178
 - conda: https://conda.anaconda.org/conda-forge/linux-64/r-fansi-1.0.6-r43hb1dbf0f_1.conda
   sha256: 21ad2a8e582dc1a11acf078c042f753cbbdc52b07510dd8a3f9d49e673f88902
   md5: 4c17a0f74a974316fdfafa5a9fe91b52
@@ -10985,6 +12082,48 @@ packages:
   purls: []
   size: 3274531
   timestamp: 1718281652437
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-forcats-1.0.0-r41hc72bb7e_0.conda
+  sha256: cdd8440887792723024b4f05ea4ca82042819d67ab5f1a01a32a4ff39d6c5508
+  md5: 6b95a229af9bb250729ae7cb149103d2
+  depends:
+  - r-base >=4.1,<4.2.0a0
+  - r-cli
+  - r-ellipsis
+  - r-glue
+  - r-lifecycle
+  - r-magrittr
+  - r-rlang >=1.0.0
+  - r-tibble
+  - r-withr
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 424400
+  timestamp: 1675050529709
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-foreach-1.5.2-r41hc72bb7e_1.tar.bz2
+  sha256: 028ea5ed35af8f01f505d303b64a114031ec452ceca104a4cfd22716fefba6e8
+  md5: 4ac59bcf363990abb478e9d358ea76ff
+  depends:
+  - r-base >=4.1,<4.2.0a0
+  - r-codetools
+  - r-iterators
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 138371
+  timestamp: 1665199781732
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-foreach-1.5.2-r43hc72bb7e_3.conda
+  sha256: efd10d141380aedcd2ced0ec1379a7b799bab8c14f58fd1fdaaed1a2ac0ba27f
+  md5: 1b0d9e2f20eead453cf64c3257076abd
+  depends:
+  - r-base >=4.3,<4.4.0a0
+  - r-codetools
+  - r-iterators
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 138664
+  timestamp: 1719764761375
 - conda: https://conda.anaconda.org/conda-forge/linux-64/r-foreign-0.8_90-r43h2b5f3a1_0.conda
   sha256: 9ca1c3cc5aeb2afc2326cb5f11ef0ab402d125104aee87b9cd0849b9c8375530
   md5: 7ff7a440b0920a402edf83ddfa47ed7d
@@ -10992,8 +12131,6 @@ packages:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
   - r-base >=4.3,<4.4.0a0
-  arch: x86_64
-  platform: linux
   license: GPL-2.0-or-later
   license_family: GPL2
   purls: []
@@ -11005,8 +12142,6 @@ packages:
   depends:
   - __osx >=10.13
   - r-base >=4.3,<4.4.0a0
-  arch: x86_64
-  platform: osx
   license: GPL-2.0-or-later
   license_family: GPL2
   purls: []
@@ -11018,8 +12153,6 @@ packages:
   depends:
   - __osx >=11.0
   - r-base >=4.3,<4.4.0a0
-  arch: arm64
-  platform: osx
   license: GPL-2.0-or-later
   license_family: GPL2
   purls: []
@@ -11032,8 +12165,6 @@ packages:
   - m2w64-gcc-libs
   - m2w64-gcc-libs-core
   - r-base >=4.1,<4.2.0a0
-  arch: x86_64
-  platform: win
   license: GPL-2.0-or-later
   license_family: GPL2
   purls: []
@@ -11059,6 +12190,68 @@ packages:
   purls: []
   size: 174759
   timestamp: 1719771688298
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-future-1.32.0-r41hc72bb7e_0.conda
+  sha256: 1ade4e341b461163e486abd1226f6d0e62a846414af5490333f626b420d4e734
+  md5: d8c3792c16265cf9c5de9af386fe0d14
+  depends:
+  - r-base >=4.1,<4.2.0a0
+  - r-digest
+  - r-globals >=0.13.1
+  - r-listenv >=0.8.0
+  - r-parallelly >=1.21.0
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  purls: []
+  size: 620771
+  timestamp: 1678181286149
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-future-1.49.0-r43h785f33e_0.conda
+  sha256: 1a17996633fc41e9a8e37cabeb7df024c94b8ff987bef855ec614c02cadbf749
+  md5: dd9f407201bdacdc5ccfcf335d9e54f8
+  depends:
+  - r-base >=4.3,<4.4.0a0
+  - r-digest
+  - r-globals >=0.16.1
+  - r-listenv >=0.8.0
+  - r-parallelly >=1.34.0
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  purls: []
+  size: 884230
+  timestamp: 1746794035712
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-future.apply-1.11.0-r41hc72bb7e_0.conda
+  sha256: 27c2018b912a094110691d8af1fb6343c9b9c1e9990664002d0c318a523cfd4c
+  md5: 46c72db23fa6b5bf453c9a80d807dfce
+  depends:
+  - r-base >=4.1,<4.2.0a0
+  - r-future >=1.13.0
+  - r-globals >=0.12.4
+  license: GPL-2.0-or-later
+  license_family: GPL3
+  purls: []
+  size: 165106
+  timestamp: 1684651143025
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-future.apply-1.11.3-r43hc72bb7e_0.conda
+  sha256: 61449d43276476bc8b5dbb326dbf9dc4e1c6b21f9778a2b6203fb1c78b43849d
+  md5: 3b103233744fe38012980538315de822
+  depends:
+  - r-base >=4.3,<4.4.0a0
+  - r-future >=1.28.0
+  - r-globals >=0.16.1
+  license: GPL-2.0-or-later
+  license_family: GPL3
+  purls: []
+  size: 166981
+  timestamp: 1736498852011
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-gbrd-0.4.12-r43hc72bb7e_1.conda
+  sha256: b2266091f5d9678b2416119c4504358ad3dfa15c4c915c7e53cf9c06971e96e2
+  md5: 82188cf6d6b8aabe25936d70785219dd
+  depends:
+  - r-base >=4.3,<4.4.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL2
+  purls: []
+  size: 59124
+  timestamp: 1719787304619
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-generics-0.1.3-r41hc72bb7e_1.tar.bz2
   sha256: 20e2cb128a0cff32dd9345dcec092e4b6329665f19778cba8ae919a3d6596497
   md5: 91a23d57270d474ab35b970ab153bdf4
@@ -11123,6 +12316,28 @@ packages:
   purls: []
   size: 4750623
   timestamp: 1721286575640
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-globals-0.16.2-r41hc72bb7e_0.conda
+  sha256: bde76c7cdc9b459355efbbd5df8b7106c8a0b4e664bba2a7338052a6d4fc8447
+  md5: 11ddcc27843ccee5551f55a1ac63c80b
+  depends:
+  - r-base >=4.1,<4.2.0a0
+  - r-codetools
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  purls: []
+  size: 120152
+  timestamp: 1669078652148
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-globals-0.18.0-r43hc72bb7e_0.conda
+  sha256: 8c749a90a39e9347c9f9a1cdb26ff64c6ddf55dcd59e2412260c91710c4ead5f
+  md5: b851ecb36cea8010e258a85ed0fe5790
+  depends:
+  - r-base >=4.3,<4.4.0a0
+  - r-codetools
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  purls: []
+  size: 174339
+  timestamp: 1746732659473
 - conda: https://conda.anaconda.org/conda-forge/linux-64/r-glue-1.8.0-r43h2b5f3a1_0.conda
   sha256: 386032769e36683b23c360815e2c29048ea71d5a074b3d5f46f8bc6806492073
   md5: 381d612db7519f2a54f1b187e738ac7b
@@ -11169,6 +12384,51 @@ packages:
   purls: []
   size: 159223
   timestamp: 1704854058885
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-gower-1.0.1-r43hb1dbf0f_2.conda
+  sha256: b64e9b4debe23bfd8c3556dd62f3c3457d46b76166de6f85aff80f387677ea09
+  md5: f61cbf09c3e0434de7d8125d576c9642
+  depends:
+  - libgcc-ng >=12
+  - r-base >=4.3,<4.4.0a0
+  license: GPL-3.0-only
+  license_family: GPL3
+  purls: []
+  size: 224775
+  timestamp: 1719766861918
+- conda: https://conda.anaconda.org/conda-forge/osx-64/r-gower-1.0.1-r43h6b9d099_2.conda
+  sha256: bd40ce56e9a793421c86b9f38dfebcf55a112ef917ceafd8f0d864a074312c9f
+  md5: 08fbd1bbd88d462d0c7804e768aa7f96
+  depends:
+  - __osx >=10.13
+  - r-base >=4.3,<4.4.0a0
+  license: GPL-3.0-only
+  license_family: GPL3
+  purls: []
+  size: 222574
+  timestamp: 1719766976235
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-gower-1.0.1-r43h07cda29_2.conda
+  sha256: 8126637e6032fae8274087ab312453db1159d209b00bb8f20bec63c97a91f9fe
+  md5: 3bf2d94777705a0117c0fbb549c68c15
+  depends:
+  - __osx >=11.0
+  - r-base >=4.3,<4.4.0a0
+  license: GPL-3.0-only
+  license_family: GPL3
+  purls: []
+  size: 223151
+  timestamp: 1719767055163
+- conda: https://conda.anaconda.org/conda-forge/win-64/r-gower-1.0.1-r41h6d2157b_1.conda
+  sha256: 36a419f359d64dbed79221c3c3821a75f4e6fd9fb7662dca7556c02abfa58537
+  md5: 3c43efd13b73757944e5facf502dffc5
+  depends:
+  - m2w64-gcc-libs
+  - m2w64-gcc-libs-core
+  - r-base >=4.1,<4.2.0a0
+  license: GPL-3.0-only
+  license_family: GPL3
+  purls: []
+  size: 228643
+  timestamp: 1686759026832
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-gtable-0.3.3-r41hc72bb7e_0.conda
   sha256: e2363cdb040878d54aace828a021d8ec920ac6dd81e7aba65713cbcdfcfbb38f
   md5: f18da5771f11c05df08eed41095d56a5
@@ -11197,6 +12457,154 @@ packages:
   purls: []
   size: 226514
   timestamp: 1729878469778
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-hardhat-1.3.0-r41hc72bb7e_0.conda
+  sha256: a514da3ae337e5f70acf7bfb9acabbd1f9400621cb79c891fd414b6030bd4662
+  md5: 9c7df605a7be4779808e5e63a48ca2bc
+  depends:
+  - r-base >=4.1,<4.2.0a0
+  - r-glue
+  - r-rlang >=0.4.1
+  - r-tibble
+  - r-vctrs >=0.2.0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 809952
+  timestamp: 1680176335602
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-hardhat-1.4.1-r43hc72bb7e_0.conda
+  sha256: 6b9e47fcca2e4b017f148aa38969601563907fcd2110fbadb7dcdafbff08d651
+  md5: e05111b91087575e374881be9702282d
+  depends:
+  - r-base >=4.3,<4.4.0a0
+  - r-cli >=3.6.0
+  - r-glue >=1.6.2
+  - r-rlang >=1.1.0
+  - r-sparsevctrs >=0.2.0
+  - r-tibble >=3.2.1
+  - r-vctrs >=0.6.0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 832161
+  timestamp: 1738571627562
+- conda: https://conda.anaconda.org/conda-forge/win-64/r-haven-2.5.4-r41ha856d6a_0.conda
+  sha256: 84379a99690bed44bd2e207f6e61d34f9243dd56ae8deebea4817b47c59c26c5
+  md5: 23d66ed5412cca33a6f9804b7c775cf7
+  depends:
+  - m2w64-gcc-libs
+  - m2w64-gcc-libs-core
+  - r-base >=4.1,<4.2.0a0
+  - r-cli >=3.0.0
+  - r-cpp11
+  - r-forcats >=0.2.0
+  - r-hms
+  - r-lifecycle
+  - r-readr >=0.1.0
+  - r-rlang >=0.4.0
+  - r-tibble
+  - r-tidyselect
+  - r-vctrs >=0.3.0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 375828
+  timestamp: 1701367782077
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-highr-0.10-r41hc72bb7e_0.conda
+  sha256: 898d2bca9e12d0e4bb0e06fb66115ca46190d818d036867d91d3151e58b042fb
+  md5: c5680c2ac76bcecf2c4c3d598fdea3a8
+  depends:
+  - r-base >=4.1,<4.2.0a0
+  - r-xfun >=0.18
+  license: GPL-2.0-or-later
+  license_family: GPL
+  purls: []
+  size: 57202
+  timestamp: 1671713526233
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-hms-1.1.3-r41hc72bb7e_0.conda
+  sha256: 50d3b6ff5c590682a5546662114f450ce6422024c2cddc94475c9083319c3b94
+  md5: 8a21dea88f1d2a88050c5e005d399b74
+  depends:
+  - r-base >=4.1,<4.2.0a0
+  - r-ellipsis
+  - r-lifecycle
+  - r-pkgconfig
+  - r-rlang
+  - r-vctrs >=0.2.1
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 106804
+  timestamp: 1679427477283
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-ipred-0.9_15-r43hdb488b9_1.conda
+  sha256: 19ad5cd21cbd6125b02abde40cc68f20dd8431334a2694d7d437a1d1cb26dc30
+  md5: 45bd44a48d22dfdbcf353801002c34ce
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  - r-base >=4.3,<4.4.0a0
+  - r-class
+  - r-mass
+  - r-nnet
+  - r-prodlim
+  - r-rpart >=3.1_8
+  - r-survival
+  license: GPL-2.0-or-later
+  license_family: GPL3
+  purls: []
+  size: 391033
+  timestamp: 1722078117954
+- conda: https://conda.anaconda.org/conda-forge/osx-64/r-ipred-0.9_15-r43h6b9d099_1.conda
+  sha256: 2cfe72b563eab6e108cabdebcc6c34e34b9dc60852104c9e723e65b5aeee9e75
+  md5: be4793733055085645c418225d0aac19
+  depends:
+  - __osx >=10.13
+  - r-base >=4.3,<4.4.0a0
+  - r-class
+  - r-mass
+  - r-nnet
+  - r-prodlim
+  - r-rpart >=3.1_8
+  - r-survival
+  license: GPL-2.0-or-later
+  license_family: GPL3
+  purls: []
+  size: 389792
+  timestamp: 1722078171865
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-ipred-0.9_15-r43h07cda29_1.conda
+  sha256: aa8303ad344805cb2973379db87454c6defa632681d76b5f739c6b885ad2d353
+  md5: 8a067fd80ed8c0fc34dff4e8ffb27ae9
+  depends:
+  - __osx >=11.0
+  - r-base >=4.3,<4.4.0a0
+  - r-class
+  - r-mass
+  - r-nnet
+  - r-prodlim
+  - r-rpart >=3.1_8
+  - r-survival
+  license: GPL-2.0-or-later
+  license_family: GPL3
+  purls: []
+  size: 390980
+  timestamp: 1722078307915
+- conda: https://conda.anaconda.org/conda-forge/win-64/r-ipred-0.9_15-r41h6c66454_0.conda
+  sha256: e7ad065c475275bbad9d3cad8e1b9c26a46f9e64a94939cfd0e2e92814032b35
+  md5: 38c2ae205752670a46f14fe06dfaf947
+  depends:
+  - m2w64-gcc-libs
+  - m2w64-gcc-libs-core
+  - r-base >=4.1,<4.2.0a0
+  - r-class
+  - r-mass
+  - r-nnet
+  - r-prodlim
+  - r-rpart >=3.1_8
+  - r-survival
+  license: GPL-2.0-or-later
+  license_family: GPL3
+  purls: []
+  size: 396943
+  timestamp: 1721412980838
 - conda: https://conda.anaconda.org/conda-forge/linux-64/r-isoband-0.2.7-r43ha18555a_3.conda
   sha256: dc617b350611976a580ece3be3e28807d0eee1fbb5964a61c8f99c8e70512ac9
   md5: 39459e8609d9461d90ee0683a7fd2f3a
@@ -11245,6 +12653,26 @@ packages:
   purls: []
   size: 1633084
   timestamp: 1686754054063
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-iterators-1.0.14-r41hc72bb7e_1.tar.bz2
+  sha256: 0a852a5e01a115ee94274fe0306402e61ab74c4077ffab8a28ed976dcaa63877
+  md5: 774088f2c449de9b334b0fc3f8a427a5
+  depends:
+  - r-base >=4.1,<4.2.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 359109
+  timestamp: 1665186314751
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-iterators-1.0.14-r43hc72bb7e_3.conda
+  sha256: 22b980e7bc669af18f178ce8fd9f20a5434f2ca7d675dc956e403ecaafb944ed
+  md5: 982226a9b2f88353204d23b7369683d7
+  depends:
+  - r-base >=4.3,<4.4.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 349580
+  timestamp: 1719752136439
 - conda: https://conda.anaconda.org/conda-forge/linux-64/r-kernsmooth-2.23_26-r43h8461fee_0.conda
   sha256: 20c119febcb77c48b00c17d5579da1a4106233406be6afb4e99afadfa36eda06
   md5: b2d302f924fbb35cd56c909842f32163
@@ -11255,8 +12683,6 @@ packages:
   - libgfortran
   - libgfortran5 >=13.3.0
   - r-base >=4.3,<4.4.0a0
-  arch: x86_64
-  platform: linux
   license: Unlimited
   license_family: MIT
   purls: []
@@ -11271,8 +12697,6 @@ packages:
   - libgfortran 5.*
   - libgfortran5 >=13.2.0
   - r-base >=4.3,<4.4.0a0
-  arch: x86_64
-  platform: osx
   license: Unlimited
   license_family: MIT
   purls: []
@@ -11287,8 +12711,6 @@ packages:
   - libgfortran 5.*
   - libgfortran5 >=13.2.0
   - r-base >=4.3,<4.4.0a0
-  arch: arm64
-  platform: osx
   license: Unlimited
   license_family: MIT
   purls: []
@@ -11302,13 +12724,25 @@ packages:
   - m2w64-gcc-libs
   - m2w64-gcc-libs-core
   - r-base >=4.1,<4.2.0a0
-  arch: x86_64
-  platform: win
   license: Unlimited
   license_family: MIT
   purls: []
   size: 103376
   timestamp: 1715957249544
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-knitr-1.43-r41hc72bb7e_0.conda
+  sha256: ebf32a8180d137fc3a377fe725e1ca3da3ad98d1c95a4bc40779ba2efb7c4a60
+  md5: 9a1b185e1cf8286af819f0def11fbafa
+  depends:
+  - r-base >=4.1,<4.2.0a0
+  - r-evaluate >=0.15
+  - r-highr
+  - r-xfun >=0.39
+  - r-yaml >=2.1.19
+  license: GPL-2.0-or-later
+  license_family: GPL
+  purls: []
+  size: 1297243
+  timestamp: 1685009767556
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-labeling-0.4.2-r41hc72bb7e_2.tar.bz2
   sha256: 0e68851a87aece39fe9cf6bc1bd659bf05b6eae1f1dd7e123b6645e0b459c0f1
   md5: 83807ad3d6daa0c5e88ad3f4e8df4758
@@ -11374,6 +12808,37 @@ packages:
   purls: []
   size: 1362054
   timestamp: 1710928136235
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-lava-1.7.2.1-r41hc72bb7e_0.conda
+  sha256: 99f9169287718e0b09d14e57f2744c65d129010b2674cbb65b43eeeaf16ba5bb
+  md5: f9e6590776d920a243044d1138a7c589
+  depends:
+  - r-base >=4.1,<4.2.0a0
+  - r-future.apply
+  - r-numderiv
+  - r-progressr
+  - r-squarem
+  - r-survival
+  license: GPL-3.0-only
+  license_family: GPL3
+  purls: []
+  size: 2439477
+  timestamp: 1677698871942
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-lava-1.8.1-r43hc72bb7e_0.conda
+  sha256: 0a1eb70fee0193d7ef1497e9e2eaee5c59814bbad0c66d06b68dac32aa085bc1
+  md5: 0e3e78dcd3e5512625e032dc251cbdf0
+  depends:
+  - r-base >=4.3,<4.4.0a0
+  - r-cli
+  - r-future.apply
+  - r-numderiv
+  - r-progressr
+  - r-squarem
+  - r-survival
+  license: GPL-3.0-only
+  license_family: GPL3
+  purls: []
+  size: 2472928
+  timestamp: 1736689844629
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-lifecycle-1.0.3-r41hc72bb7e_1.tar.bz2
   sha256: b417a9801d2a80a746ddc5c7c4d3e03001a679a6d99e7753d1ebcb62d340338e
   md5: bed96e636722252c2a37c392c5994f9d
@@ -11400,6 +12865,168 @@ packages:
   purls: []
   size: 121795
   timestamp: 1721176797340
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-listenv-0.9.0-r41hc72bb7e_0.conda
+  sha256: b4f5924fed68d0daab9a9a13e7be1c52425a5c02de5e21079e41d651c6e7c523
+  md5: 16b05ccb97ac8c2394238c870f125e0b
+  depends:
+  - r-base >=4.1,<4.2.0a0
+  license: LGPL-2.1
+  license_family: LGPL
+  purls: []
+  size: 120567
+  timestamp: 1671189556724
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-listenv-0.9.1-r43hc72bb7e_1.conda
+  sha256: 155670341ce928c513714766a412e548f27ff892e7203c450ce9e7012a9682c5
+  md5: ec5e5ed484ed53445c5ae5debc3f3f53
+  depends:
+  - r-base >=4.3,<4.4.0a0
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  purls: []
+  size: 121181
+  timestamp: 1719758660891
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-lme4-1.1_37-r43h93ab643_0.conda
+  sha256: 9efdce5ced93e9eb9968ac26eb07f1b0d431c9e67995b950b736aadaa9e58a38
+  md5: f43ef6ab43758d57a53b36a62ea4b6e3
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - r-base >=4.3,<4.4.0a0
+  - r-boot
+  - r-lattice
+  - r-mass
+  - r-matrix 1.6_5 r43he966344_1
+  - r-minqa >=1.1.15
+  - r-nlme >=3.1_123
+  - r-nloptr >=1.0.4
+  - r-rcpp >=0.10.5
+  - r-rcppeigen >=0.3.3.9.4
+  - r-reformulas >=0.3.0
+  license: GPL-2.0-or-later
+  license_family: GPL3
+  purls: []
+  size: 4624846
+  timestamp: 1744637396171
+- conda: https://conda.anaconda.org/conda-forge/osx-64/r-lme4-1.1_37-r43h2711daa_0.conda
+  sha256: 782bc77b795c73dfde02b6e0631ca10d2654634fd5168babb1e62a421cfce733
+  md5: a30e284f29be5b8629ac24431925f262
+  depends:
+  - __osx >=10.13
+  - libcxx >=18
+  - r-base >=4.3,<4.4.0a0
+  - r-boot
+  - r-lattice
+  - r-mass
+  - r-matrix 1.6_5 r43h9cf22e7_1
+  - r-minqa >=1.1.15
+  - r-nlme >=3.1_123
+  - r-nloptr >=1.0.4
+  - r-rcpp >=0.10.5
+  - r-rcppeigen >=0.3.3.9.4
+  - r-reformulas >=0.3.0
+  license: GPL-2.0-or-later
+  license_family: GPL3
+  purls: []
+  size: 4605804
+  timestamp: 1744637503741
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-lme4-1.1_37-r43h31118f2_0.conda
+  sha256: c52bc2daa70c7f582d40d52cf846629ed10f0df26346d03486602ebc195ee1b4
+  md5: c23200f61fdd7c4a3067d361c1a7896b
+  depends:
+  - __osx >=11.0
+  - libcxx >=18
+  - r-base >=4.3,<4.4.0a0
+  - r-boot
+  - r-lattice
+  - r-mass
+  - r-matrix 1.6_5 r43hded8dfa_1
+  - r-minqa >=1.1.15
+  - r-nlme >=3.1_123
+  - r-nloptr >=1.0.4
+  - r-rcpp >=0.10.5
+  - r-rcppeigen >=0.3.3.9.4
+  - r-reformulas >=0.3.0
+  license: GPL-2.0-or-later
+  license_family: GPL3
+  purls: []
+  size: 4591725
+  timestamp: 1744637651159
+- conda: https://conda.anaconda.org/conda-forge/win-64/r-lme4-1.1_35.5-r41he75b88d_0.conda
+  sha256: 666f3fd528d1a153d7de06f8025d8873edd703089f813d97975b65853bfec7ee
+  md5: 366a48cc52ed368a19ca4731920d26ef
+  depends:
+  - m2w64-gcc-libs
+  - m2w64-gcc-libs-core
+  - r-base >=4.1,<4.2.0a0
+  - r-boot
+  - r-lattice
+  - r-mass
+  - r-matrix >=1.6_2
+  - r-minqa >=1.1.15
+  - r-nlme >=3.1_123
+  - r-nloptr >=1.0.4
+  - r-rcpp >=0.10.5
+  - r-rcppeigen >=0.3.3.9.4
+  license: GPL-2.0-or-later
+  license_family: GPL3
+  purls: []
+  size: 4561658
+  timestamp: 1720036631034
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-lubridate-1.9.4-r43h2b5f3a1_0.conda
+  sha256: b8ca00db70eb183106f36fea6908a102ad993243488aa96fc5700b3b2fe92f05
+  md5: ea3d9586d87bb3644505fe792e84f884
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - r-base >=4.3,<4.4.0a0
+  - r-generics
+  - r-timechange >=0.1.1
+  license: GPL-2.0-or-later
+  license_family: GPL2
+  purls: []
+  size: 984722
+  timestamp: 1733774233605
+- conda: https://conda.anaconda.org/conda-forge/osx-64/r-lubridate-1.9.4-r43h79f565e_0.conda
+  sha256: 5a8daf9f32916faf58a71dd9ef70e08ceb1e4cb46a8c3330984ba440e0bcb070
+  md5: 2581d25c911b0e05926ce4f2986438e1
+  depends:
+  - __osx >=10.13
+  - r-base >=4.3,<4.4.0a0
+  - r-generics
+  - r-timechange >=0.1.1
+  license: GPL-2.0-or-later
+  license_family: GPL2
+  purls: []
+  size: 977454
+  timestamp: 1733774307243
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-lubridate-1.9.4-r43h570997c_0.conda
+  sha256: 3b63133e8572fe0f954da9eb15480893007a9f7e927361663eea07d9eadf29d9
+  md5: d0bd348c611ec22637e5dc23dc45e829
+  depends:
+  - __osx >=11.0
+  - r-base >=4.3,<4.4.0a0
+  - r-generics
+  - r-timechange >=0.1.1
+  license: GPL-2.0-or-later
+  license_family: GPL2
+  purls: []
+  size: 979431
+  timestamp: 1733774482533
+- conda: https://conda.anaconda.org/conda-forge/win-64/r-lubridate-1.9.3-r41h6d2157b_0.conda
+  sha256: 8ecbe84c3fba13ed9e0748859cf385365b78733435baa217c3e752dd36d2d98c
+  md5: 5236f25de00f121890cfd503cdd5c53f
+  depends:
+  - m2w64-gcc-libs
+  - m2w64-gcc-libs-core
+  - r-base >=4.1,<4.2.0a0
+  - r-generics
+  - r-timechange >=0.1.1
+  license: GPL-2.0-or-later
+  license_family: GPL2
+  purls: []
+  size: 943277
+  timestamp: 1695817298537
 - conda: https://conda.anaconda.org/conda-forge/linux-64/r-magrittr-2.0.3-r43hb1dbf0f_3.conda
   sha256: 7812c24da1b48c408bcfac9c7b0ea76fec952e8948b4fc28c4579822e8712b60
   md5: fc61bcf37e59037b486c8841a704e9da
@@ -11445,6 +13072,21 @@ packages:
   purls: []
   size: 210699
   timestamp: 1686654730205
+- conda: https://conda.anaconda.org/conda-forge/win-64/r-maptools-1.1_8-r41h6d2157b_0.conda
+  sha256: 5f3d0840bdc503e3e323b9cd90976ca0f645b86d67e1774fb9958fe6df6fe8ad
+  md5: 6bc197a7224225ee06d8d53ad3c76de8
+  depends:
+  - m2w64-gcc-libs
+  - m2w64-gcc-libs-core
+  - r-base >=4.1,<4.2.0a0
+  - r-foreign >=0.8
+  - r-lattice
+  - r-sp >=1.0_11
+  license: GPL-2.0-or-later
+  license_family: GPL3
+  purls: []
+  size: 1805828
+  timestamp: 1689716634310
 - conda: https://conda.anaconda.org/conda-forge/linux-64/r-mass-7.3_60.0.1-r43hb1dbf0f_1.conda
   sha256: fada325f851e7b6c96d0ccadc5e99010e7286fda9e72fb0faad825520b1b7894
   md5: c3c9184486ccabe19b86aba11351652e
@@ -11547,6 +13189,74 @@ packages:
   purls: []
   size: 3748234
   timestamp: 1705018478364
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-matrixmodels-0.5_1-r41hc72bb7e_0.tar.bz2
+  sha256: f3f2a43540a30f1de45ea3071af147afa9032ccf9b8d7c29bebf8caaeaa0e98b
+  md5: 3b2d61e7777c2b1247084e9fa3aa667a
+  depends:
+  - r-base >=4.1,<4.2.0a0
+  - r-matrix >=1.1_5
+  license: GPL-2.0-or-later
+  license_family: GPL3
+  purls: []
+  size: 444629
+  timestamp: 1665500208381
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-matrixmodels-0.5_4-r43hc72bb7e_0.conda
+  sha256: e9c20105d4e33bf07bbcf6e67bea4dea6ff6a99bb786d8dc7c415e7b0a372ccc
+  md5: 62b9765c547a0e84659586e7ff31d1a8
+  depends:
+  - r-base >=4.3,<4.4.0a0
+  - r-matrix >=1.1_5
+  license: GPL-2.0-or-later
+  license_family: GPL3
+  purls: []
+  size: 381069
+  timestamp: 1742991444367
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-matrixstats-1.5.0-r43h2b5f3a1_0.conda
+  sha256: 5717afb7497bf42866418a37bd628ec15bb051492168f91642212ed541f6840c
+  md5: bbf709a87ed6a14852cb0a4171539a06
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - r-base >=4.3,<4.4.0a0
+  license: Artistic-2.0
+  license_family: OTHER
+  purls: []
+  size: 460726
+  timestamp: 1736293696262
+- conda: https://conda.anaconda.org/conda-forge/osx-64/r-matrixstats-1.5.0-r43h79f565e_0.conda
+  sha256: ead961b6b4422f09ee7f0038dee90d89cfcb1e512b6dc919ca7bd9007790d83e
+  md5: 0f2643b1de13dc732ac3933ba941b387
+  depends:
+  - __osx >=10.13
+  - r-base >=4.3,<4.4.0a0
+  license: Artistic-2.0
+  license_family: OTHER
+  purls: []
+  size: 451542
+  timestamp: 1736293698358
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-matrixstats-1.5.0-r43h570997c_0.conda
+  sha256: 69c016ff76b2593605d6aca9d253311df4693d5befba34247eea52c2996ee691
+  md5: 4b71b95497c0dbb94d1065fd6f0b3554
+  depends:
+  - __osx >=11.0
+  - r-base >=4.3,<4.4.0a0
+  license: Artistic-2.0
+  license_family: OTHER
+  purls: []
+  size: 429183
+  timestamp: 1736293851902
+- conda: https://conda.anaconda.org/conda-forge/win-64/r-matrixstats-1.3.0-r41h6d2157b_0.conda
+  sha256: dc2e62ea4403a3d202c9dfab908a31e1ae6cad67629bec71337c8bf655f4ad98
+  md5: 4636aa348f6ac57315af057134aa79df
+  depends:
+  - m2w64-gcc-libs
+  - m2w64-gcc-libs-core
+  - r-base >=4.1,<4.2.0a0
+  license: Artistic-2.0
+  license_family: OTHER
+  purls: []
+  size: 459538
+  timestamp: 1712829431600
 - conda: https://conda.anaconda.org/conda-forge/linux-64/r-mgcv-1.9_1-r43h0d28552_1.conda
   sha256: 47c1d253c32ea3c596f37dcb30177ca873c3318547f98b77ecb4547362ac9a7b
   md5: 154d840fb734a3f80a5ef623b52ff6cd
@@ -11612,6 +13322,178 @@ packages:
   purls: []
   size: 3208497
   timestamp: 1703135718189
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-microbenchmark-1.5.0-r43h2b5f3a1_0.conda
+  sha256: c0dfc90b2ba42cc5cb4e782e88e18b561d3997bb8a7e230bf92e94fb6af24920
+  md5: 9bc60d06c5a0f438f2b66cf0a24c281f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - r-base >=4.3,<4.4.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  purls: []
+  size: 73355
+  timestamp: 1725545145259
+- conda: https://conda.anaconda.org/conda-forge/osx-64/r-microbenchmark-1.5.0-r43h199b6f9_0.conda
+  sha256: 92d02000d4245536489c4906aa13fbe650119686003db140d8ca2c4bed6df97e
+  md5: c6dfe84046b6667743eb096814bea77f
+  depends:
+  - __osx >=10.13
+  - r-base >=4.3,<4.4.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  purls: []
+  size: 72598
+  timestamp: 1725545376154
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-microbenchmark-1.5.0-r43h0d9a900_0.conda
+  sha256: a8618ca21323f44be6e659255171505a6bd72c44a99f764747054ceae495958d
+  md5: eb57ba1d7bc8ecf38c3b278ef6cbdc37
+  depends:
+  - __osx >=11.0
+  - r-base >=4.3,<4.4.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  purls: []
+  size: 73336
+  timestamp: 1725545236343
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-minqa-1.2.8-r43ha936806_0.conda
+  sha256: edf83a0b57e22da23f5dbf36eb1114edacfbfa9db00aa78e15afc4abaa702789
+  md5: 027f16b1393b490924cba41ee6d61f04
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  - libgfortran-ng
+  - libgfortran5 >=12.4.0
+  - libstdcxx-ng >=12
+  - r-base >=4.3,<4.4.0a0
+  - r-rcpp >=0.9.10
+  license: GPL-2.0-only
+  license_family: GPL2
+  purls: []
+  size: 143414
+  timestamp: 1723948046187
+- conda: https://conda.anaconda.org/conda-forge/osx-64/r-minqa-1.2.8-r43hc1e73ce_0.conda
+  sha256: 40f172fe8271d0ea8add90d9ac704deb6927f0b775eb8ec475579617c59dd3cc
+  md5: 70872ec5631b0b597f6543d145d14eaf
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  - libgfortran >=5
+  - libgfortran5 >=12.3.0
+  - libgfortran5 >=13.2.0
+  - r-base >=4.3,<4.4.0a0
+  - r-rcpp >=0.9.10
+  license: GPL-2.0-only
+  license_family: GPL2
+  purls: []
+  size: 138818
+  timestamp: 1723948183536
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-minqa-1.2.8-r43ha0027a1_0.conda
+  sha256: 850e7aebc7773b8283944241d577bdfd9008f0faa946c947684e1e3eb898447a
+  md5: 11c1fbe168e20f91b2c28f0c371d61f4
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  - libgfortran >=5
+  - libgfortran5 >=12.3.0
+  - libgfortran5 >=13.2.0
+  - r-base >=4.3,<4.4.0a0
+  - r-rcpp >=0.9.10
+  license: GPL-2.0-only
+  license_family: GPL2
+  purls: []
+  size: 127825
+  timestamp: 1723948245112
+- conda: https://conda.anaconda.org/conda-forge/win-64/r-minqa-1.2.7-r41h92b2e5c_0.conda
+  sha256: 592e7e7c52401c33b5f07c75acbd1694af145cd416c7ec2a26811fe0ebaf239a
+  md5: 9e8baee976021b90c32dae102cb9f183
+  depends:
+  - m2w64-gcc-libs
+  - m2w64-gcc-libs-core
+  - r-base >=4.1,<4.2.0a0
+  - r-rcpp >=0.9.10
+  license: GPL-2.0-only
+  license_family: GPL2
+  purls: []
+  size: 129877
+  timestamp: 1716207808448
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-modelmetrics-1.2.2.2-r43h0d4f4ea_4.conda
+  sha256: 716bbd13bd25c5ff872e7460418339f8a56ca43ecc44e3ec9fcdaf74774bd7d5
+  md5: fd7c52a5efdafc2f4eeb6b2b5a14e598
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - _openmp_mutex >=4.5
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - r-base >=4.3,<4.4.0a0
+  - r-data.table
+  - r-rcpp
+  license: GPL-2.0-or-later
+  license_family: GPL3
+  purls: []
+  size: 168858
+  timestamp: 1722054857986
+- conda: https://conda.anaconda.org/conda-forge/osx-64/r-modelmetrics-1.2.2.2-r43hccab667_4.conda
+  sha256: 6c8f2fb075345d309b5fc48957a5c0cd00b5c2a0cd79494e08814a86287c1f66
+  md5: f46fe2c5e28e6a4fc0e9e41f7d0aed84
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  - llvm-openmp >=16.0.6
+  - r-base >=4.3,<4.4.0a0
+  - r-data.table
+  - r-rcpp
+  license: GPL-2.0-or-later
+  license_family: GPL3
+  purls: []
+  size: 153212
+  timestamp: 1722054961816
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-modelmetrics-1.2.2.2-r43h173a3d2_4.conda
+  sha256: d7bb2461d714a292b48c3782c90f6034c9686228ddd5e5e293f89663bc48db1a
+  md5: d3704e1ab5f14f9d0b6669e8ed0eb640
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  - llvm-openmp >=16.0.6
+  - r-base >=4.3,<4.4.0a0
+  - r-data.table
+  - r-rcpp
+  license: GPL-2.0-or-later
+  license_family: GPL3
+  purls: []
+  size: 151755
+  timestamp: 1722055055134
+- conda: https://conda.anaconda.org/conda-forge/win-64/r-modelmetrics-1.2.2.2-r41ha856d6a_3.conda
+  sha256: aa34764ff140a532a7b22da4e5df3b34c4bbc4281d037004c9cdacce09c2c5b0
+  md5: 7a9f616c42f7566f126186cda9b7575a
+  depends:
+  - m2w64-gcc-libs
+  - m2w64-gcc-libs-core
+  - r-base >=4.1,<4.2.0a0
+  - r-data.table
+  - r-rcpp
+  license: GPL-2.0-or-later
+  license_family: GPL3
+  purls: []
+  size: 157467
+  timestamp: 1687265038661
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-modelr-0.1.11-r43hc72bb7e_2.conda
+  sha256: df667af19826269d49ea7208770758a77fb18d7a5466506041d20a6d5f9c84e1
+  md5: 2cdd8c74b0c949695af0debfd3a44974
+  depends:
+  - r-base >=4.3,<4.4.0a0
+  - r-broom
+  - r-dplyr
+  - r-magrittr
+  - r-purrr >=0.2.2
+  - r-rlang >=0.2.0
+  - r-tibble
+  - r-tidyr >=0.8.0
+  license: GPL-3
+  license_family: GPL3
+  purls: []
+  size: 220288
+  timestamp: 1721421650977
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-munsell-0.5.0-r41hc72bb7e_1005.tar.bz2
   sha256: cac8fdb4b1a3104ac1203021beca696909eaf122862dbd5c56f876132879496d
   md5: 102b2cf348101fd85afda3b26460b0f3
@@ -11691,6 +13573,65 @@ packages:
   purls: []
   size: 2274213
   timestamp: 1717908793877
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-nloptr-2.2.1-r43hb8c4c88_0.conda
+  sha256: 49f0bc674eccd09608a6e4319e6538fbfe2ddd1cbafbe113601429ecd247627c
+  md5: 3eb86c4a75aa420197af87892d1fa67f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libgfortran
+  - libgfortran5 >=13.3.0
+  - libstdcxx >=13
+  - nlopt >=2.9.0,<2.10.0a0
+  - r-base >=4.3,<4.4.0a0
+  license: LGPL-3.0-only
+  license_family: LGPL
+  purls: []
+  size: 269202
+  timestamp: 1742197240315
+- conda: https://conda.anaconda.org/conda-forge/osx-64/r-nloptr-2.2.1-r43h1fbd797_0.conda
+  sha256: d0d79d67305ae09d2f16f0d13719636c88a0753b5662e11de80f892340b388c1
+  md5: 066a68dc736d02cef9e9edff2ee999bd
+  depends:
+  - __osx >=10.13
+  - libcxx >=18
+  - libgfortran >=5
+  - libgfortran5 >=13.2.0
+  - nlopt >=2.9.0,<2.10.0a0
+  - r-base >=4.3,<4.4.0a0
+  license: LGPL-3.0-only
+  license_family: LGPL
+  purls: []
+  size: 267212
+  timestamp: 1742197403514
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-nloptr-2.2.1-r43h0873fe7_0.conda
+  sha256: 7d5d4beb3e4145f323289cc6e055bcd7acd402fdd3cd890b88234c62e96e0e81
+  md5: f47c0498c26c8c2518559c0b02976ae8
+  depends:
+  - __osx >=11.0
+  - libcxx >=18
+  - libgfortran >=5
+  - libgfortran5 >=13.2.0
+  - nlopt >=2.9.0,<2.10.0a0
+  - r-base >=4.3,<4.4.0a0
+  license: LGPL-3.0-only
+  license_family: LGPL
+  purls: []
+  size: 267581
+  timestamp: 1742197381648
+- conda: https://conda.anaconda.org/conda-forge/win-64/r-nloptr-2.0.3-r41h96779af_2.conda
+  sha256: 00dc50d693d8608e930e3db3933aeac4bf718e5a77dd03af3e02f8fc742cc216
+  md5: 3f79fb4479d74aca50b867da9dfed3af
+  depends:
+  - m2w64-gcc-libs
+  - m2w64-gcc-libs-core
+  - m2w64-nlopt
+  - r-base >=4.1,<4.2.0a0
+  license: LGPL-3.0-only
+  license_family: LGPL
+  purls: []
+  size: 626133
+  timestamp: 1686760205147
 - conda: https://conda.anaconda.org/conda-forge/linux-64/r-nnet-7.3_20-r43h2b5f3a1_0.conda
   sha256: fa3c1e52c32c989d8fe0c64a72f248cf329ab705a3737bb2f3f271a62616089f
   md5: c58e4fcb2f1e30872bbf3e11bdced351
@@ -11699,8 +13640,6 @@ packages:
   - libgcc >=13
   - r-base >=4.3,<4.4.0a0
   - r-mass
-  arch: x86_64
-  platform: linux
   license: GPL-2.0-or-later
   license_family: GPL3
   purls: []
@@ -11713,8 +13652,6 @@ packages:
   - __osx >=10.13
   - r-base >=4.3,<4.4.0a0
   - r-mass
-  arch: x86_64
-  platform: osx
   license: GPL-2.0-or-later
   license_family: GPL3
   purls: []
@@ -11727,8 +13664,6 @@ packages:
   - __osx >=11.0
   - r-base >=4.3,<4.4.0a0
   - r-mass
-  arch: arm64
-  platform: osx
   license: GPL-2.0-or-later
   license_family: GPL3
   purls: []
@@ -11742,8 +13677,6 @@ packages:
   - m2w64-gcc-libs-core
   - r-base >=4.1,<4.2.0a0
   - r-mass
-  arch: x86_64
-  platform: win
   license: GPL-2.0-or-later
   license_family: GPL3
   purls: []
@@ -11769,6 +13702,103 @@ packages:
   purls: []
   size: 127013
   timestamp: 1719752122849
+- conda: https://conda.anaconda.org/conda-forge/win-64/r-openxlsx-4.2.5.2-r41ha856d6a_1.conda
+  sha256: 1779898a169d35eafcbffbe41ba10f2dc271df33b7c1c65f3b71246ea0a44f88
+  md5: b52df559b1cbdc54d4d93325137cb320
+  depends:
+  - m2w64-gcc-libs
+  - m2w64-gcc-libs-core
+  - r-base >=4.1,<4.2.0a0
+  - r-rcpp
+  - r-rlang >=0.1.2
+  - r-stringi
+  - r-zip
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 1950242
+  timestamp: 1686772950953
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-parallelly-1.44.0-r43h2b5f3a1_0.conda
+  sha256: 36d972b5a3331d0ae8208775f4c5c9fdded5e2e03cf8bb6decd3674827da1df4
+  md5: cdd2adc5da91f15937874439e02982ef
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - r-base >=4.3,<4.4.0a0
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  purls: []
+  size: 569068
+  timestamp: 1746650598549
+- conda: https://conda.anaconda.org/conda-forge/osx-64/r-parallelly-1.44.0-r43h79f565e_0.conda
+  sha256: 16a97c37b0af6cc5fe95bed1d471cdf733818cce8e06800a24782c29e1b5835d
+  md5: bc022047aa2767a7bcab77450ef14ed3
+  depends:
+  - __osx >=10.13
+  - r-base >=4.3,<4.4.0a0
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  purls: []
+  size: 568460
+  timestamp: 1746650772181
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-parallelly-1.44.0-r43h570997c_0.conda
+  sha256: 87d5f03ae9ea9847eb0809b6c4446f227ca0070042a7b0322f47f80ae666d6df
+  md5: 83aa595a82cd5ddbba0f9e5b38ec8df0
+  depends:
+  - __osx >=11.0
+  - r-base >=4.3,<4.4.0a0
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  purls: []
+  size: 568903
+  timestamp: 1746650911278
+- conda: https://conda.anaconda.org/conda-forge/win-64/r-parallelly-1.37.1-r41h6d2157b_0.conda
+  sha256: bc20145a4b91a0f26f8d55195169f1de2bcb31ec7eb03f40342ac7593fca588e
+  md5: 69bee56ae71aae6cd33802745b29842b
+  depends:
+  - m2w64-gcc-libs
+  - m2w64-gcc-libs-core
+  - r-base >=4.1,<4.2.0a0
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  purls: []
+  size: 375215
+  timestamp: 1709200335797
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-pbkrtest-0.5.2-r41hc72bb7e_0.conda
+  sha256: b2a3cbc63f75eda5c45eac25d1a9339c9b536624a7313b0948daab06952cf7a1
+  md5: 8fb872e4992d02675f75bf9d7b134f29
+  depends:
+  - r-base >=4.1,<4.2.0a0
+  - r-broom
+  - r-dplyr
+  - r-knitr
+  - r-lme4 >=1.1.10
+  - r-magrittr
+  - r-mass
+  - r-matrix >=1.2.3
+  - r-numderiv
+  license: GPL-2.0-or-later
+  license_family: GPL2
+  purls: []
+  size: 196453
+  timestamp: 1674170582515
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-pbkrtest-0.5.4-r43hc72bb7e_0.conda
+  sha256: 67035e0d0da5edd5e4ec8c8ab522677e3523b49e80e5197db392dbc0ed4e8709
+  md5: 0ecad07e9860ca6ba7a8aeae5d28f49d
+  depends:
+  - r-base >=4.3,<4.4.0a0
+  - r-broom
+  - r-doby
+  - r-dplyr
+  - r-lme4 >=1.1.31
+  - r-mass
+  - r-matrix >=1.2.3
+  - r-numderiv
+  license: GPL-2.0-or-later
+  license_family: GPL2
+  purls: []
+  size: 231170
+  timestamp: 1745863037591
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-pillar-1.10.1-r43hc72bb7e_0.conda
   sha256: ab191b8bbcfa3e8f6812e3e1cdad41797a62ee21c82a06f029f83f051c7ac398
   md5: 88e4d2579080275d1d7914d052c3c335
@@ -11825,6 +13855,286 @@ packages:
   purls: []
   size: 26365
   timestamp: 1719725359345
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-plyr-1.8.9-r43ha18555a_1.conda
+  sha256: 5fa74530d0e7c600e19e9703e381c1a01a93ecf466154c4b03d9e57de1866ae2
+  md5: d93aedee4cc78f78413969b1e891842c
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - r-base >=4.3,<4.4.0a0
+  - r-rcpp >=0.11.0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 822760
+  timestamp: 1719753127445
+- conda: https://conda.anaconda.org/conda-forge/osx-64/r-plyr-1.8.9-r43h25d921d_1.conda
+  sha256: 4b4173747141f2ebe93bd6e4c7b6b17d6ae1e6bd39b265a3e6bbc4764a1acee9
+  md5: 1ca3bad195633deed13c8cd8bfd4852e
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  - r-base >=4.3,<4.4.0a0
+  - r-rcpp >=0.11.0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 820404
+  timestamp: 1719753173541
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-plyr-1.8.9-r43hd76f289_1.conda
+  sha256: 8e8a823bc536a500b11d52670e842d2b6871aaa12e01e8d4ec5e5e78f6b581a7
+  md5: db87611167bdd7972e0c7396f03528c3
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  - r-base >=4.3,<4.4.0a0
+  - r-rcpp >=0.11.0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 820777
+  timestamp: 1719753379517
+- conda: https://conda.anaconda.org/conda-forge/win-64/r-plyr-1.8.9-r41ha856d6a_0.conda
+  sha256: db21460c1471f4fde97fa77721ffa4165000f92c7268fc544f2574603329281e
+  md5: d345db050002c82befe1ce4e76566ac3
+  depends:
+  - m2w64-gcc-libs
+  - m2w64-gcc-libs-core
+  - r-base >=4.1,<4.2.0a0
+  - r-rcpp >=0.11.0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 818939
+  timestamp: 1696237850116
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-prettyunits-1.1.1-r41hc72bb7e_2.tar.bz2
+  sha256: 94fdcad33c2507184f99bcce9c9e8861c9631bad4508cbf56a06a7cb41774db5
+  md5: 749430ac02fcabd79fe67a1a1c1414ab
+  depends:
+  - r-assertthat
+  - r-base >=4.1,<4.2.0a0
+  - r-magrittr
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 43176
+  timestamp: 1665199819180
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-proc-1.18.5-r43ha18555a_1.conda
+  sha256: 78d310c846367d48a3ea27e5f6eae6874e02f481019b77d9dcc9ed86bacbc015
+  md5: 1d7db1e76a22b4bee1e95d67ef62bfd9
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - r-base >=4.3,<4.4.0a0
+  - r-plyr
+  - r-rcpp >=0.11.1
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  purls: []
+  size: 838902
+  timestamp: 1719787313775
+- conda: https://conda.anaconda.org/conda-forge/osx-64/r-proc-1.18.5-r43h25d921d_1.conda
+  sha256: 08178e7fc9c9367fc6ce7077cced5cb187b5f38ed76534ca3346ac351bcbfd7f
+  md5: 365a839e0391fb9626ee2b51893b33ac
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  - r-base >=4.3,<4.4.0a0
+  - r-plyr
+  - r-rcpp >=0.11.1
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  purls: []
+  size: 835048
+  timestamp: 1719787485414
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-proc-1.18.5-r43hd76f289_1.conda
+  sha256: e59e19c4c0939a5bd142e3f8106ab2bb9454cf10a39030f5360a7e103fdafb26
+  md5: 845c72278966f97979527c583bd79676
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  - r-base >=4.3,<4.4.0a0
+  - r-plyr
+  - r-rcpp >=0.11.1
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  purls: []
+  size: 834537
+  timestamp: 1719787476343
+- conda: https://conda.anaconda.org/conda-forge/win-64/r-proc-1.18.5-r41ha856d6a_0.conda
+  sha256: eedf01af88d00d6aa7a0f5609c6952f0fa752f3d4de92ed1e75d766eb137db68
+  md5: 93168039cfd19745547136ffe430cee2
+  depends:
+  - m2w64-gcc-libs
+  - m2w64-gcc-libs-core
+  - r-base >=4.1,<4.2.0a0
+  - r-plyr
+  - r-rcpp >=0.11.1
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  purls: []
+  size: 849761
+  timestamp: 1698929941417
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-prodlim-2025.04.28-r43h93ab643_0.conda
+  sha256: c9db422bad625dd4807b3a78ec77501a4cbc453af803a311b11b3f00be794eb8
+  md5: 2d272f5f6b99b79ab4c2e6df43f8895d
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - r-base >=4.3,<4.4.0a0
+  - r-data.table
+  - r-diagram
+  - r-ggplot2
+  - r-kernsmooth
+  - r-lava
+  - r-rcpp >=0.11.5
+  - r-rlang
+  - r-survival
+  license: GPL-2.0-or-later
+  license_family: GPL2
+  purls: []
+  size: 459106
+  timestamp: 1745938645912
+- conda: https://conda.anaconda.org/conda-forge/osx-64/r-prodlim-2025.04.28-r43h2711daa_0.conda
+  sha256: f3a42e666360145ee509544494c687a7af917a511a514a9b45fe8c5f13d3768a
+  md5: 47a05b888b6ab3d5157dc424dc3bf69c
+  depends:
+  - __osx >=10.13
+  - libcxx >=18
+  - r-base >=4.3,<4.4.0a0
+  - r-data.table
+  - r-diagram
+  - r-ggplot2
+  - r-kernsmooth
+  - r-lava
+  - r-rcpp >=0.11.5
+  - r-rlang
+  - r-survival
+  license: GPL-2.0-or-later
+  license_family: GPL2
+  purls: []
+  size: 459160
+  timestamp: 1745938855733
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-prodlim-2025.04.28-r43h31118f2_0.conda
+  sha256: 91f3da355f156aa786262ddb2efbf5a5dda2e66f3d11d5fdfd285316802307ed
+  md5: a5ece1473669cfff1149b33969026ab8
+  depends:
+  - __osx >=11.0
+  - libcxx >=18
+  - r-base >=4.3,<4.4.0a0
+  - r-data.table
+  - r-diagram
+  - r-ggplot2
+  - r-kernsmooth
+  - r-lava
+  - r-rcpp >=0.11.5
+  - r-rlang
+  - r-survival
+  license: GPL-2.0-or-later
+  license_family: GPL2
+  purls: []
+  size: 457604
+  timestamp: 1745938840135
+- conda: https://conda.anaconda.org/conda-forge/win-64/r-prodlim-2024.06.25-r41he75b88d_0.conda
+  sha256: 32da7cb425854e05fbdeccfc192f3a70365b42e6f6f6bc6a3587540827c4c424
+  md5: 291a66354367739f1d115fd598a1c2b3
+  depends:
+  - m2w64-gcc-libs
+  - m2w64-gcc-libs-core
+  - r-base >=4.1,<4.2.0a0
+  - r-data.table
+  - r-diagram
+  - r-kernsmooth
+  - r-lava
+  - r-rcpp >=0.11.5
+  - r-survival
+  license: GPL-2.0-or-later
+  license_family: GPL2
+  purls: []
+  size: 437180
+  timestamp: 1719280558123
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-progress-1.2.2-r41hc72bb7e_3.tar.bz2
+  sha256: 0e048bad7cee41d96f282eea329413bd2b25fe22471630dcf75105815b0dbb16
+  md5: 284788289276072133ba78cca81006b4
+  depends:
+  - r-base >=4.1,<4.2.0a0
+  - r-crayon
+  - r-hms
+  - r-prettyunits
+  - r-r6
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 94299
+  timestamp: 1665212888616
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-progressr-0.13.0-r41hc72bb7e_0.conda
+  sha256: bc8dfdb2fbc7a6b2662b1b9054aa2a44581fcd9cf170843fb62fb60031fa8830
+  md5: 9e57331b574e0e0e448fff70d06faa23
+  depends:
+  - r-base >=4.1,<4.2.0a0
+  - r-digest
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  purls: []
+  size: 350470
+  timestamp: 1673368809471
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-progressr-0.15.1-r43hc72bb7e_0.conda
+  sha256: 1b8e2faca222b023c04733ae43e3f4fb26489a1e6c8e20f5d949e16b996f51c1
+  md5: 58328f17c8a6d7941ffd43d035c874c0
+  depends:
+  - r-base >=4.3,<4.4.0a0
+  - r-digest
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  purls: []
+  size: 360622
+  timestamp: 1732302114289
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-proxy-0.4_27-r43hb1dbf0f_3.conda
+  sha256: e10bb685ea53e74715c4155d2daf383cf3291d75aa54c54586999dc86746c363
+  md5: d7b831353a7bfbbe20980873e81fef97
+  depends:
+  - libgcc-ng >=12
+  - r-base >=4.3,<4.4.0a0
+  license: GPL-2.0-only
+  license_family: GPL2
+  purls: []
+  size: 185053
+  timestamp: 1719753196858
+- conda: https://conda.anaconda.org/conda-forge/osx-64/r-proxy-0.4_27-r43h6b9d099_3.conda
+  sha256: 0d8aa40392726b0cce774d61e3c9e6e96f2d2f74dcae3c6080ca4317b31f9c0e
+  md5: 5acb0a40767f0937514c1aea1973966e
+  depends:
+  - __osx >=10.13
+  - r-base >=4.3,<4.4.0a0
+  license: GPL-2.0-only
+  license_family: GPL2
+  purls: []
+  size: 182455
+  timestamp: 1719753258608
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-proxy-0.4_27-r43h07cda29_3.conda
+  sha256: 55d8ecd7fa7c618c465e4a978622290fa6b612671bccf55465c7bb5da5dfb198
+  md5: e0e60c4c0076574af500ff6523be1f92
+  depends:
+  - __osx >=11.0
+  - r-base >=4.3,<4.4.0a0
+  license: GPL-2.0-only
+  license_family: GPL2
+  purls: []
+  size: 182582
+  timestamp: 1719753347743
+- conda: https://conda.anaconda.org/conda-forge/win-64/r-proxy-0.4_27-r41h6d2157b_2.conda
+  sha256: 181b8d467a4de94d3dbe5c269a2bae84e30ab47a7133dc55f0cb750deac2fff7
+  md5: 120a0269d322253e91676080740c06b2
+  depends:
+  - m2w64-gcc-libs
+  - m2w64-gcc-libs-core
+  - r-base >=4.1,<4.2.0a0
+  license: GPL-2.0-only
+  license_family: GPL2
+  purls: []
+  size: 190469
+  timestamp: 1686754449343
 - conda: https://conda.anaconda.org/conda-forge/linux-64/r-purrr-1.0.2-r43hdb488b9_1.conda
   sha256: ce10fe4113ee69c9e59e049ed79f717e612d31fd57fcabc7317caa1c06e1d640
   md5: 4270c6c51a02fc0da32b9d7b453ef3f5
@@ -11891,6 +14201,82 @@ packages:
   purls: []
   size: 487609
   timestamp: 1691665847660
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-quantreg-6.1-r43h012206f_0.conda
+  sha256: f2d6104e1185aafb9501d22e1f560448aec7ba5286cbff1bd822f270ef212f50
+  md5: fc1a3a12a23548d109556c7d60f586cd
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libblas >=3.9.0,<4.0a0
+  - libgcc >=13
+  - libgfortran
+  - libgfortran5 >=13.3.0
+  - liblapack >=3.9.0,<4.0a0
+  - r-base >=4.3,<4.4.0a0
+  - r-conquer
+  - r-matrix
+  - r-matrixmodels
+  - r-sparsem
+  license: GPL-2.0-or-later
+  license_family: GPL3
+  purls: []
+  size: 1474244
+  timestamp: 1741610695663
+- conda: https://conda.anaconda.org/conda-forge/osx-64/r-quantreg-6.1-r43hfe2c0ad_0.conda
+  sha256: 3835ad9f15d8c85031db8f30cc7670cfbfda137bb3b28f7f9d70c4d934dfd994
+  md5: 8f2dd13c7fb2104173ae943f5e1bfb53
+  depends:
+  - __osx >=10.13
+  - libblas >=3.9.0,<4.0a0
+  - libgfortran >=5
+  - libgfortran5 >=13.2.0
+  - liblapack >=3.9.0,<4.0a0
+  - r-base >=4.3,<4.4.0a0
+  - r-conquer
+  - r-matrix
+  - r-matrixmodels
+  - r-sparsem
+  license: GPL-2.0-or-later
+  license_family: GPL3
+  purls: []
+  size: 1467923
+  timestamp: 1741610875247
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-quantreg-6.1-r43h0c5c079_0.conda
+  sha256: e9b8a9d0b3e73a483fb76629cef306bf2b6c76fa7a430eb719756278275d5f6e
+  md5: bded2070f5c41478bf1e23a0ec953271
+  depends:
+  - __osx >=11.0
+  - libblas >=3.9.0,<4.0a0
+  - libgfortran >=5
+  - libgfortran5 >=13.2.0
+  - liblapack >=3.9.0,<4.0a0
+  - r-base >=4.3,<4.4.0a0
+  - r-conquer
+  - r-matrix
+  - r-matrixmodels
+  - r-sparsem
+  license: GPL-2.0-or-later
+  license_family: GPL3
+  purls: []
+  size: 1461792
+  timestamp: 1741610831167
+- conda: https://conda.anaconda.org/conda-forge/win-64/r-quantreg-5.98-r41h9b73d3e_0.conda
+  sha256: 895c9753016a33a172dd9d8617ef85cf2cf6c2874283dd6b2cde74fc851197cd
+  md5: 234a03cf1e1a3bcb6af040a89aa339a0
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - m2w64-gcc-libs
+  - m2w64-gcc-libs-core
+  - r-base >=4.1,<4.2.0a0
+  - r-conquer
+  - r-matrix
+  - r-matrixmodels
+  - r-sparsem
+  license: GPL-2.0-or-later
+  license_family: GPL3
+  purls: []
+  size: 1565019
+  timestamp: 1716998125154
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-r6-2.5.1-r41hc72bb7e_1.tar.bz2
   sha256: 63bfc44c14262bbd8d2f518179700fc72161f23c4ec97534c63c2bf2a20ea7a8
   md5: 04cf390ece28f6df5c096f78409a9b41
@@ -11911,6 +14297,43 @@ packages:
   purls: []
   size: 90453
   timestamp: 1719719035545
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-rbibutils-2.3-r43h2b5f3a1_0.conda
+  sha256: 76b779470e2fc82fc7089e27b4eaed1273650ceff5f2b004d427582f0d483384
+  md5: 087da213d1cbe455e3568f437976b10d
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - r-base >=4.3,<4.4.0a0
+  - r-xml2
+  license: GPL-2.0-only
+  license_family: GPL2
+  purls: []
+  size: 966631
+  timestamp: 1728045656531
+- conda: https://conda.anaconda.org/conda-forge/osx-64/r-rbibutils-2.3-r43h199b6f9_0.conda
+  sha256: e19d8e87024d11a180eab9ba816b80227085e120c4a139d1d2205de0cf0e827a
+  md5: c5c18af3669e5401b7cea46c497fa8fb
+  depends:
+  - __osx >=10.13
+  - r-base >=4.3,<4.4.0a0
+  - r-xml2
+  license: GPL-2.0-only
+  license_family: GPL2
+  purls: []
+  size: 862445
+  timestamp: 1728045753778
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-rbibutils-2.3-r43h0d9a900_0.conda
+  sha256: 9493d59ba9b79a3ea9509f2eb1dcc4b13b5051126bb52ab019be25dc2a0fa935
+  md5: 1bd5191cd278c5d82f8f6893859106a0
+  depends:
+  - __osx >=11.0
+  - r-base >=4.3,<4.4.0a0
+  - r-xml2
+  license: GPL-2.0-only
+  license_family: GPL2
+  purls: []
+  size: 1017108
+  timestamp: 1728045767585
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-rcolorbrewer-1.1_3-r41h785f33e_1.tar.bz2
   sha256: 3a595799735e503f4ec5dff49a57a2b5a46e10a7177378f7cb95b448f6963ad5
   md5: cf94059b05cc67854cb7e704ea751d7f
@@ -11980,6 +14403,249 @@ packages:
   purls: []
   size: 1978060
   timestamp: 1704797173468
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-rcpparmadillo-14.4.2_1-r43hc2d650c_0.conda
+  sha256: 1018bdd066a98fcbdf7d45c3367f363b8d067891bd98b84a4c443be18b4f566c
+  md5: a9ded0b699d83238bcb9ba6949924fce
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - _openmp_mutex >=4.5
+  - libblas >=3.9.0,<4.0a0
+  - libgcc >=13
+  - liblapack >=3.9.0,<4.0a0
+  - libstdcxx >=13
+  - r-base >=4.3,<4.4.0a0
+  - r-rcpp >=0.11.0
+  license: GPL-2.0-or-later
+  license_family: GPL2
+  purls: []
+  size: 904978
+  timestamp: 1745647199296
+- conda: https://conda.anaconda.org/conda-forge/osx-64/r-rcpparmadillo-14.4.2_1-r43hda2d453_0.conda
+  sha256: 3c23441b3c46a351e5881126744703c609660e4374379037f4732013d882d13a
+  md5: 87497150d553ed0b89116e5a10655115
+  depends:
+  - __osx >=10.13
+  - libblas >=3.9.0,<4.0a0
+  - libcxx >=18
+  - liblapack >=3.9.0,<4.0a0
+  - llvm-openmp >=18.1.8
+  - r-base >=4.3,<4.4.0a0
+  - r-rcpp >=0.11.0
+  license: GPL-2.0-or-later
+  license_family: GPL2
+  purls: []
+  size: 912766
+  timestamp: 1745647354599
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-rcpparmadillo-14.4.2_1-r43h9618d43_0.conda
+  sha256: e72fb76cee5402c5771f01deff54251eba68abb290a053229a9fb26258c12b9c
+  md5: 919131a6441b0e90318a1e414dd30e14
+  depends:
+  - __osx >=11.0
+  - libblas >=3.9.0,<4.0a0
+  - libcxx >=18
+  - liblapack >=3.9.0,<4.0a0
+  - llvm-openmp >=18.1.8
+  - r-base >=4.3,<4.4.0a0
+  - r-rcpp >=0.11.0
+  license: GPL-2.0-or-later
+  license_family: GPL2
+  purls: []
+  size: 905739
+  timestamp: 1745647405505
+- conda: https://conda.anaconda.org/conda-forge/win-64/r-rcpparmadillo-0.12.6.4.0-r41h78deb2a_0.conda
+  sha256: 60beb6d0b0c27409d237f60897dc85e60360f14733949fb371306df31fa24084
+  md5: dfbfbb55f2efbab8f5c309fd9891c466
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - m2w64-gcc-libs
+  - m2w64-gcc-libs-core
+  - r-base >=4.1,<4.2.0a0
+  - r-rcpp >=0.11.0
+  license: GPL-2.0-or-later
+  license_family: GPL2
+  purls: []
+  size: 924119
+  timestamp: 1694344557325
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-rcppeigen-0.3.4.0.2-r43hb79369c_0.conda
+  sha256: 87ad28ecbc3fe117fabe455ed78868536aa6e928560db7963ebb529f7ff9a6d2
+  md5: 02aedbcf8e80e09bd14a6512344993bf
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libblas >=3.9.0,<4.0a0
+  - libgcc-ng >=13
+  - liblapack >=3.9.0,<4.0a0
+  - libstdcxx-ng >=13
+  - r-base >=4.3,<4.4.0a0
+  - r-matrix >=1.1_0
+  - r-rcpp >=0.11.0
+  license: GPL-2.0-or-later
+  license_family: GPL2
+  purls: []
+  size: 1486666
+  timestamp: 1724495148375
+- conda: https://conda.anaconda.org/conda-forge/osx-64/r-rcppeigen-0.3.4.0.2-r43haa2a3db_0.conda
+  sha256: b6a4428dcd241f874e56ce7f825b909bc066b21fb54cb816e2586f17085a96eb
+  md5: 8919432431926699238dd090c240b3d3
+  depends:
+  - __osx >=10.13
+  - libblas >=3.9.0,<4.0a0
+  - libcxx >=17
+  - liblapack >=3.9.0,<4.0a0
+  - r-base >=4.3,<4.4.0a0
+  - r-matrix >=1.1_0
+  - r-rcpp >=0.11.0
+  license: GPL-2.0-or-later
+  license_family: GPL2
+  purls: []
+  size: 1488396
+  timestamp: 1724495234850
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-rcppeigen-0.3.4.0.2-r43h8c6f55f_0.conda
+  sha256: bff5b164139c1ce6343721e7b36a75c56620826b9ff3e37c4d47c3f8d4f3fdb0
+  md5: ffa3a23f2e29facead1eb784767c2f22
+  depends:
+  - __osx >=11.0
+  - libblas >=3.9.0,<4.0a0
+  - libcxx >=17
+  - liblapack >=3.9.0,<4.0a0
+  - r-base >=4.3,<4.4.0a0
+  - r-matrix >=1.1_0
+  - r-rcpp >=0.11.0
+  license: GPL-2.0-or-later
+  license_family: GPL2
+  purls: []
+  size: 1467699
+  timestamp: 1724495323634
+- conda: https://conda.anaconda.org/conda-forge/win-64/r-rcppeigen-0.3.4.0.0-r41h78deb2a_0.conda
+  sha256: 337fa1b9ae1f900e7e3eeffcbcc4f0499a8c3e2250c289c677eeea0a63d5a5a9
+  md5: 1816199d8ec664e97b64d4d19ee7a6d4
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - m2w64-gcc-libs
+  - m2w64-gcc-libs-core
+  - r-base >=4.1,<4.2.0a0
+  - r-matrix >=1.1_0
+  - r-rcpp >=0.11.0
+  license: GPL-2.0-or-later
+  license_family: GPL2
+  purls: []
+  size: 1474826
+  timestamp: 1709161532836
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-rdpack-2.6.4-r43hc72bb7e_0.conda
+  sha256: 37bbcbf9ee19ead1f6004bf828fbc795bfa5ca702532c2d3f2d1a3a44327adb5
+  md5: 071b85fd451b565d6ddaf10dd6973f7d
+  depends:
+  - r-base >=4.3,<4.4.0a0
+  - r-gbrd
+  - r-rbibutils >=1.3
+  license: GPL-2.0-or-later
+  license_family: GPL3
+  purls: []
+  size: 626744
+  timestamp: 1744178394297
+- conda: https://conda.anaconda.org/conda-forge/win-64/r-readr-2.1.5-r41ha856d6a_0.conda
+  sha256: 4bb8a0e14905368f30bd09d66075dc5f740342e0f8fdf396be129699762ebd3c
+  md5: 3e5060979f3990f1380dcec1f5602740
+  depends:
+  - m2w64-gcc-libs
+  - m2w64-gcc-libs-core
+  - r-base >=4.1,<4.2.0a0
+  - r-cli
+  - r-clipr
+  - r-cpp11
+  - r-crayon
+  - r-hms >=0.4.1
+  - r-lifecycle >=0.2.0
+  - r-r6
+  - r-rlang
+  - r-tibble
+  - r-tzdb >=0.1.1
+  - r-vroom >=1.5.4
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 824766
+  timestamp: 1704939320548
+- conda: https://conda.anaconda.org/conda-forge/win-64/r-readxl-1.4.3-r41h1c2d66b_0.conda
+  sha256: 88b7f57a289dc091dc91d023bcb2a2eb2c88b59888fbffcedda9dca751f35918
+  md5: 7db77d596bcecc21761276193c6e7b97
+  depends:
+  - libiconv >=1.17,<2.0a0
+  - m2w64-gcc-libs
+  - m2w64-gcc-libs-core
+  - r-base >=4.1,<4.2.0a0
+  - r-cellranger
+  - r-cpp11 >=0.4.0
+  - r-progress
+  - r-tibble >=2.0.1
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 779599
+  timestamp: 1688691409988
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-recipes-1.0.6-r41hc72bb7e_0.conda
+  sha256: 5e90f95ad1fe66bdee31ebaa6223f1be7df10859307136f2d5820163f7c4ed64
+  md5: aaa48afa6bf09a5324a67d215c308718
+  depends:
+  - r-base >=4.1,<4.2.0a0
+  - r-cli
+  - r-clock >=0.6.1
+  - r-dplyr
+  - r-ellipsis
+  - r-generics >=0.1.2
+  - r-glue
+  - r-gower
+  - r-hardhat >=1.2.0
+  - r-ipred >=0.9_12
+  - r-lifecycle >=1.0.3
+  - r-lubridate >=1.8.0
+  - r-magrittr
+  - r-matrix
+  - r-purrr >=0.2.3
+  - r-rlang >=1.0.3
+  - r-tibble
+  - r-tidyr >=1.0.0
+  - r-tidyselect >=1.2.0
+  - r-timedate
+  - r-vctrs >=0.5.0
+  - r-withr
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 1464940
+  timestamp: 1682395571035
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-recipes-1.3.0-r43hc72bb7e_0.conda
+  sha256: 040b14e63f327e18de0d8562aa912d645dc301da3dccf5c1beee721c4e84c741
+  md5: e35e42d2c3d0738321d7630be6a8f5e3
+  depends:
+  - r-base >=4.3,<4.4.0a0
+  - r-cli
+  - r-clock >=0.6.1
+  - r-dplyr >=1.1.0
+  - r-generics >=0.1.2
+  - r-glue
+  - r-gower
+  - r-hardhat >=1.4.1
+  - r-ipred >=0.9_12
+  - r-lifecycle >=1.0.3
+  - r-lubridate >=1.8.0
+  - r-magrittr
+  - r-matrix
+  - r-purrr >=1.0.0
+  - r-rlang >=1.1.0
+  - r-sparsevctrs >=0.3.0
+  - r-tibble
+  - r-tidyr >=1.0.0
+  - r-tidyselect >=1.2.0
+  - r-timedate
+  - r-vctrs >=0.5.0
+  - r-withr
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 1651266
+  timestamp: 1744882880518
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-recommended-4.1-r41hd8ed1ab_1005.tar.bz2
   sha256: 1f4595f3c43d26a80796371fd67ec469e39186ba9117386c4c7fd3f6ca1288af
   md5: ee9c21634725576901145a899b519f05
@@ -12030,6 +14696,106 @@ packages:
   purls: []
   size: 18027
   timestamp: 1722411963859
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-reformulas-0.4.1-r43hc72bb7e_0.conda
+  sha256: 00088f1a4e5739b385312f6ba61ec9e8ac3bca086a1ab0054e70adb010ec388f
+  md5: a5324989afb832b334691f9cfbb122ca
+  depends:
+  - r-base >=4.3,<4.4.0a0
+  - r-matrix
+  - r-rdpack
+  license: GPL-3.0-only
+  license_family: GPL3
+  purls: []
+  size: 145665
+  timestamp: 1746178592139
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-rematch-1.0.1-r41hc72bb7e_1005.tar.bz2
+  sha256: 101b58df234bd00e06e4c45be30e17358eb739cdea603b8501d41159f026a43d
+  md5: a8f957048515e308310c088474fb2f39
+  depends:
+  - r-base >=4.1,<4.2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 20730
+  timestamp: 1665194011508
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-reshape2-1.4.4-r43h0d4f4ea_4.conda
+  sha256: 20c5dab7ddfc2355415a001ff68c4db84eb3d019fdbe6dc81d014af27f48b7c3
+  md5: 45c563cc9243b5243331b57a4dc445f0
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - r-base >=4.3,<4.4.0a0
+  - r-plyr >=1.8.1
+  - r-rcpp
+  - r-stringr
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 122237
+  timestamp: 1721242403431
+- conda: https://conda.anaconda.org/conda-forge/osx-64/r-reshape2-1.4.4-r43h25d921d_4.conda
+  sha256: 5e734d9bc93b88be44fce5f91e10e8b6abc460c26a5e17cc96f36e67b3db6b93
+  md5: c5fe66b1a3e732d5508c4c255a94e906
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  - r-base >=4.3,<4.4.0a0
+  - r-plyr >=1.8.1
+  - r-rcpp
+  - r-stringr
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 117906
+  timestamp: 1721242496799
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-reshape2-1.4.4-r43hd76f289_4.conda
+  sha256: 73ca745b59e2eccec0afa2054df7bb45ec717a46a84042e76f5699e3eea0cf73
+  md5: 1f92afd321441af5add90d5c6127d874
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  - r-base >=4.3,<4.4.0a0
+  - r-plyr >=1.8.1
+  - r-rcpp
+  - r-stringr
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 117075
+  timestamp: 1721242493471
+- conda: https://conda.anaconda.org/conda-forge/win-64/r-reshape2-1.4.4-r41ha856d6a_3.conda
+  sha256: 8c33686a4cc8ccd2a84322a64eed36ac51d10fbbd34d6b0bf1ebfb5bd33da586
+  md5: 687e69f0dbed729f90128ae47812354c
+  depends:
+  - m2w64-gcc-libs
+  - m2w64-gcc-libs-core
+  - r-base >=4.1,<4.2.0a0
+  - r-plyr >=1.8.1
+  - r-rcpp
+  - r-stringr
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 120540
+  timestamp: 1686765868361
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-rio-0.5.29-r41hc72bb7e_1.tar.bz2
+  sha256: 40f9fc26fa8dfb090006bff54cf4e9c8aa8fbe5b8b900cddc9edd64dfda47e6c
+  md5: 011527cbd2e8710d7fb5a980fc77d8cc
+  depends:
+  - r-base >=4.1,<4.2.0a0
+  - r-curl >=0.6
+  - r-data.table >=1.9.8
+  - r-foreign
+  - r-haven >=1.1.2
+  - r-openxlsx
+  - r-readxl >=0.1.1
+  - r-tibble
+  license: GPL-2.0-only
+  license_family: GPL2
+  purls: []
+  size: 539384
+  timestamp: 1665313283405
 - conda: https://conda.anaconda.org/conda-forge/linux-64/r-rlang-1.1.5-r43h93ab643_0.conda
   sha256: 9c725e3e033d27729973a1bc35b7341f8902631b3dc76d9d3adb1c14660751b7
   md5: 8c1a8d3063031b4d795a8a43fcc2ee3c
@@ -12086,8 +14852,6 @@ packages:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
   - r-base >=4.3,<4.4.0a0
-  arch: x86_64
-  platform: linux
   license: GPL-2.0-or-later
   license_family: GPL3
   purls: []
@@ -12099,8 +14863,6 @@ packages:
   depends:
   - __osx >=10.13
   - r-base >=4.3,<4.4.0a0
-  arch: x86_64
-  platform: osx
   license: GPL-2.0-or-later
   license_family: GPL3
   purls: []
@@ -12112,8 +14874,6 @@ packages:
   depends:
   - __osx >=11.0
   - r-base >=4.3,<4.4.0a0
-  arch: arm64
-  platform: osx
   license: GPL-2.0-or-later
   license_family: GPL3
   purls: []
@@ -12126,8 +14886,6 @@ packages:
   - m2w64-gcc-libs
   - m2w64-gcc-libs-core
   - r-base >=4.1,<4.2.0a0
-  arch: x86_64
-  platform: win
   license: GPL-2.0-or-later
   license_family: GPL3
   purls: []
@@ -12189,6 +14947,139 @@ packages:
   purls: []
   size: 657227
   timestamp: 1721190112402
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-shape-1.4.6-r41ha770c72_1.tar.bz2
+  sha256: f61cad2a92a5de2412f862f48a354589cc65c02bf550539e4b3ceecebe712b0b
+  md5: a78c628184a11ff60fdb5d76b0410d86
+  depends:
+  - r-base >=4.1,<4.2.0a0
+  license: GPL (>= 3)
+  license_family: GPL3
+  purls: []
+  size: 815345
+  timestamp: 1665205883974
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-shape-1.4.6.1-r43ha770c72_1.conda
+  sha256: 386a3e131a035ca29581291deee9c2e7b055aa940d405300d87aecdac825cd57
+  md5: f3dc2930e4ff73b8913f773988fe47a9
+  depends:
+  - r-base >=4.3,<4.4.0a0
+  license: GPL (>= 3)
+  license_family: GPL3
+  purls: []
+  size: 760843
+  timestamp: 1719758671771
+- conda: https://conda.anaconda.org/conda-forge/win-64/r-sp-2.1_4-r41h245b76f_0.conda
+  sha256: 876d609be5a5959338add81e2491ab268fee99a64b006e680a0d9736131b67eb
+  md5: add4dd7bf836013f2038050276544afa
+  depends:
+  - m2w64-gcc-libs
+  - m2w64-gcc-libs-core
+  - r-base >=4.1,<4.2.0a0
+  - r-lattice
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.38.33130
+  license: GPL-2.0-or-later
+  license_family: GPL3
+  purls: []
+  size: 1653206
+  timestamp: 1714499679726
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-sparsem-1.84_2-r43hc4980d5_0.conda
+  sha256: b4e2c53e2d58e3209ed55ee616e2bff558f6fc28c17de283de6b66fed3c06963
+  md5: 951c5138758a0d45ad351a6eeeb19833
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  - libgfortran-ng
+  - libgfortran5 >=12.4.0
+  - r-base >=4.3,<4.4.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL3
+  purls: []
+  size: 832979
+  timestamp: 1721459931793
+- conda: https://conda.anaconda.org/conda-forge/osx-64/r-sparsem-1.84_2-r43h9612530_0.conda
+  sha256: e749bf9c87cf516901912ed9e72164f5db9a4e96c0b3826d29b4199314a37532
+  md5: 24a3fa157eec49eb2d677af7050087cc
+  depends:
+  - __osx >=10.13
+  - libgfortran >=5
+  - libgfortran5 >=12.3.0
+  - libgfortran5 >=13.2.0
+  - r-base >=4.3,<4.4.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL3
+  purls: []
+  size: 832268
+  timestamp: 1721460005332
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-sparsem-1.84_2-r43h7807725_0.conda
+  sha256: a0e488785d059363e0170646ef78126d6de11dff04be5664c6da50d3ec2fcc1e
+  md5: ec6989fdff4181a9a2a7b1677faa05f5
+  depends:
+  - __osx >=11.0
+  - libgfortran >=5
+  - libgfortran5 >=12.3.0
+  - libgfortran5 >=13.2.0
+  - r-base >=4.3,<4.4.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL3
+  purls: []
+  size: 828831
+  timestamp: 1721460088470
+- conda: https://conda.anaconda.org/conda-forge/win-64/r-sparsem-1.84-r41hd63c432_0.conda
+  sha256: aa31079aeb44141b40378d96d44ffdce342159eef116cff21dcbb8c41e8441df
+  md5: a8d53154ef3e3ea4221a4786036cb833
+  depends:
+  - m2w64-gcc-libs
+  - m2w64-gcc-libs-core
+  - r-base >=4.1,<4.2.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL3
+  purls: []
+  size: 823208
+  timestamp: 1719334382127
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-sparsevctrs-0.3.3-r43h2b5f3a1_0.conda
+  sha256: e8fcc54bba15ef83b3e2cc540c62622488eefa9bcd5383fb6acda36ec999e769
+  md5: 21b50343f77396fa849c912080b0dd39
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - r-base >=4.3,<4.4.0a0
+  - r-cli >=3.4.0
+  - r-rlang >=1.1.0
+  - r-vctrs
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 200430
+  timestamp: 1744919543300
+- conda: https://conda.anaconda.org/conda-forge/osx-64/r-sparsevctrs-0.3.3-r43h79f565e_0.conda
+  sha256: 72cac14b6a157ae3081f36d934bf8ff54838369b580d48ff02eb0f72b56baa19
+  md5: a29321c39f485617e7e60bb378fdc5f3
+  depends:
+  - __osx >=10.13
+  - r-base >=4.3,<4.4.0a0
+  - r-cli >=3.4.0
+  - r-rlang >=1.1.0
+  - r-vctrs
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 197842
+  timestamp: 1744919629815
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-sparsevctrs-0.3.3-r43h570997c_0.conda
+  sha256: ba229d5365f6ea8797ae29eb833775238903934c0879474fa3774cfa28eabf9e
+  md5: ff8dec49c57866f68b5a88ea78abb080
+  depends:
+  - __osx >=11.0
+  - r-base >=4.3,<4.4.0a0
+  - r-cli >=3.4.0
+  - r-rlang >=1.1.0
+  - r-vctrs
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 197172
+  timestamp: 1744919668955
 - conda: https://conda.anaconda.org/conda-forge/linux-64/r-spatial-7.3_18-r43h2b5f3a1_0.conda
   sha256: 6e562bd973181c95c7d95bb748d95fc0cd471bd9f8a800b7a840b44be807caba
   md5: c7e699fe0b6df04ce8ebf71705c676ea
@@ -12196,8 +15087,6 @@ packages:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
   - r-base >=4.3,<4.4.0a0
-  arch: x86_64
-  platform: linux
   license: GPL-2.0-or-later
   license_family: GPL3
   purls: []
@@ -12209,8 +15098,6 @@ packages:
   depends:
   - __osx >=10.13
   - r-base >=4.3,<4.4.0a0
-  arch: x86_64
-  platform: osx
   license: GPL-2.0-or-later
   license_family: GPL3
   purls: []
@@ -12222,8 +15109,6 @@ packages:
   depends:
   - __osx >=11.0
   - r-base >=4.3,<4.4.0a0
-  arch: arm64
-  platform: osx
   license: GPL-2.0-or-later
   license_family: GPL3
   purls: []
@@ -12236,13 +15121,31 @@ packages:
   - m2w64-gcc-libs
   - m2w64-gcc-libs-core
   - r-base >=4.1,<4.2.0a0
-  arch: x86_64
-  platform: win
   license: GPL-2.0-or-later
   license_family: GPL3
   purls: []
   size: 157155
   timestamp: 1689908821867
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-squarem-2021.1-r41hc72bb7e_1.tar.bz2
+  sha256: c380cf0d516faca72d422dec2fbc40e0eea631d0eda0bc68b014dad736e8967e
+  md5: ed5dae434dc0e59c59cc53b9881e16ab
+  depends:
+  - r-base >=4.1,<4.2.0a0
+  license: GPL (>= 2)
+  license_family: GPL3
+  purls: []
+  size: 199405
+  timestamp: 1665193801113
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-squarem-2021.1-r43hc72bb7e_3.conda
+  sha256: ea2b2aa0b0a00439994eee07ff0cf38b1a6a8968935ab90b48f6adcb22157259
+  md5: 7540130cd26e12a02742dac9ddc184d6
+  depends:
+  - r-base >=4.3,<4.4.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL3
+  purls: []
+  size: 194776
+  timestamp: 1719765413315
 - conda: https://conda.anaconda.org/conda-forge/linux-64/r-stringi-1.8.4-r43h33cde33_3.conda
   sha256: 613fddb570c4f74ff1ba06006fe1da67ed0b162a737e93bfe67fdb5c174eb68a
   md5: 827bd9c9e7a678acee9c6a2d5b0586a6
@@ -12397,8 +15300,6 @@ packages:
   - libgcc >=13
   - r-base >=4.3,<4.4.0a0
   - r-matrix
-  arch: x86_64
-  platform: linux
   license: LGPL-2.0-or-later
   license_family: LGPL
   purls: []
@@ -12411,8 +15312,6 @@ packages:
   - __osx >=10.13
   - r-base >=4.3,<4.4.0a0
   - r-matrix
-  arch: x86_64
-  platform: osx
   license: LGPL-2.0-or-later
   license_family: LGPL
   purls: []
@@ -12425,8 +15324,6 @@ packages:
   - __osx >=11.0
   - r-base >=4.3,<4.4.0a0
   - r-matrix
-  arch: arm64
-  platform: osx
   license: LGPL-2.0-or-later
   license_family: LGPL
   purls: []
@@ -12443,8 +15340,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.3,<15
   - vc14_runtime >=14.38.33135
-  arch: x86_64
-  platform: win
   license: LGPL-2.0-or-later
   license_family: LGPL
   purls: []
@@ -12649,6 +15544,131 @@ packages:
   purls: []
   size: 216463
   timestamp: 1686753518989
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-timechange-0.3.0-r43ha18555a_1.conda
+  sha256: c7e6b5f2f394b589825e2fa7ef42b54db45efcd32f51278b7d0f271c1cfc4fc9
+  md5: da155dc726414cca04cdc76a297c4463
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - r-base >=4.3,<4.4.0a0
+  - r-cpp11 >=0.2.7
+  license: GPL-3.0-only AND Apache-2.0
+  license_family: GPL3
+  purls: []
+  size: 191005
+  timestamp: 1719759752046
+- conda: https://conda.anaconda.org/conda-forge/osx-64/r-timechange-0.3.0-r43h25d921d_1.conda
+  sha256: aba7b09b7253c5590c743ceb6a0a97f3ad1708c9b2d4ade306782f3b7a68936c
+  md5: 51c015491614a690d8809baf3d49b3f0
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  - r-base >=4.3,<4.4.0a0
+  - r-cpp11 >=0.2.7
+  license: GPL-3.0-only AND Apache-2.0
+  license_family: GPL3
+  purls: []
+  size: 180402
+  timestamp: 1719759768510
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-timechange-0.3.0-r43hd76f289_1.conda
+  sha256: 880da4d40346faa3981606cb84eceafba231fce742fa2421b20bb135c041314a
+  md5: 9e997e5d04a7d017f32c2ca85587a756
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  - r-base >=4.3,<4.4.0a0
+  - r-cpp11 >=0.2.7
+  license: GPL-3.0-only AND Apache-2.0
+  license_family: GPL3
+  purls: []
+  size: 176563
+  timestamp: 1719759881002
+- conda: https://conda.anaconda.org/conda-forge/win-64/r-timechange-0.3.0-r41ha856d6a_0.conda
+  sha256: d3d775d7182898ddd52bbd499f87c03eef90819259d953296a3f91313a93e168
+  md5: 0093d548b5d43b04c0fa891e468671c1
+  depends:
+  - m2w64-gcc-libs
+  - m2w64-gcc-libs-core
+  - r-base >=4.1,<4.2.0a0
+  - r-cpp11 >=0.2.7
+  license: GPL-3.0-only AND Apache-2.0
+  license_family: GPL3
+  purls: []
+  size: 217689
+  timestamp: 1705580914739
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-timedate-4022.108-r41hc72bb7e_0.conda
+  sha256: 480a86db7c44fd0789edb7f5e0d0d38c7d9e677ca3e6b50219f3a34c3d25d816
+  md5: 047f9b550bf49b95d662f4180c9097c8
+  depends:
+  - r-base >=4.1,<4.2.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL3
+  purls: []
+  size: 1202549
+  timestamp: 1673125673006
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-timedate-4041.110-r43hc72bb7e_0.conda
+  sha256: 1210aa2dadb7ad3c7e18872469cfbf1ac45049b3b5dd789edbf60fa87f62812b
+  md5: 77c4992076f8edd8f5fa4b3ed2717fa2
+  depends:
+  - r-base >=4.3,<4.4.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL3
+  purls: []
+  size: 1249991
+  timestamp: 1727020210599
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-tzdb-0.5.0-r43h93ab643_0.conda
+  sha256: 2b41bcdfb662a526a6e8fd983d47fe57761b82c778243571a3e55a8de8633652
+  md5: a2abc26bd2c81ad6227752ec8465fd33
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - r-base >=4.3,<4.4.0a0
+  - r-cpp11 >=0.5.2
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 551797
+  timestamp: 1743493647546
+- conda: https://conda.anaconda.org/conda-forge/osx-64/r-tzdb-0.5.0-r43h2711daa_0.conda
+  sha256: 1299d7a90d666389f0afae4af0717e82a369dad1f517b3f5aad500bde9825566
+  md5: 1f11c0f3b8fe094f87afa2592826fef9
+  depends:
+  - __osx >=10.13
+  - libcxx >=18
+  - r-base >=4.3,<4.4.0a0
+  - r-cpp11 >=0.5.2
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 551248
+  timestamp: 1743493870967
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-tzdb-0.5.0-r43h31118f2_0.conda
+  sha256: 329b66232bbea05eed15c0d6c34bf0d27b97a92cacd5b8321c412759f3360bb1
+  md5: 10f75f04b5b9912ec5adb0f032ef9e2a
+  depends:
+  - __osx >=11.0
+  - libcxx >=18
+  - r-base >=4.3,<4.4.0a0
+  - r-cpp11 >=0.5.2
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 546726
+  timestamp: 1743494095010
+- conda: https://conda.anaconda.org/conda-forge/win-64/r-tzdb-0.4.0-r41ha856d6a_1.conda
+  sha256: 5a6f361b0cec7b161e9f2ee238e4b482447aad43144616633dd70775acc08535
+  md5: f917c2dcec1070ca500a18fa87594b88
+  depends:
+  - m2w64-gcc-libs
+  - m2w64-gcc-libs-core
+  - r-base >=4.1,<4.2.0a0
+  - r-cpp11 >=0.4.2
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 556207
+  timestamp: 1686772132588
 - conda: https://conda.anaconda.org/conda-forge/linux-64/r-utf8-1.2.4-r43hb1dbf0f_1.conda
   sha256: 68f86411dfe4dfede26981af34744d76a6f6c566d545dd4ac39b1698228fb884
   md5: 6337f1f20dea2a325142d2b7b1b7d42c
@@ -12779,6 +15799,32 @@ packages:
   purls: []
   size: 1303517
   timestamp: 1719738713050
+- conda: https://conda.anaconda.org/conda-forge/win-64/r-vroom-1.6.5-r41ha856d6a_0.conda
+  sha256: 77a717821ea727c6dcff8b30a7f1aa671d7ba1b137e938caf6ea3ba1d2718f90
+  md5: 88ea58839f4d51a1d0e2431a29696936
+  depends:
+  - m2w64-gcc-libs
+  - m2w64-gcc-libs-core
+  - r-base >=4.1,<4.2.0a0
+  - r-bit64
+  - r-cli
+  - r-cpp11 >=0.2.0
+  - r-crayon
+  - r-glue
+  - r-hms
+  - r-lifecycle
+  - r-progress >=1.2.1
+  - r-rlang >=0.4.2
+  - r-tibble >=2.0.0
+  - r-tidyselect
+  - r-tzdb >=0.1.1
+  - r-vctrs >=0.2.0
+  - r-withr
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 887488
+  timestamp: 1701825816410
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-withr-2.5.0-r41hc72bb7e_1.tar.bz2
   sha256: 59a3a6243a455e4be16e4f2a45d3ec6ea7d8928eaa3cb0edf3f92d8158ef9c0c
   md5: 23c0e5a3dc9258b9a06928097560adba
@@ -12799,6 +15845,88 @@ packages:
   purls: []
   size: 231178
   timestamp: 1730138441270
+- conda: https://conda.anaconda.org/conda-forge/win-64/r-xfun-0.45-r41he75b88d_0.conda
+  sha256: 101bd356aa38901a34cfd25a2c9994029cce8bf375d014cd32cfe4c40873558c
+  md5: a7e3ab778f58b7e42efc3e183659f0d6
+  depends:
+  - m2w64-gcc-libs
+  - m2w64-gcc-libs-core
+  - r-base >=4.1,<4.2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 503271
+  timestamp: 1718594859610
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-xml2-1.3.6-r43h8194278_2.conda
+  sha256: 87d885d36d2c28e91ed80c6e6319d3c129a66449b6dad923b12a82d31a0f8043
+  md5: bf45fca038138a632e44be28adad50b5
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libxml2 >=2.12.7,<2.14.0a0
+  - r-base >=4.3,<4.4.0a0
+  - r-cli
+  - r-rlang >=1.1.0
+  license: GPL-2.0-or-later
+  license_family: GPL2
+  purls: []
+  size: 346428
+  timestamp: 1722634295195
+- conda: https://conda.anaconda.org/conda-forge/osx-64/r-xml2-1.3.6-r43h0ea9301_2.conda
+  sha256: 79497942d3c79fae09bd86eb360aa2c0644d5ca4cc6ebf4c3974869a414fb15d
+  md5: c2cc8dcdf9921c0070c71f6d804b83ab
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  - libxml2 >=2.12.7,<2.14.0a0
+  - r-base >=4.3,<4.4.0a0
+  - r-cli
+  - r-rlang >=1.1.0
+  license: GPL-2.0-or-later
+  license_family: GPL2
+  purls: []
+  size: 345172
+  timestamp: 1722634376748
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/r-xml2-1.3.6-r43hdac5c33_2.conda
+  sha256: 61461594f012d7eec18da6dddd3cc1ab8ed6399d13c776bc6855fb944deac6d6
+  md5: faad52b12a044f21a1e5a1f746130324
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  - libxml2 >=2.12.7,<2.14.0a0
+  - r-base >=4.3,<4.4.0a0
+  - r-cli
+  - r-rlang >=1.1.0
+  license: GPL-2.0-or-later
+  license_family: GPL2
+  purls: []
+  size: 200422
+  timestamp: 1722634480949
+- conda: https://conda.anaconda.org/conda-forge/win-64/r-yaml-2.3.8-r41h6d2157b_0.conda
+  sha256: 3ae119e0f5da0198382cae38fb5d6504461e30d031f30b84fedb1ceb14c4f122
+  md5: c56149984cbb9b55b6988f8a3b7ff618
+  depends:
+  - m2w64-gcc-libs
+  - m2w64-gcc-libs-core
+  - r-base >=4.1,<4.2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 124686
+  timestamp: 1702335579870
+- conda: https://conda.anaconda.org/conda-forge/win-64/r-zip-2.3.1-r41h6d2157b_0.conda
+  sha256: ef5f8bfcc9c4e5255d5772809ac549d5e3a2e7126b83c98b9d556bb0fe82adf2
+  md5: 970721ed57adf4fe0cf6ed6d7db0f9c6
+  depends:
+  - m2w64-gcc-libs
+  - m2w64-gcc-libs-core
+  - r-base >=4.1,<4.2.0a0
+  license: MIT
+  license_family: CC
+  purls: []
+  size: 300463
+  timestamp: 1706360756018
 - conda: https://conda.anaconda.org/conda-forge/linux-64/r-zoo-1.8_12-r43hb1dbf0f_2.conda
   sha256: c10148d59300b7b97026d5a4b586844dd83d0e21165da94ed40262a93f936631
   md5: 952e1c80dccc51f914f821157b2a67e8
@@ -13957,7 +17085,7 @@ packages:
   version: 4.67.1
   sha256: 26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2
   requires_dist:
-  - colorama ; platform_system == 'Windows'
+  - colorama ; sys_platform == 'win32'
   - pytest>=6 ; extra == 'dev'
   - pytest-cov ; extra == 'dev'
   - pytest-timeout ; extra == 'dev'

--- a/pixi.lock
+++ b/pixi.lock
@@ -10098,7 +10098,7 @@ packages:
 - pypi: ./
   name: pyfixest
   version: 0.29.0
-  sha256: 51ec4b84fe2035483ba10a708f81cd98c87d8e164111b846638b34c631b49198
+  sha256: e8bacad57eaddef2231e3be50c53f3b72817d0b6580526868753fcee00ce672b
   requires_dist:
   - scipy>=1.6
   - formulaic>=1.1.0

--- a/pyfixest/utils/check_r_install.py
+++ b/pyfixest/utils/check_r_install.py
@@ -1,0 +1,21 @@
+from rpy2.robjects.packages import importr
+
+
+def _catch_import_issue(name: str, strict: bool) -> None:
+    if strict:
+        raise ImportError(
+            f"{name} package not found. Make sure the extended R environment is installed."
+        )
+    else:
+        print(f"Warning: {name} is not installed. Extended R tests will be unable to run.")
+
+
+def check_r_install(package_names: str | list[str], strict: bool = False) -> None:
+    "Catch R import issues for package_names and raise ImportError if strict is True."
+    utils = importr("utils")
+    package_list = package_names if isinstance(package_names, list) else [package_names]
+    installed_packages = utils.installed_packages()
+
+    for package in package_list:
+        if package not in installed_packages:
+            _catch_import_issue(package, strict)

--- a/pyfixest/utils/check_r_install.py
+++ b/pyfixest/utils/check_r_install.py
@@ -7,7 +7,9 @@ def _catch_import_issue(name: str, strict: bool) -> None | bool:
             f"{name} package not found. Make sure the extended R environment is installed."
         )
     else:
-        print(f"Warning: {name} is not installed. Extended R tests will be unable to run.")
+        print(
+            f"Warning: {name} is not installed. Extended R tests will be unable to run."
+        )
         return False
 
 

--- a/pyfixest/utils/check_r_install.py
+++ b/pyfixest/utils/check_r_install.py
@@ -1,21 +1,26 @@
 from rpy2.robjects.packages import importr
 
 
-def _catch_import_issue(name: str, strict: bool) -> None:
+def _catch_import_issue(name: str, strict: bool) -> None | bool:
     if strict:
         raise ImportError(
             f"{name} package not found. Make sure the extended R environment is installed."
         )
     else:
         print(f"Warning: {name} is not installed. Extended R tests will be unable to run.")
+        return False
 
 
-def check_r_install(package_names: str | list[str], strict: bool = False) -> None:
-    "Catch R import issues for package_names and raise ImportError if strict is True."
+def check_r_install(package_names: str | list[str], strict: bool = False) -> bool:
+    "Catch R import issues for package_names and raise ImportError if strict is True, otherwise pass a bool for passing check."
     utils = importr("utils")
     package_list = package_names if isinstance(package_names, list) else [package_names]
     installed_packages = utils.installed_packages()
 
+    package_status = []
     for package in package_list:
         if package not in installed_packages:
-            _catch_import_issue(package, strict)
+            package_status.append(_catch_import_issue(package, strict))
+        else:
+            package_status.append(True)
+    return all(package_status)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,10 @@ dependencies = [
 
 [tool.pixi.feature.dev.dependencies]
 rpy2 = ">=3.5.11,<4"
+r = "*"
+r-fixest = ">=0.12.1,<0.13"
+r-sandwich = ">=3.0_2,<4"
+r-broom = ">=1.0.5,<2"
 
 [project.optional-dependencies]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,8 +95,9 @@ plots = { features = ["plots"], solve-group = "default" }
 
 [tool.pixi.feature.dev.tasks]
 tests = "pytest -n 4 --cov-report=term tests"
-tests-against-r = "pytest tests -n 4 -m \"against_r\" --cov=pyfixest --cov-report=xml"
-tests-regular = "pytest tests -n 4 -m \"not (extended or against_r or plots)\" --cov=pyfixest --cov-report=xml"
+tests-against-r-core = "pytest tests -n 4 -m \"against_r_core\" --cov=pyfixest --cov-report=xml"
+tests-against-r-extended = "pytest tests -n 4 -m \"against_r_extended\" --cov=pyfixest --cov-report=xml"
+tests-regular = "pytest tests -n 4 -m \"not (extended or against_r_core or against_r_extended or plots)\" --cov=pyfixest --cov-report=xml"
 tests-extended = "pytest tests -n 4 -m \"extended\" --cov=pyfixest --cov-report=xml"
 tests-fixest = "pytest tests/test_vs_fixest.py -n 4 --cov=pyfixest --cov-report=xml"
 tests-plots-dev = "pixi run --environment dev pytest tests/test_plots.py -n 4"
@@ -105,7 +106,7 @@ tests-rerun = "pytest --lf -n 4"
 debug = "python pyfixest/debug.py"
 lint = "pre-commit run ruff --all-files"
 update-test-data = "Rscript tests/r_test_comparisons.R"
-install-r = "Rscript r_test_requirements.R"
+install-r-extended = "Rscript r_test_requirements.R"
 render-notebooks = "python scripts/run_notebooks.py"
 
 [tool.pixi.feature.build.tasks]
@@ -132,7 +133,8 @@ addopts = [
 ]
 
 markers = [
-  "against_r: mark test to be part of the test suite that depends on R",
+  "against_r_core: mark test to be part of the test suite that depends on conda available R modules",
+  "against_r_extended: mark test to be part of the test suite that depends on other R modules",
   "extended: mark test to be part of the extended test suite",
   "plots: marks all tests for plotting functionality, tests only triggered when using tag in github issue",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ r = "*"
 r-fixest = ">=0.12.1,<0.13"
 r-sandwich = ">=3.0_2,<4"
 r-broom = ">=1.0.5,<2"
+r-car = ">=3.1_2,<4"
 
 [project.optional-dependencies]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,12 +94,12 @@ jax = { features = ["jax"], solve-group = "default" }
 plots = { features = ["plots"], solve-group = "default" }
 
 [tool.pixi.feature.dev.tasks]
-tests = "pytest -n 4 --cov-report=term tests"
-tests-against-r-core = "pytest tests -n 4 -m \"against_r_core\" --cov=pyfixest --cov-report=xml"
-tests-against-r-extended = "pytest tests -n 4 -m \"against_r_extended\" --cov=pyfixest --cov-report=xml"
+tests = "pytest -rs -n 4 --cov-report=term tests"
+tests-against-r-core = "pytest -rs tests -n 4 -m \"against_r_core\" --cov=pyfixest --cov-report=xml"
+tests-against-r-extended = "pytest -rs tests -n 4 -m \"against_r_extended\" --cov=pyfixest --cov-report=xml"
 tests-regular = "pytest tests -n 4 -m \"not (extended or against_r_core or against_r_extended or plots)\" --cov=pyfixest --cov-report=xml"
 tests-extended = "pytest tests -n 4 -m \"extended\" --cov=pyfixest --cov-report=xml"
-tests-fixest = "pytest tests/test_vs_fixest.py -n 4 --cov=pyfixest --cov-report=xml"
+tests-fixest = "pytest -rs tests/test_vs_fixest.py -n 4 --cov=pyfixest --cov-report=xml"
 tests-plots-dev = "pixi run --environment dev pytest tests/test_plots.py -n 4"
 tests-plots = "pixi run --environment plots pytest tests/test_plots.py -n 4"
 tests-rerun = "pytest --lf -n 4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,6 +119,7 @@ docs-preview = "quarto preview docs"
 
 [tool.pixi.feature.docs.dependencies]
 rpy2 = ">=3.5.11,<4"
+r = "*"
 r-fixest = ">=0.12.1,<0.13"
 r-broom = ">=1.0.5,<2"
 

--- a/r_test_requirements.R
+++ b/r_test_requirements.R
@@ -1,7 +1,11 @@
 # note: R, fixest, sandwich, broom are installed via conda
 install.packages(
-    c('did2s', 'wildrwolf', 'reticulate', 'ivDiag', 'car'),
+    c('did2s', 'reticulate', 'ivDiag', 'car'),
     repos='https://cran.rstudio.com'
+);
+install.packages(
+   c('collapse', 'summclust', 'wildrwolf'),
+    repos = c('https://s3alfisc.r-universe.dev', 'https://cloud.r-project.org', 'https://fastverse.r-universe.dev')
 );
 install.packages(
     'ritest',

--- a/r_test_requirements.R
+++ b/r_test_requirements.R
@@ -1,6 +1,6 @@
 # note: R, fixest, sandwich, broom are installed via conda
 install.packages(
-    c('did2s', 'reticulate', 'ivDiag', 'car'),
+    c('did2s', 'reticulate', 'ivDiag'),
     repos='https://cran.rstudio.com'
 );
 install.packages(

--- a/r_test_requirements.R
+++ b/r_test_requirements.R
@@ -1,6 +1,6 @@
-# note: fixest and broom are installed via conda
+# note: R, fixest, sandwich, broom are installed via conda
 install.packages(
-    c('fixest', 'broom','clubSandwich', 'did2s', 'wildrwolf', 'reticulate', 'ivDiag', 'stats', 'base', 'car'),
+    c('did2s', 'wildrwolf', 'reticulate', 'ivDiag', 'car'),
     repos='https://cran.rstudio.com'
 );
 install.packages(

--- a/tests/test_ccv.py
+++ b/tests/test_ccv.py
@@ -7,7 +7,6 @@ from pyfixest.estimation.estimation import feols
 
 
 @pytest.fixture
-@pytest.mark.extended
 def data(local=False):
     """Load the census data used in the tests."""
     if local:
@@ -17,6 +16,7 @@ def data(local=False):
 
 
 # function retrieved from Harvard Dataverse
+@pytest.mark.extended
 def compute_CCV_AAIW(data, depvar, cluster, seed, nmx, pk):
     """
     Compute the CCV variance using a slight variation of AAIW's code.

--- a/tests/test_did.py
+++ b/tests/test_did.py
@@ -1,4 +1,5 @@
 from importlib import resources
+from pathlib import Path
 
 import numpy as np
 import pandas as pd
@@ -22,6 +23,9 @@ fixest = importr("fixest")
 # Extended Packages
 if import_check := check_r_install("did2s", strict=False):
     did2s = importr("did2s")
+# Check mpdata avaialibility
+MPDATA_LOC = "C:/Users/alexa/Documents/pyfixest-zalando-talk/mpdta.csv"
+mpdata_check = Path(MPDATA_LOC).is_file()
 
 
 @pytest.fixture
@@ -362,9 +366,9 @@ def test_fully_interacted(unit, cluster):
 
 
 @pytest.mark.against_r_core
-@pytest.mark.skip("mpdata not available online as csv, only run test locally.")
+@pytest.mark.skipif(mpdata_check is False, reason="mpdata not available online as csv, only run test locally.")
 @pytest.mark.parametrize(
-    "mpdata_path", [r"C:/Users/alexa/Documents/pyfixest-zalando-talk/mpdta.csv"]
+    "mpdata_path", [MPDATA_LOC]
 )
 def test_fully_interacted_mpdata(mpdata_path):
     mpdata = pd.read_csv(mpdata_path)

--- a/tests/test_did.py
+++ b/tests/test_did.py
@@ -366,10 +366,11 @@ def test_fully_interacted(unit, cluster):
 
 
 @pytest.mark.against_r_core
-@pytest.mark.skipif(mpdata_check is False, reason="mpdata not available online as csv, only run test locally.")
-@pytest.mark.parametrize(
-    "mpdata_path", [MPDATA_LOC]
+@pytest.mark.skipif(
+    mpdata_check is False,
+    reason="mpdata not available online as csv, only run test locally.",
 )
+@pytest.mark.parametrize("mpdata_path", [MPDATA_LOC])
 def test_fully_interacted_mpdata(mpdata_path):
     mpdata = pd.read_csv(mpdata_path)
     mpdata["first_treat"] = mpdata["first.treat"]

--- a/tests/test_did.py
+++ b/tests/test_did.py
@@ -12,9 +12,9 @@ from rpy2.robjects.packages import importr
 import pyfixest as pf
 from pyfixest.did.estimation import did2s as did2s_pyfixest
 from pyfixest.did.estimation import event_study, lpdid
-from pyfixest.utils.set_rpy2_path import update_r_paths
+from pyfixest.utils.check_r_install import check_r_install
 
-update_r_paths()
+check_r_install("did2s", strict=True)
 
 pandas2ri.activate()
 did2s = importr("did2s")
@@ -33,6 +33,7 @@ def data():
     return df_het
 
 
+@pytest.mark.against_r_extended
 def test_event_study(data):
     """Test the event_study() function."""
     fit_did2s = event_study(
@@ -73,6 +74,7 @@ def test_event_study(data):
     np.testing.assert_allclose(fit_did2s.se(), float(r_df[2]), atol=1e-05, rtol=1e-05)
 
 
+@pytest.mark.against_r_extended
 @pytest.mark.parametrize("weights", [None, "weights"])
 def test_did2s(data, weights):
     """Test the did2s() function."""
@@ -279,6 +281,7 @@ def test_lpdid():
     fit.tidy()
 
 
+@pytest.mark.against_r_core
 @pytest.mark.parametrize("unit", ["unit"])
 @pytest.mark.parametrize("cluster", ["unit", "unit2"])
 def test_fully_interacted(unit, cluster):
@@ -355,6 +358,7 @@ def test_fully_interacted(unit, cluster):
     )
 
 
+@pytest.mark.against_r_core
 @pytest.mark.skip("mpdata not available online as csv, only run test locally.")
 @pytest.mark.parametrize(
     "mpdata_path", [r"C:/Users/alexa/Documents/pyfixest-zalando-talk/mpdta.csv"]

--- a/tests/test_did.py
+++ b/tests/test_did.py
@@ -20,7 +20,7 @@ stats = importr("stats")
 broom = importr("broom")
 fixest = importr("fixest")
 # Extended Packages
-if (import_check := check_r_install("did2s", strict=False)):
+if import_check := check_r_install("did2s", strict=False):
     did2s = importr("did2s")
 
 

--- a/tests/test_did.py
+++ b/tests/test_did.py
@@ -14,13 +14,14 @@ from pyfixest.did.estimation import did2s as did2s_pyfixest
 from pyfixest.did.estimation import event_study, lpdid
 from pyfixest.utils.check_r_install import check_r_install
 
-check_r_install("did2s", strict=True)
-
 pandas2ri.activate()
-did2s = importr("did2s")
+# Core Packages
 stats = importr("stats")
 broom = importr("broom")
 fixest = importr("fixest")
+# Extended Packages
+if (import_check := check_r_install("did2s", strict=False)):
+    did2s = importr("did2s")
 
 
 @pytest.fixture
@@ -33,6 +34,7 @@ def data():
     return df_het
 
 
+@pytest.mark.skipif(import_check is False, reason="R package did2s not installed.")
 @pytest.mark.against_r_extended
 def test_event_study(data):
     """Test the event_study() function."""
@@ -74,6 +76,7 @@ def test_event_study(data):
     np.testing.assert_allclose(fit_did2s.se(), float(r_df[2]), atol=1e-05, rtol=1e-05)
 
 
+@pytest.mark.skipif(import_check is False, reason="R package did2s not installed.")
 @pytest.mark.against_r_extended
 @pytest.mark.parametrize("weights", [None, "weights"])
 def test_did2s(data, weights):

--- a/tests/test_feols_compressed.py
+++ b/tests/test_feols_compressed.py
@@ -40,7 +40,6 @@ fmls = [
 ]
 
 
-@pytest.mark.against_r
 @pytest.mark.parametrize("fml", fmls)
 @pytest.mark.parametrize("vcov", ["iid", "hetero"])
 @pytest.mark.parametrize(
@@ -140,7 +139,6 @@ def test_feols_compressed(data, fml, vcov, ssc, dropna):
             ), "Error in pvalue"
 
 
-@pytest.mark.against_r
 def test_identical_seed():
     data = pf.get_data()
 
@@ -153,7 +151,6 @@ def test_identical_seed():
     assert np.allclose(fit1.pvalue().xs("f1"), fit2.pvalue().xs("f1")), "Error in seed"
 
 
-@pytest.mark.against_r
 def test_different_seed():
     data = pf.get_data()
 

--- a/tests/test_i.py
+++ b/tests/test_i.py
@@ -8,9 +8,6 @@ from rpy2.robjects import pandas2ri
 from rpy2.robjects.packages import importr
 
 from pyfixest.estimation.estimation import feols
-from pyfixest.utils.set_rpy2_path import update_r_paths
-
-update_r_paths()
 
 pandas2ri.activate()
 
@@ -19,6 +16,7 @@ stats = importr("stats")
 broom = importr("broom")
 
 
+@pytest.mark.against_r_core
 def test_i():
     df_het = pd.read_csv("pyfixest/did/data/df_het.csv")
     df_het["X"] = np.random.normal(size=len(df_het))
@@ -53,6 +51,7 @@ def test_i():
         feols("dep_var~i(rel_year, ref = [1.0, 'a'])", df_het)
 
 
+@pytest.mark.against_r_core
 def test_i_vs_fixest():
     df_het = pd.read_csv("pyfixest/did/data/df_het.csv")
     df_het = df_het[df_het["year"] >= 2010]
@@ -115,6 +114,7 @@ def test_i_vs_fixest():
     )
 
 
+@pytest.mark.against_r_core
 @pytest.mark.parametrize(
     "fml",
     [

--- a/tests/test_iv.py
+++ b/tests/test_iv.py
@@ -13,7 +13,7 @@ from pyfixest.utils.utils import get_data
 pandas2ri.activate()
 
 # Extend R packages
-if (import_check := check_r_install("ivDiag", strict=False)):
+if import_check := check_r_install("ivDiag", strict=False):
     ivDiag = importr("ivDiag")
 
 

--- a/tests/test_iv.py
+++ b/tests/test_iv.py
@@ -6,20 +6,16 @@ from rpy2.robjects import pandas2ri
 from rpy2.robjects.packages import importr
 
 from pyfixest.estimation.estimation import feols
-from pyfixest.utils.set_rpy2_path import update_r_paths
+from pyfixest.utils.check_r_install import check_r_install
 from pyfixest.utils.utils import get_data
 
-update_r_paths()
+check_r_install("ivDiag", strict=True)
 
-# Activate pandas2ri to enable conversion between pandas DataFrames and R DataFrames
+# Enable the automatic conversion between pandas DataFrame and R DataFrame
 pandas2ri.activate()
 
 # Import the ivDiag package
 ivDiag = importr("ivDiag")
-
-
-# Enable the automatic conversion between pandas DataFrame and R DataFrame
-pandas2ri.activate()
 
 
 @pytest.fixture(scope="module")
@@ -120,6 +116,7 @@ def r_results():
     }
 
 
+@pytest.mark.against_r_extended
 @pytest.mark.parametrize("has_weight", [False, True])
 @pytest.mark.parametrize("adj_vcov", ["iid", "hetero", {"CRV1": "cluster"}])
 def test_iv_Fstat_ivDiag(has_weight, adj_vcov, r_results):

--- a/tests/test_iv.py
+++ b/tests/test_iv.py
@@ -9,13 +9,12 @@ from pyfixest.estimation.estimation import feols
 from pyfixest.utils.check_r_install import check_r_install
 from pyfixest.utils.utils import get_data
 
-check_r_install("ivDiag", strict=True)
-
 # Enable the automatic conversion between pandas DataFrame and R DataFrame
 pandas2ri.activate()
 
-# Import the ivDiag package
-ivDiag = importr("ivDiag")
+# Extend R packages
+if (import_check := check_r_install("ivDiag", strict=False)):
+    ivDiag = importr("ivDiag")
 
 
 @pytest.fixture(scope="module")
@@ -116,6 +115,7 @@ def r_results():
     }
 
 
+@pytest.mark.skipif(import_check is False, reason="R package ivDiag not installed.")
 @pytest.mark.against_r_extended
 @pytest.mark.parametrize("has_weight", [False, True])
 @pytest.mark.parametrize("adj_vcov", ["iid", "hetero", {"CRV1": "cluster"}])

--- a/tests/test_multcomp.py
+++ b/tests/test_multcomp.py
@@ -8,10 +8,10 @@ from rpy2.robjects.packages import importr
 import pyfixest as pf
 from pyfixest.estimation.estimation import feols
 from pyfixest.estimation.multcomp import _get_rwolf_pval, bonferroni, rwolf
-from pyfixest.utils.set_rpy2_path import update_r_paths
+from pyfixest.utils.check_r_install import check_r_install
 from pyfixest.utils.utils import get_data
 
-update_r_paths()
+check_r_install("wildrwolf", strict=True)
 
 pandas2ri.activate()
 
@@ -21,6 +21,7 @@ stats = importr("stats")
 broom = importr("broom")
 
 
+@pytest.mark.against_r_core
 @pytest.mark.extended
 def test_bonferroni():
     data = get_data().dropna()
@@ -56,6 +57,7 @@ def test_bonferroni():
     )
 
 
+@pytest.mark.against_r_extended
 @pytest.mark.extended
 @pytest.mark.parametrize("seed", [293, 912, 831])
 @pytest.mark.parametrize("sd", [0.5, 1.0, 1.5])
@@ -96,6 +98,7 @@ def test_wildrwolf_hc(seed, sd):
         )
 
 
+@pytest.mark.against_r_extended
 @pytest.mark.extended
 @pytest.mark.parametrize("seed", [9391])
 @pytest.mark.parametrize("sd", [0.5, 1.5])
@@ -138,6 +141,7 @@ def test_wildrwolf_crv(seed, sd):
         )
 
 
+@pytest.mark.against_r_extended
 @pytest.mark.extended
 def test_stepwise_function():
     B = 1000

--- a/tests/test_multcomp.py
+++ b/tests/test_multcomp.py
@@ -18,9 +18,8 @@ fixest = importr("fixest")
 stats = importr("stats")
 broom = importr("broom")
 # Extended R packages
-if (import_check := check_r_install("wildrwolf", strict=False)):
+if import_check := check_r_install("wildrwolf", strict=False):
     wildrwolf = importr("wildrwolf")
-
 
 
 @pytest.mark.against_r_core

--- a/tests/test_multcomp.py
+++ b/tests/test_multcomp.py
@@ -11,14 +11,16 @@ from pyfixest.estimation.multcomp import _get_rwolf_pval, bonferroni, rwolf
 from pyfixest.utils.check_r_install import check_r_install
 from pyfixest.utils.utils import get_data
 
-check_r_install("wildrwolf", strict=True)
-
 pandas2ri.activate()
 
+# Core R packages
 fixest = importr("fixest")
-wildrwolf = importr("wildrwolf")
 stats = importr("stats")
 broom = importr("broom")
+# Extended R packages
+if (import_check := check_r_install("wildrwolf", strict=False)):
+    wildrwolf = importr("wildrwolf")
+
 
 
 @pytest.mark.against_r_core
@@ -57,6 +59,7 @@ def test_bonferroni():
     )
 
 
+@pytest.mark.skipif(import_check is False, reason="R package wildrwolf not installed.")
 @pytest.mark.against_r_extended
 @pytest.mark.extended
 @pytest.mark.parametrize("seed", [293, 912, 831])
@@ -98,6 +101,7 @@ def test_wildrwolf_hc(seed, sd):
         )
 
 
+@pytest.mark.skipif(import_check is False, reason="R package wildrwolf not installed.")
 @pytest.mark.against_r_extended
 @pytest.mark.extended
 @pytest.mark.parametrize("seed", [9391])
@@ -141,6 +145,7 @@ def test_wildrwolf_crv(seed, sd):
         )
 
 
+@pytest.mark.skipif(import_check is False, reason="R package wildrwolf not installed.")
 @pytest.mark.against_r_extended
 @pytest.mark.extended
 def test_stepwise_function():

--- a/tests/test_poisson.py
+++ b/tests/test_poisson.py
@@ -12,14 +12,10 @@ from rpy2.robjects.packages import importr
 
 import pyfixest as pf
 from pyfixest.estimation.estimation import fepois
-from pyfixest.utils.set_rpy2_path import update_r_paths
-
-update_r_paths()
 
 pandas2ri.activate()
 
 fixest = importr("fixest")
-stats = importr("stats")
 
 
 def test_separation():
@@ -101,6 +97,7 @@ def test_separation():
             assert len(record) == 0
 
 
+@pytest.mark.against_r_core
 @pytest.mark.parametrize("fml", ["Y ~ X1", "Y ~ X1 | f1"])
 def test_against_fixest(fml):
     data = pf.get_data(model="Fepois")

--- a/tests/test_predict_resid_fixef.py
+++ b/tests/test_predict_resid_fixef.py
@@ -9,9 +9,6 @@ from rpy2.robjects.packages import importr
 
 import pyfixest as pf
 from pyfixest.utils.dev_utils import _extract_variable_level
-from pyfixest.utils.set_rpy2_path import update_r_paths
-
-update_r_paths()
 
 pandas2ri.activate()
 
@@ -73,6 +70,7 @@ def test_poisson_prediction_internally(data, weights, fml):
         fit.predict()
 
 
+@pytest.mark.against_r_core
 @pytest.mark.parametrize(
     "fml",
     [
@@ -167,6 +165,7 @@ def test_vs_fixest(data, fml):
     # test with missing fixed effects
 
 
+@pytest.mark.against_r_core
 def test_predict_nas():
     # tests to fix #246: https://github.com/py-econometrics/pyfixest/issues/246
 
@@ -214,6 +213,7 @@ def test_predict_nas():
     assert len(res) == len(res_r)
 
 
+@pytest.mark.against_r_core
 @pytest.mark.parametrize(
     "fml",
     [

--- a/tests/test_vs_fixest.py
+++ b/tests/test_vs_fixest.py
@@ -12,10 +12,7 @@ from rpy2.robjects.packages import importr
 import pyfixest as pf
 from pyfixest.estimation.estimation import feols
 from pyfixest.estimation.FixestMulti_ import FixestMulti
-from pyfixest.utils.set_rpy2_path import update_r_paths
 from pyfixest.utils.utils import get_data, ssc
-
-update_r_paths()
 
 pandas2ri.activate()
 
@@ -191,7 +188,7 @@ test_counter_feiv = 0
 # - cluster_adj: True
 
 
-@pytest.mark.against_r
+@pytest.mark.against_r_core
 @pytest.mark.parametrize("dropna", [False, True])
 @pytest.mark.parametrize("inference", ["iid", "hetero", {"CRV1": "group_id"}])
 @pytest.mark.parametrize("weights", [None, "weights"])
@@ -428,7 +425,7 @@ def test_single_fit_feols(
         )
 
 
-@pytest.mark.against_r
+@pytest.mark.against_r_core
 @pytest.mark.parametrize("dropna", [False, True])
 @pytest.mark.parametrize("weights", [None, "weights"])
 @pytest.mark.parametrize("f3_type", ["str", "object", "int", "categorical", "float"])
@@ -486,7 +483,7 @@ def test_single_fit_feols_empty(
     assert mod._beta_hat.size == 0
 
 
-@pytest.mark.against_r
+@pytest.mark.against_r_core
 @pytest.mark.parametrize("dropna", [False])
 @pytest.mark.parametrize("inference", ["iid", "hetero", {"CRV1": "group_id"}])
 @pytest.mark.parametrize("f3_type", ["str"])
@@ -611,7 +608,7 @@ def test_single_fit_fepois(
         )
 
 
-@pytest.mark.against_r
+@pytest.mark.against_r_core
 @pytest.mark.parametrize("dropna", [False])
 @pytest.mark.parametrize("weights", [None, "weights"])
 @pytest.mark.parametrize("inference", ["iid", "hetero", {"CRV1": "group_id"}])
@@ -707,7 +704,7 @@ def test_single_fit_iv(
     check_absolute_diff(py_confint, r_confint, 1e-06, "py_confint != r_confint")
 
 
-@pytest.mark.against_r
+@pytest.mark.against_r_core
 @pytest.mark.parametrize("N", [100])
 @pytest.mark.parametrize("seed", [172])
 @pytest.mark.parametrize("dropna", [True, False])
@@ -871,7 +868,7 @@ def test_glm_vs_fixest(N, seed, dropna, fml, inference, family):
     )
 
 
-@pytest.mark.against_r
+@pytest.mark.against_r_core
 @pytest.mark.parametrize("N", [100])
 @pytest.mark.parametrize("seed", [17021])
 @pytest.mark.parametrize("beta_type", ["1"])
@@ -978,7 +975,7 @@ def test_multi_fit(N, seed, beta_type, error_type, dropna, fml_multi):
         )
 
 
-@pytest.mark.against_r
+@pytest.mark.against_r_core
 @pytest.mark.parametrize("N", [100])
 @pytest.mark.parametrize("seed", [31])
 @pytest.mark.parametrize("beta_type", ["1"])
@@ -1054,7 +1051,7 @@ def test_split_fit(N, seed, beta_type, error_type, dropna, fml_multi, split, fsp
         )
 
 
-@pytest.mark.against_r
+@pytest.mark.against_r_core
 def test_twoway_clustering():
     data = get_data(N=500, seed=17021, beta_type="1", error_type="1").dropna()
 
@@ -1111,7 +1108,7 @@ def test_twoway_clustering():
             )
 
 
-@pytest.mark.against_r
+@pytest.mark.against_r_core
 def test_wls_na():
     """Special tests for WLS and NA values."""
     data = get_data()
@@ -1229,7 +1226,7 @@ def get_data_r(fml, data):
     return data_r
 
 
-@pytest.mark.against_r
+@pytest.mark.against_r_core
 @pytest.mark.parametrize(
     "fml",
     [
@@ -1260,7 +1257,7 @@ def test_wald_test(fml, data):
     # np.testing.assert_allclose(fit1._f_statistic_pvalue, wald_pval_r)
 
 
-@pytest.mark.against_r
+@pytest.mark.against_r_core
 def test_singleton_dropping():
     data = get_data()
     # create a singleton fixed effect
@@ -1320,7 +1317,7 @@ ssc_fmls = [
 ]
 
 
-@pytest.mark.against_r
+@pytest.mark.against_r_core
 @pytest.mark.parametrize("fml", ssc_fmls)
 @pytest.mark.parametrize("dropna", [True, False])
 @pytest.mark.parametrize("weights", [None, "weights"])

--- a/tests/test_wald_test.py
+++ b/tests/test_wald_test.py
@@ -20,7 +20,7 @@ stats = importr("stats")
 base = importr("base")
 broom = importr("broom")
 # Extended R packages
-if (import_check := check_r_install("car", strict=False)):
+if import_check := check_r_install("car", strict=False):
     car = importr("car")
 
 

--- a/tests/test_wald_test.py
+++ b/tests/test_wald_test.py
@@ -9,7 +9,6 @@ from rpy2.robjects.packages import importr
 
 import pyfixest as pf
 from pyfixest.estimation.estimation import feols
-from pyfixest.utils.check_r_install import check_r_install
 from pyfixest.utils.utils import ssc
 
 pandas2ri.activate()
@@ -22,7 +21,7 @@ broom = importr("broom")
 car = importr("car")
 
 
-@pytest.mark.against_r_extended
+@pytest.mark.against_r_core
 @pytest.mark.parametrize(
     "R",
     [
@@ -67,7 +66,7 @@ def test_F_test_single_equation_no_clustering(R):
     np.testing.assert_allclose(p_stat, r_pvalue, rtol=1e-03, atol=1e-02)
 
 
-@pytest.mark.against_r_extended
+@pytest.mark.against_r_core
 @pytest.mark.parametrize(
     "R",
     [
@@ -104,7 +103,7 @@ def test_F_test_single_equation(R):
     np.testing.assert_allclose(p_value, r_pvalue, rtol=1e-03, atol=1e-03)
 
 
-@pytest.mark.against_r_extended
+@pytest.mark.against_r_core
 @pytest.mark.parametrize(
     "seedn",
     [
@@ -154,7 +153,7 @@ def test_F_test_multiple_equation(seedn):
     np.testing.assert_allclose(p_value, r_pvalue, rtol=1e-03, atol=1e-03)
 
 
-@pytest.mark.against_r_extended
+@pytest.mark.against_r_core
 @pytest.mark.parametrize(
     "R, fml",
     [
@@ -214,7 +213,7 @@ def test_F_test_multiple_equations_pvalue(R, fml):
     np.testing.assert_allclose(f_stat, r_fstat, rtol=1e-02, atol=1e-02)
 
 
-@pytest.mark.against_r_extended
+@pytest.mark.against_r_core
 @pytest.mark.parametrize(
     "R, q, fml",
     [

--- a/tests/test_wald_test.py
+++ b/tests/test_wald_test.py
@@ -19,12 +19,9 @@ fixest = importr("fixest")
 stats = importr("stats")
 base = importr("base")
 broom = importr("broom")
-# Extended R packages
-if import_check := check_r_install("car", strict=False):
-    car = importr("car")
+car = importr("car")
 
 
-@pytest.mark.skipif(import_check is False, reason="R package car not installed.")
 @pytest.mark.against_r_extended
 @pytest.mark.parametrize(
     "R",
@@ -70,7 +67,6 @@ def test_F_test_single_equation_no_clustering(R):
     np.testing.assert_allclose(p_stat, r_pvalue, rtol=1e-03, atol=1e-02)
 
 
-@pytest.mark.skipif(import_check is False, reason="R package car not installed.")
 @pytest.mark.against_r_extended
 @pytest.mark.parametrize(
     "R",
@@ -108,7 +104,6 @@ def test_F_test_single_equation(R):
     np.testing.assert_allclose(p_value, r_pvalue, rtol=1e-03, atol=1e-03)
 
 
-@pytest.mark.skipif(import_check is False, reason="R package car not installed.")
 @pytest.mark.against_r_extended
 @pytest.mark.parametrize(
     "seedn",
@@ -159,7 +154,6 @@ def test_F_test_multiple_equation(seedn):
     np.testing.assert_allclose(p_value, r_pvalue, rtol=1e-03, atol=1e-03)
 
 
-@pytest.mark.skipif(import_check is False, reason="R package car not installed.")
 @pytest.mark.against_r_extended
 @pytest.mark.parametrize(
     "R, fml",
@@ -220,7 +214,6 @@ def test_F_test_multiple_equations_pvalue(R, fml):
     np.testing.assert_allclose(f_stat, r_fstat, rtol=1e-02, atol=1e-02)
 
 
-@pytest.mark.skipif(import_check is False, reason="R package car not installed.")
 @pytest.mark.against_r_extended
 @pytest.mark.parametrize(
     "R, q, fml",

--- a/tests/test_wald_test.py
+++ b/tests/test_wald_test.py
@@ -12,17 +12,19 @@ from pyfixest.estimation.estimation import feols
 from pyfixest.utils.check_r_install import check_r_install
 from pyfixest.utils.utils import ssc
 
-check_r_install("car", strict=True)
-
 pandas2ri.activate()
 
+# Core R packages
 fixest = importr("fixest")
 stats = importr("stats")
-broom = importr("broom")
-car = importr("car")
 base = importr("base")
+broom = importr("broom")
+# Extended R packages
+if (import_check := check_r_install("car", strict=False)):
+    car = importr("car")
 
 
+@pytest.mark.skipif(import_check is False, reason="R package car not installed.")
 @pytest.mark.against_r_extended
 @pytest.mark.parametrize(
     "R",
@@ -68,6 +70,7 @@ def test_F_test_single_equation_no_clustering(R):
     np.testing.assert_allclose(p_stat, r_pvalue, rtol=1e-03, atol=1e-02)
 
 
+@pytest.mark.skipif(import_check is False, reason="R package car not installed.")
 @pytest.mark.against_r_extended
 @pytest.mark.parametrize(
     "R",
@@ -105,6 +108,7 @@ def test_F_test_single_equation(R):
     np.testing.assert_allclose(p_value, r_pvalue, rtol=1e-03, atol=1e-03)
 
 
+@pytest.mark.skipif(import_check is False, reason="R package car not installed.")
 @pytest.mark.against_r_extended
 @pytest.mark.parametrize(
     "seedn",
@@ -155,6 +159,7 @@ def test_F_test_multiple_equation(seedn):
     np.testing.assert_allclose(p_value, r_pvalue, rtol=1e-03, atol=1e-03)
 
 
+@pytest.mark.skipif(import_check is False, reason="R package car not installed.")
 @pytest.mark.against_r_extended
 @pytest.mark.parametrize(
     "R, fml",
@@ -215,6 +220,7 @@ def test_F_test_multiple_equations_pvalue(R, fml):
     np.testing.assert_allclose(f_stat, r_fstat, rtol=1e-02, atol=1e-02)
 
 
+@pytest.mark.skipif(import_check is False, reason="R package car not installed.")
 @pytest.mark.against_r_extended
 @pytest.mark.parametrize(
     "R, q, fml",

--- a/tests/test_wald_test.py
+++ b/tests/test_wald_test.py
@@ -9,10 +9,10 @@ from rpy2.robjects.packages import importr
 
 import pyfixest as pf
 from pyfixest.estimation.estimation import feols
-from pyfixest.utils.set_rpy2_path import update_r_paths
+from pyfixest.utils.check_r_install import check_r_install
 from pyfixest.utils.utils import ssc
 
-update_r_paths()
+check_r_install("car", strict=True)
 
 pandas2ri.activate()
 
@@ -23,6 +23,7 @@ car = importr("car")
 base = importr("base")
 
 
+@pytest.mark.against_r_extended
 @pytest.mark.parametrize(
     "R",
     [
@@ -67,6 +68,7 @@ def test_F_test_single_equation_no_clustering(R):
     np.testing.assert_allclose(p_stat, r_pvalue, rtol=1e-03, atol=1e-02)
 
 
+@pytest.mark.against_r_extended
 @pytest.mark.parametrize(
     "R",
     [
@@ -103,6 +105,7 @@ def test_F_test_single_equation(R):
     np.testing.assert_allclose(p_value, r_pvalue, rtol=1e-03, atol=1e-03)
 
 
+@pytest.mark.against_r_extended
 @pytest.mark.parametrize(
     "seedn",
     [
@@ -152,6 +155,7 @@ def test_F_test_multiple_equation(seedn):
     np.testing.assert_allclose(p_value, r_pvalue, rtol=1e-03, atol=1e-03)
 
 
+@pytest.mark.against_r_extended
 @pytest.mark.parametrize(
     "R, fml",
     [
@@ -211,6 +215,7 @@ def test_F_test_multiple_equations_pvalue(R, fml):
     np.testing.assert_allclose(f_stat, r_fstat, rtol=1e-02, atol=1e-02)
 
 
+@pytest.mark.against_r_extended
 @pytest.mark.parametrize(
     "R, q, fml",
     [


### PR DESCRIPTION
This is a PR related to #828. 

**Summary of Code Changes:**
- R and conda-forge available R packages ("core") are now installed as part of the dev environment. Other R packages ("extended") are still installed via the "r_test_requirements.R" method and pixi task. The doc environment was also updated to install R via conda so users (I think) do not need their own out-of-project R installation. 
- All tests that call R packages (even if the package is only called on a path that cannot be taken) are labeled as part of "against_r_core" or "against_r_extended. 
- Added a small utility to check for installed R packages. Tests that rely on extended R packages will be skipped with an informative message if the related package is not installed. This is similar to how the visualization tests are handled if dependencies are not available. 
- Updated the contribution docs to reflect the changes above. 
- [!] Updated the github actions, but I'm not sure if that was done correctly. 

**Some Notes:**
1. I am not sure if the doc environment also relies on "extended R packages". If so the updates may break that code. When installing the extra R packages, I am fairly sure they will only be available in the dev and not doc environment. 
2. I think `utils/set_rpy2_path.py` could be deprecated. The updates actually remove all references to this code, but then there is no built in way to extend the check R module libraries beyond the project install. 
3. I had a very tough time installing "ivDiag" as it has a dependency on "lfe" that has a configuration not updated for modern Macs. The configuration can be adjusted, but this requires a lot of system-specific configuration.
4. I found it was almost feasible to have a completely self-contained R environment for the user without dependencies outside of the project. The issue is some of the extended R packages that rely on gcc or cmake. Cmake can also be installed via conda-forge. Gcc can as well, but requires pulling different versions for different systems (this seems doable in pixi, but I can only test the Mac version). Finally, there is still the issue of installing ivDiag. 