### PR TITLE
chore(license): add MIT SPDX headers and permission record for fixest-derived code

### DIFF
--- a/THIRD_PARTY_PERMISSIONS.md
+++ b/THIRD_PARTY_PERMISSIONS.md
@@ -1,0 +1,6 @@
+I, Laurent Berge, hereby grant irrevocable permission to redistribute
+and re-license the relevant code from the fixest project under the MIT
+License. The relevant code is the following:
+
+- The script to generate benchmark data (https://github.com/lrberge/fixest/blob/master/_BENCHMARK/Data%20generation.R)
+- The c++ function cpp_cholesky (https://github.com/lrberge/fixest/blob/dbe56c5d953deb797a61dfc37f6e25fd143c68d4/src/lm_related.cpp#L105).

--- a/benchmarks/data_generation.r
+++ b/benchmarks/data_generation.r
@@ -1,12 +1,21 @@
-#----------------------------------------------#
-# Author: Laurent Berge
-# Date creation: Fri Oct 18 17:05:15 2019
-# ~: Benchmarking: data generation
-#----------------------------------------------#
+# ----------------------------------------------------------------------
+# SPDX-License-Identifier: MIT
+#
+# Copyright (c) 2019-2025  PyFixest Authors
+#
+# Original author: Laurent Berge
+# Original creation: Fri Oct 18 17:05:15 2019
+#
+# This script is adapted from the “benchmarking: data generation” code in
+# Laurent Berge’s **fixest** project
+# (see https://github.com/lrberge/fixest/blob/a4d1a9b/src/…),
+# which was originally distributed under GPL-3.0-or-later.
+#
+# Laurent Berge granted the PyFixest maintainers an irrevocable, written
+# permission to redistribute and re-license the relevant
+# code under the MIT License.
+# ----------------------------------------------------------------------
 
-####
-#### SIMULATION ####
-####
 setwd("/Users/marc/Documents/pyfixest/benchmarks/DATA/")
 
 library(MASS)

--- a/benchmarks/data_generation.r
+++ b/benchmarks/data_generation.r
@@ -1,19 +1,23 @@
 # ----------------------------------------------------------------------
 # SPDX-License-Identifier: MIT
 #
-# Copyright (c) 2019-2025  PyFixest Authors
+# Copyright (c) 2025  PyFixest Authors
 #
 # Original author: Laurent Berge
 # Original creation: Fri Oct 18 17:05:15 2019
 #
 # This script is adapted from the “benchmarking: data generation” code in
 # Laurent Berge’s **fixest** project
-# (see https://github.com/lrberge/fixest/blob/a4d1a9b/src/…),
+# (see https://github.com/lrberge/fixest/),
 # which was originally distributed under GPL-3.0-or-later.
 #
 # Laurent Berge granted the PyFixest maintainers an irrevocable, written
 # permission to redistribute and re-license the relevant
 # code under the MIT License.
+#
+# The full text of that permission is archived at:
+#
+# docs/THIRD_PARTY_PERMISSIONS.md
 # ----------------------------------------------------------------------
 
 setwd("/Users/marc/Documents/pyfixest/benchmarks/DATA/")

--- a/pyfixest/estimation/numba/find_collinear_variables_nb.py
+++ b/pyfixest/estimation/numba/find_collinear_variables_nb.py
@@ -1,3 +1,17 @@
+# ----------------------------------------------------------------------
+#
+# SPDX-License-Identifier: MIT
+#
+# Copyright (c) 2025  PyFixest Authors
+#
+# This function is a Python/Numba re-implementation of the algorithm
+# published by Laurent Berge in the **fixest**
+# project (see See the fixest repo
+# [here](https:#github.com/lrberge/fixest/blob/a4d1a9bea20aa7ab7ab0e0f1d2047d8097971ad7/src/lm_related.cpp#L130)),
+# originally licensed under GPL-3.0.  Laurent Berge granted the maintainers of this
+# project an irrevocable, written permission to
+# redistribute and re-license the relevant code under the MIT License.
+
 import numba as nb
 import numpy as np
 

--- a/pyfixest/estimation/numba/find_collinear_variables_nb.py
+++ b/pyfixest/estimation/numba/find_collinear_variables_nb.py
@@ -11,6 +11,10 @@
 # originally licensed under GPL-3.0.  Laurent Berge granted the maintainers of this
 # project an irrevocable, written permission to
 # redistribute and re-license the relevant code under the MIT License.
+# The full text of that permission is archived at:
+#
+# docs/THIRD_PARTY_PERMISSIONS.md
+# ----------------------------------------------------------------------
 
 import numba as nb
 import numpy as np

--- a/src/collinear.rs
+++ b/src/collinear.rs
@@ -1,3 +1,17 @@
+// ----------------------------------------------------------------------
+//
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2025  PyFixest Authors
+//
+// This function is a Rust re-implementation of the algorithm
+// published by Laurent Berge in the **fixest**
+// project (see See the fixest repo
+// [here](https://github.com/lrberge/fixest/blob/a4d1a9bea20aa7ab7ab0e0f1d2047d8097971ad7/src/lm_related.cpp#L130)),
+// originally licensed under GPL-3.0.  Laurent Berge granted the maintainers of this
+// project an irrevocable, written permission to
+// redistribute and re-license the relevant code under the MIT License.
+
 use ndarray::{Array1, Array2, ArrayView2};
 use numpy::IntoPyArray;
 use numpy::{PyArray1, PyReadonlyArray2};

--- a/src/collinear.rs
+++ b/src/collinear.rs
@@ -11,6 +11,11 @@
 // originally licensed under GPL-3.0.  Laurent Berge granted the maintainers of this
 // project an irrevocable, written permission to
 // redistribute and re-license the relevant code under the MIT License.
+// The full text of that permission is archived at:
+//
+// docs/THIRD_PARTY_PERMISSIONS.md
+//
+// ----------------------------------------------------------------------
 
 use ndarray::{Array1, Array2, ArrayView2};
 use numpy::IntoPyArray;


### PR DESCRIPTION
This pull-request adds explicit MIT SPDX headers to the two files adapted from fixest project and checks in the written permission that allows us to re-license those GPL-origin snippets.

No functional code has changed; this is purely a licensing/compliance cleanup.

@lrberge, if you are ok with the re-license of the files derived from fixest, could you please confirm permission by replying to this PR with the sentence below (or similar, if you prefer, but it must include the same substance)? This reply will be archived in the repo under `THIRD_PARTY_PERMISSIONS.md`: 

> 
> I, Laurent Berge, hereby grant irrevocable permission to redistribute
> and re-license the relevant code from the fixest project under the MIT
> License. The relevant code is the following:
> 
> - The script to generate benchmark data (https://github.com/lrberge/fixest/blob/master/_BENCHMARK/Data%20generation.R)
> - The c++ function cpp_cholesky (https://github.com/lrberge/fixest/blob/dbe56c5d953deb797a61dfc37f6e25fd143c68d4/src/lm_related.cpp#L105).
