### PR TITLE
fix: Add type cast to python layer to match types required by rust backend

### DIFF
--- a/pyfixest/core/demean.py
+++ b/pyfixest/core/demean.py
@@ -70,4 +70,10 @@ def demean(
     print(pf.feols(fml, data).coef())
     ```
     """
-    return _demean_rs(x, flist.astype(np.uint64), weights, tol, maxiter)
+    return _demean_rs(
+        x.astype(np.float64, copy=False),
+        flist.astype(np.uint64, copy=False),
+        weights.astype(np.float64, copy=False),
+        tol,
+        maxiter,
+    )


### PR DESCRIPTION
This PR adds `astype` calls to the python layer in `pyfixest.core.demean` calling the rust backend to match the expected dtypes.

Using `copy=False` to avoid data duplication in case of compatible dtypes.

Closes #1023 