### PR TITLE
Type Errors on Windows

### DIFF
--- a/pyfixest/core/_core_impl.pyi
+++ b/pyfixest/core/_core_impl.pyi
@@ -4,12 +4,12 @@ from numpy.typing import NDArray
 def _find_collinear_variables_rs(x: NDArray[np.float64], tol: float = 1e-10): ...
 def _crv1_meat_loop_rs(
     scores: NDArray[np.float64],
-    clustid: NDArray[np.float64],
-    cluster_col: NDArray[np.float64],
-) -> NDArray: ...
+    clustid: NDArray[np.uint64],
+    cluster_col: NDArray[np.uint64],
+) -> NDArray[np.float64]: ...
 def _demean_rs(
     x: NDArray[np.float64],
-    flist: NDArray[np.uint],
+    flist: NDArray[np.uint64],
     weights: NDArray[np.float64],
     tol: float = 1e-08,
     maxiter: int = 100_000,
@@ -17,6 +17,6 @@ def _demean_rs(
 def _count_fixef_fully_nested_all_rs(
     all_fixef_array: NDArray,
     cluster_colnames: NDArray,
-    cluster_data: NDArray[np.uint],
-    fe_data: NDArray[np.uint],
+    cluster_data: NDArray[np.uint64],
+    fe_data: NDArray[np.uint64],
 ) -> tuple[np.ndarray, int]: ...

--- a/pyfixest/core/demean.py
+++ b/pyfixest/core/demean.py
@@ -6,7 +6,7 @@ from ._core_impl import _demean_rs
 
 def demean(
     x: NDArray[np.float64],
-    flist: NDArray[np.uint],
+    flist: NDArray[np.uint64],
     weights: NDArray[np.float64],
     tol: float = 1e-08,
     maxiter: int = 100_000,
@@ -70,4 +70,4 @@ def demean(
     print(pf.feols(fml, data).coef())
     ```
     """
-    return _demean_rs(x, flist.astype(np.uint), weights, tol, maxiter)
+    return _demean_rs(x, flist.astype(np.uint64), weights, tol, maxiter)


### PR DESCRIPTION
When installing from PyPi on my windows machine, the Rust code runs into a type error: 

```python
    return _demean_rs(x, flist.astype(np.uint), weights, tol, maxiter)
TypeError: argument 'flist': 'ndarray' object cannot be converted to 'PyArray<T, D>'
```
This PR tries to fix this.