### PR TITLE
Update FixestMulti_.py

### DIFF
--- a/pyfixest/estimation/FixestMulti_.py
+++ b/pyfixest/estimation/FixestMulti_.py
@@ -442,6 +442,7 @@ class FixestMulti:
                         FIT.get_inference()
                         if _method == "feols" and not FIT._is_iv:
                             FIT.get_performance()
+                            FIT.wald_test()
                         if isinstance(FIT, Feiv):
                             FIT.first_stage()
                     # delete large attributes


### PR DESCRIPTION
# Automatically compute F-Stat in `pf.feols()` calls

## Summary

This PR implements automatic computation of F-statistics in `pf.feols()` calls by default, addressing issue #1025.

Previously, users had to explicitly call `Feols.wald_test()` to compute F-statistics. Now, F-statistics are automatically computed during the estimation process for OLS models.

## Changes Made

- **File Modified**: `pyfixest/estimation/FixestMulti_.py`
- **Location**: Line ~444 in the `_estimate_all_models` method
- **Change**: Added automatic `wald_test()` call with default parameters

### Code Changes

```python
# Before
FIT.get_inference()
if _method == "feols" and not FIT._is_iv:
    FIT.get_performance()
if isinstance(FIT, Feiv):
    FIT.first_stage()

# After  
FIT.get_inference()
if _method == "feols" and not FIT._is_iv:
    FIT.get_performance()
    # Automatically compute F-statistic using default wald_test
    FIT.wald_test()
if isinstance(FIT, Feiv):
    FIT.first_stage()