### PR TITLE
Improve docs for `Feols.fixef()`

### DIFF
--- a/pyfixest/estimation/feols_.py
+++ b/pyfixest/estimation/feols_.py
@@ -193,6 +193,8 @@ class Feols:
         F-statistic for the model, set in get_Ftest().
     _fixef_dict : dict
         dictionary containing fixed effects estimates.
+    _alpha : pd.DataFrame
+        A DataFrame with the estimated fixed effects.
     _sumFE : np.ndarray
         Sum of all fixed effects for each observation.
     _rmse : float
@@ -358,6 +360,7 @@ class Feols:
 
         # set in fixef()
         self._fixef_dict: dict[str, dict[str, float]] = {}
+        self._alpha = None
         self._sumFE = None
 
         # set in get_performance()
@@ -1801,13 +1804,14 @@ class Feols:
         Compute the coefficients of (swept out) fixed effects for a regression model.
 
         This method creates the following attributes:
-        - `alphaDF` (pd.DataFrame): A DataFrame with the estimated fixed effects.
-        - `sumFE` (np.array): An array with the sum of fixed effects for each
+        - `_alpha` (pd.DataFrame): A DataFrame with the estimated fixed effects.
+        - `_sumFE` (np.array): An array with the sum of fixed effects for each
         observation (i = 1, ..., N).
 
         Returns
         -------
-        None
+        dict[str, dict[str, float]]
+            A dictionary with the estimated fixed effects.
         """
         _has_fixef = self._has_fixef
         _is_iv = self._is_iv

--- a/pyfixest/estimation/feols_.py
+++ b/pyfixest/estimation/feols_.py
@@ -1808,6 +1808,17 @@ class Feols:
         - `_sumFE` (np.array): An array with the sum of fixed effects for each
         observation (i = 1, ..., N).
 
+        Parameters
+        ----------
+        atol : Float, default 1e-6
+            Stopping tolerance for scipy.sparse.linalg.lsqr().
+            See https://docs.scipy.org/doc/
+                scipy/reference/generated/scipy.sparse.linalg.lsqr.html
+        btol : Float, default 1e-6
+            Another stopping tolerance for scipy.sparse.linalg.lsqr().
+            See https://docs.scipy.org/doc/
+                scipy/reference/generated/scipy.sparse.linalg.lsqr.html
+
         Returns
         -------
         dict[str, dict[str, float]]


### PR DESCRIPTION
Right now the docstring for `Feols.fixef()` is not reflecting its current behavior. This PR corrects it and describes the saved attributes and the returned object.

It also documents the purpose of two tolerance parameters: `atol` and `btol` passed to the SciPy's lsqr solver.

Let me know if you guys have any thoughts.