### PR TITLE
Add missing file_name argument to `make_table`

### DIFF
--- a/docs/table-layout.qmd
+++ b/docs/table-layout.qmd
@@ -72,7 +72,7 @@ pf.etable([fit1, fit2, fit3, fit4, fit5, fit6], drop=["X1"])
 ```
 
 ## Hide fixed effects or SE-type rows
-We can hide the rows showing the relevant fixed effects and those showing the S.E. type by setting `show_fe=False` and `show_setype=False` (for instance when the set of fixed effects or the estimation method for the std. errors is the same for all models and you want to describe this in the text or table notes rather than displaying it in the table).
+We can hide the rows showing the relevant fixed effects and those showing the S.E. type by setting `show_fe=False` and `show_se_type=False` (for instance when the set of fixed effects or the estimation method for the std. errors is the same for all models and you want to describe this in the text or table notes rather than displaying it in the table).
 
 ```{python}
 pf.etable([fit1, fit2, fit3, fit4, fit5, fit6], show_fe=False, show_se_type=False)

--- a/pyfixest/report/summarize.py
+++ b/pyfixest/report/summarize.py
@@ -514,7 +514,12 @@ def etable(
                     + f"Format of coefficient cell: {coef_fmt_title}"
                 )
         return make_table(
-            res_all, type=type, notes=notes, rgroup_display=False, **kwargs
+            res_all,
+            type=type,
+            notes=notes,
+            rgroup_display=False,
+            file_name=file_name,
+            **kwargs,
         )
 
     return None


### PR DESCRIPTION
The `file_name` parameter was not passed to the underlying `make_table`
call when constructing a table using `etable`:

```python
import pyfixest as pf

df = pf.get_data()
fit1 = pf.feols("Y~X1 + X2 | f1", df)
fit2 = pf.feols("Y~X1 + X2 | f1 + f2", df)
tab = pf.etable([fit1, fit2], file_name="output/table.html")
```

This commit fixest this issue.