### PR TITLE
Global Options

### DIFF
--- a/docs/quickstart.qmd
+++ b/docs/quickstart.qmd
@@ -577,3 +577,41 @@ pf.etable([fit_twfe, fit_did2s])
 ```
 
 For more details see the vignette on [Difference-in-Differences Estimation](https://py-econometrics.github.io/pyfixest/difference-in-differences.html).
+
+## Setting Global Options
+
+We can set all function arguments of the estimation functions `feols`, `fepois`, and `feglm` as global options.
+
+For example, we can set the estimation data set, variance covariance matrix, weights, small sample corrections and demeaner backend defaults via `pf.set_options()`.
+
+```{python}
+pf.set_options(
+    data = pf.get_data().dropna(),
+    vcov = {"CRV1": "f1"},
+    weights = "weights",
+    demeaner_backend = "rust"
+)
+```
+
+In this case, we don't have to provide data, vcov, weights, etc to the model call: they will automatically be applied.
+
+```{python}
+fit1 = pf.feols(fml = "Y~X1")
+```
+
+If we actively set a function argument, the global default will be overwritten:
+
+```{python}
+fit2 = pf.feols(fml = "Y ~ X1", vcov = "hetero")
+
+pf.etable([fit1, fit2])
+```
+
+We can set a local option context in the following way:
+
+```{python}
+with option_context(vcov="hetero"):
+    fit3 = pf.feols("Y ~ X1")
+
+pf.etable([fit1, fit2, fit3])
+```

--- a/pyfixest/__init__.py
+++ b/pyfixest/__init__.py
@@ -23,6 +23,7 @@ from pyfixest.estimation import (
     rwolf,
     wyoung,
 )
+from pyfixest.options import option_context, set_option
 from pyfixest.report import coefplot, dtable, etable, iplot, make_table, summary
 from pyfixest.utils import (
     get_data,
@@ -49,9 +50,11 @@ __all__ = [
     "iplot",
     "lpdid",
     "make_table",
+    "option_context",
     "panelview",
     "report",
     "rwolf",
+    "set_option",
     "ssc",
     "summary",
     "utils",

--- a/pyfixest/options.py
+++ b/pyfixest/options.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import asdict, dataclass, field
+from typing import Any, Optional, Union
+from contextlib import contextmanager
+
+import pandas as pd
+
+from pyfixest.utils.utils import ssc as ssc_func
+
+__all__ = ["get_option", "option_context", "options", "set_option"]
+
+
+@dataclass
+class _Options:
+    data: Optional[pd.DataFrame] = None
+    vcov: Optional[Union[str, Mapping[str, str]]] = None
+    weights: Optional[str] = None
+    ssc: Optional[dict[str, Union[str, bool]]] = field(default_factory=ssc_func)
+    fixef_rm: str = "none"
+    fixef_tol: float = 1e-8
+    collin_tol: float = 1e-10
+    drop_intercept: bool = False
+    i_ref1: Optional[str] = None
+    copy_data: bool = True
+    store_data: bool = True
+    lean: bool = False
+    weights_type: str = "aweights"
+    solver: str = "scipy.linalg.solve"
+    demeaner_backend: str = "numba"
+    use_compression: bool = False
+    reps: int = 100
+    context: Optional[Union[int, Mapping[str, Any]]] = None
+    seed: Optional[int] = None
+    split: Optional[str] = None
+    fsplit: Optional[str] = None
+
+    separation_check: list[str] = field(default_factory=lambda: ["fe"])
+    iwls_tol: Optional[float] = 1e-6
+    iwls_maxiter: Optional[int] = 25
+
+    # helpers ------------
+    def update(self, **kwargs):
+        for k, v in kwargs.items():
+            if not hasattr(self, k):
+                raise KeyError(f"Unknown option '{k}'")
+            setattr(self, k, v)
+
+    def to_dict(self):
+        return asdict(self)
+
+
+options = _Options()
+
+
+def set_option(**kwargs):
+    """Globally set default options (except `fml`)."""
+    options.update(**kwargs)
+
+
+def get_option(name: str):
+    return getattr(options, name)
+
+
+@contextmanager
+def option_context(**kwargs):
+    "Temporarily override options inside a `with` block."
+    old = options.to_dict()
+    try:
+        options.update(**kwargs)
+        yield
+    finally:
+        options.__dict__.update(old)

--- a/pyfixest/options.py
+++ b/pyfixest/options.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from contextlib import contextmanager
 from dataclasses import asdict, dataclass, field
 from typing import Any, Optional, Union
-from contextlib import contextmanager
 
 import pandas as pd
 

--- a/pyfixest/utils/api_input_checks.py
+++ b/pyfixest/utils/api_input_checks.py
@@ -1,0 +1,95 @@
+from dataclasses import dataclass, field
+from typing import Optional, Union
+
+import pandas as pd
+
+@dataclass
+class EstimationInputs:
+    fml: str
+    data: pd.DataFrame
+    vcov: Optional[Union[str, dict[str, str]]]
+    weights: Optional[str]
+    ssc: dict[str, Union[str, bool]]
+    fixef_rm: str
+    collin_tol: float
+    copy_data: bool
+    store_data: bool
+    lean: bool
+    fixef_tol: float
+    weights_type: str
+    use_compression: bool
+    reps: Optional[int]
+    seed: Optional[int]
+    split: Optional[str]
+    fsplit: Optional[str]
+    separation_check: Optional[list[str]] = field(default=None)
+
+    "Dataclass to store and check the arguments of the estimation functions feols, fepois, feglm etc."
+
+    def validate(self):
+
+        "Validate the arguments of the EstimationInputs class."
+
+        # Step 1: Check types
+        _check_type(self.fml, str, "fml")
+        _check_type(self.data, pd.DataFrame, "data")
+        _check_type(self.vcov, (str, dict, type(None)), "vcov")
+        _check_type(self.weights, (str, type(None)), "weights")
+        _check_type(self.ssc, dict, "ssc")
+        _check_type(self.fixef_rm, str, "fixef_rm")
+        _check_type(self.collin_tol, float, "collin_tol")
+        _check_type(self.copy_data, bool, "copy_data")
+        _check_type(self.store_data, bool, "store_data")
+        _check_type(self.lean, bool, "lean")
+        _check_type(self.fixef_tol, float, "fixef_tol")
+        _check_type(self.weights_type, str, "weights_type")
+        _check_type(self.use_compression, bool, "use_compression")
+        _check_type(self.reps, (int, type(None)), "reps")
+        _check_type(self.seed, (int, type(None)), "seed")
+        _check_type(self.split, (str, type(None)), "split")
+        _check_type(self.fsplit, (str, type(None)), "fsplit")
+        _check_type(self.separation_check, (list, type(None)), "separation_check")
+
+        # Step 2: Check values
+        if isinstance(self.vcov, str):
+            _check_value(self.vcov, ["iid", "HC1", "HC2", "HC3", "hetero"], "vcov")
+        elif isinstance(self.vcov, dict):
+            for key, value in self.vcov.items():
+                if not isinstance(key, str):
+                    raise TypeError(f"Key '{key}' in vcov must be a string.")
+                if not isinstance(value, str):
+                    raise TypeError(f"Value '{value}' in vcov must be a string.")
+                _check_value(key, ["CRV1", "CRV3"], f"key: {key} in vcov")
+                _check_value(value, self.data.columns, f"value: {value} in vcov")
+        if self.weights is not None:
+            _check_value(self.weights, self.data.columns, "weights")
+        _check_value(self.fixef_rm, ["none", "singleton", "drop"], "fixef_rm")
+        if not (0 < self.collin_tol < 1):
+            raise ValueError("collin_tol must be in (0, 1).")
+        if not (0 < self.fixef_tol < 1):
+            raise ValueError("fixef_tol must be in (0, 1).")
+        _check_value(self.weights_type, ["aweights", "fweights"], "weights_type")
+        if not (0 < self.reps):
+            raise ValueError("reps must be strictly positive.")
+        if self.split is not None:
+            _check_value(self.split, self.data.columns, "split")
+        if self.fsplit is not None:
+            _check_value(self.fsplit, self.data.columns, "fsplit")
+        if self.split is not None and self.fsplit is not None:
+            if self.split != self.fsplit:
+                raise ValueError(
+                    f"split and fsplit specified but not identical: {self.split} vs {self.fsplit}"
+                )
+        _check_value(self.separation_check, ["fe", "ir", None], "separation_check")
+
+def _check_type(value, expected_type, name):
+    if not isinstance(value, expected_type):
+        raise TypeError(
+            f"Argument '{name}' must be {expected_type.__name__}, got {type(value).__name__}"
+        )
+
+def _check_value(value, valid_values, name):
+    if value not in valid_values:
+        raise ValueError(
+            f"Argument '{name}' must be one of {valid_values}, got {value!r}"
+        )

--- a/pyfixest/utils/dev_utils.py
+++ b/pyfixest/utils/dev_utils.py
@@ -8,7 +8,6 @@ from narwhals.typing import IntoDataFrame
 
 DataFrameType = IntoDataFrame
 
-
 def _narwhals_to_pandas(data: IntoDataFrame) -> pd.DataFrame:  # type: ignore
     return nw.from_native(data, eager_or_interchange_only=True).to_pandas()
 

--- a/tests/test_global_options.py
+++ b/tests/test_global_options.py
@@ -1,0 +1,263 @@
+import pytest
+import numpy as np
+import pandas as pd
+import pyfixest as pf
+from pyfixest.options import get_option, set_option, option_context
+
+@pytest.fixture
+def data():
+    """Create test data."""
+    np.random.seed(123)
+    n = 100
+    data = pd.DataFrame({
+        'y': np.random.normal(0, 1, n),
+        'x1': np.random.normal(0, 1, n),
+        'x2': np.random.normal(0, 1, n),
+        'id': np.repeat(range(10), 10),
+        'weights': np.random.uniform(0.5, 1.5, n)
+    })
+    return data
+
+def test_default_options_feols(data):
+    """Test that default options are correctly applied to feols."""
+    # Get default options
+    default_vcov = get_option('vcov')
+    default_weights = get_option('weights')
+    default_ssc = get_option('ssc')
+    default_fixef_tol = get_option('fixef_tol')
+    default_collin_tol = get_option('collin_tol')
+
+    # Fit model with defaults
+    fit = pf.feols('y ~ x1 + x2 | id', data=data)
+
+    # Check that defaults were applied
+    assert fit._vcov_type == default_vcov
+    assert fit._weights is default_weights
+    assert fit._ssc_dict == default_ssc
+    assert fit._fixef_tol == default_fixef_tol
+    assert fit._collin_tol == default_collin_tol
+
+def test_default_options_fepois(data):
+    """Test that default options are correctly applied to fepois."""
+    # Get default options
+    default_vcov = get_option('vcov')
+    default_weights = get_option('weights')
+    default_ssc = get_option('ssc')
+    default_fixef_tol = get_option('fixef_tol')
+    default_collin_tol = get_option('collin_tol')
+
+    # Fit model with defaults
+    fit = pf.fepois('y ~ x1 + x2 | id', data=data)
+
+    # Check that defaults were applied
+    assert fit._vcov_type == default_vcov
+    assert fit._weights is None  # No weights by default
+    assert fit._ssc_dict == default_ssc
+    assert fit._fixef_tol == default_fixef_tol
+    assert fit._collin_tol == default_collin_tol
+
+def test_default_options_feglm(data):
+    """Test that default options are correctly applied to feglm."""
+    # Get default options
+    default_vcov = get_option('vcov')
+    default_weights = get_option('weights')
+    default_ssc = get_option('ssc')
+    default_fixef_tol = get_option('fixef_tol')
+    default_collin_tol = get_option('collin_tol')
+
+    # Fit model with defaults
+    fit = pf.feglm('y ~ x1 + x2 | id', data=data)
+
+    # Check that defaults were applied
+    assert fit._vcov_type == default_vcov
+    assert fit._weights is None  # No weights by default
+    assert fit._ssc_dict == default_ssc
+    assert fit._fixef_tol == default_fixef_tol
+    assert fit._collin_tol == default_collin_tol
+
+def test_override_options(data):
+    """Test that options can be overridden at the function call level."""
+    # Set custom options
+    custom_vcov = "hetero"
+    custom_weights = "weights"
+    custom_ssc = {"adj": True, "fixef_k": "none"}
+
+    # Fit model with custom options
+    fit = pf.feols(
+        'y ~ x1 + x2 | id',
+        data=data,
+        vcov=custom_vcov,
+        weights=custom_weights,
+        ssc=custom_ssc
+    )
+
+    # Check that custom options were applied
+    assert fit._vcov_type == custom_vcov
+    assert fit._weights_name == custom_weights
+    assert fit._ssc_dict == custom_ssc
+
+def test_option_context(data):
+    """Test that options can be temporarily changed using the context manager."""
+    # Original options
+    original_vcov = get_option('vcov')
+    original_weights = get_option('weights')
+
+    # Custom options
+    custom_vcov = "hetero"
+    custom_weights = "weights"
+
+    # Use context manager to temporarily change options
+    with option_context(vcov=custom_vcov, weights=custom_weights):
+        fit = pf.feols('y ~ x1 + x2 | id', data=data)
+        assert fit._vcov_type == custom_vcov
+        assert fit._weights_name == custom_weights
+
+    # Check that original options are restored
+    assert get_option('vcov') == original_vcov
+    assert get_option('weights') == original_weights
+
+def test_set_option(data):
+    """Test that options can be permanently changed using set_option."""
+    # Original options
+    original_vcov = get_option('vcov')
+    original_weights = get_option('weights')
+
+    try:
+        # Set new options
+        custom_vcov = "hetero"
+        custom_weights = "weights"
+        set_option(vcov=custom_vcov, weights=custom_weights)
+
+        # Fit model with new defaults
+        fit = pf.feols('y ~ x1 + x2 | id', data=data)
+        assert fit._vcov_type == custom_vcov
+        assert fit._weights_name == custom_weights
+
+    finally:
+        # Restore original options
+        set_option(vcov=original_vcov, weights=original_weights)
+
+def test_options_persistence(data):
+    """Test that options persist across multiple function calls."""
+    # Set custom options
+    custom_vcov = "hetero"
+    custom_weights = "weights"
+    set_option(vcov=custom_vcov, weights=custom_weights)
+
+    try:
+        # Fit multiple models
+        fit1 = pf.feols('y ~ x1 | id', data=data)
+        fit2 = pf.fepois('y ~ x1 | id', data=data)
+        fit3 = pf.feglm('y ~ x1 | id', data=data)
+
+        # Check that all models use the custom options
+        assert fit1._vcov_type == custom_vcov
+        assert fit2._vcov_type == custom_vcov
+        assert fit3._vcov_type == custom_vcov
+
+        assert fit1._weights_name == custom_weights
+        assert fit2._weights_name == custom_weights
+        assert fit3._weights_name == custom_weights
+
+    finally:
+        # Restore original options
+        set_option(vcov=get_option('vcov'), weights=get_option('weights'))
+
+def test_global_vs_direct_options(data):
+    """Test that applying global options leads to the same results as providing arguments directly."""
+    # Set custom options
+    custom_vcov = "hetero"
+    custom_weights = "weights"
+    custom_ssc = {"adj": True, "fixef_k": "none"}
+
+    # Fit model with direct arguments
+    direct_fit = pf.feols(
+        'y ~ x1 + x2 | id',
+        data=data,
+        vcov=custom_vcov,
+        weights=custom_weights,
+        ssc=custom_ssc
+    )
+
+    # Set global options
+    set_option(vcov=custom_vcov, weights=custom_weights, ssc=custom_ssc)
+
+    try:
+        # Fit model with global options
+        global_fit = pf.feols('y ~ x1 + x2 | id', data=data)
+
+        # Compare coefficients
+        np.testing.assert_allclose(
+            direct_fit.coef(),
+            global_fit.coef(),
+            rtol=1e-10,
+            atol=1e-10,
+            err_msg="Coefficients do not match between direct and global options"
+        )
+
+        # Compare standard errors
+        np.testing.assert_allclose(
+            direct_fit.se(),
+            global_fit.se(),
+            rtol=1e-10,
+            atol=1e-10,
+            err_msg="Standard errors do not match between direct and global options"
+        )
+
+        # Compare t-statistics
+        np.testing.assert_allclose(
+            direct_fit.tstat(),
+            global_fit.tstat(),
+            rtol=1e-10,
+            atol=1e-10,
+            err_msg="t-statistics do not match between direct and global options"
+        )
+
+        # Compare p-values
+        np.testing.assert_allclose(
+            direct_fit.pvalue(),
+            global_fit.pvalue(),
+            rtol=1e-10,
+            atol=1e-10,
+            err_msg="p-values do not match between direct and global options"
+        )
+
+        # Compare confidence intervals
+        np.testing.assert_allclose(
+            direct_fit.confint().values,
+            global_fit.confint().values,
+            rtol=1e-10,
+            atol=1e-10,
+            err_msg="Confidence intervals do not match between direct and global options"
+        )
+
+        # Compare variance-covariance matrices
+        np.testing.assert_allclose(
+            direct_fit._vcov,
+            global_fit._vcov,
+            rtol=1e-10,
+            atol=1e-10,
+            err_msg="Variance-covariance matrices do not match between direct and global options"
+        )
+
+        # Compare predictions
+        np.testing.assert_allclose(
+            direct_fit.predict(),
+            global_fit.predict(),
+            rtol=1e-10,
+            atol=1e-10,
+            err_msg="Predictions do not match between direct and global options"
+        )
+
+        # Compare residuals
+        np.testing.assert_allclose(
+            direct_fit.resid(),
+            global_fit.resid(),
+            rtol=1e-10,
+            atol=1e-10,
+            err_msg="Residuals do not match between direct and global options"
+        )
+
+    finally:
+        # Restore original options
+        set_option(vcov=get_option('vcov'), weights=get_option('weights'), ssc=get_option('ssc'))


### PR DESCRIPTION
Allows to set global options for estimation. Would close #766. 

Example: 

```python
%load_ext autoreload
%autoreload 2

import pyfixest as pf 
data = pf.get_data()

pf.set_option(
    data = pf.get_data().dropna(), 
    vcov = {"CRV1": "f1"}, 
    weights = "weights", 
    demeaner_backend = "rust"
)

# if arg not explicity provided, looks for and uses global default
fit1 = pf.feols(fml = "Y ~ X1 + X2 | f2", vcov = "hetero")
fit2 = pf.feols(fml = "Y ~ X1 | f1 + f2")
fit3 = pf.feols(fml = "Y ~ X1 + X2 ")
pf.etable([fit1, fit2, fit3],)
```
Is this a feature we'd like to have? Are there any risks? @apoorvalal @juanitorduz 