### PR TITLE
Add missing file_name argument to `make_table`

### DIFF
--- a/pyfixest/report/summarize.py
+++ b/pyfixest/report/summarize.py
@@ -514,7 +514,12 @@ def etable(
                     + f"Format of coefficient cell: {coef_fmt_title}"
                 )
         return make_table(
-            res_all, type=type, notes=notes, rgroup_display=False, **kwargs
+            res_all,
+            type=type,
+            notes=notes,
+            rgroup_display=False,
+            file_name=file_name,
+            **kwargs,
         )
 
     return None


### PR DESCRIPTION
The `file_name` parameter was not passed to the underlying `make_table`
call when constructing a table using `etable`:

```python
import pyfixest as pf

df = pf.get_data()
fit1 = pf.feols("Y~X1 + X2 | f1", df)
fit2 = pf.feols("Y~X1 + X2 | f1 + f2", df)
tab = pf.etable([fit1, fit2], file_name="output/table.html")
```

This commit fixest this issue.