### PR TITLE
Add customizable fixed effects markers, instead of only "x" or "-"

### DIFF
--- a/pyfixest/report/fe_marker_examples.py
+++ b/pyfixest/report/fe_marker_examples.py
@@ -1,0 +1,29 @@
+# Examples of using custom fixed effects markers in pyfixest etable
+
+import pyfixest as pf
+
+# Load data
+df = pf.get_data()
+fit1 = pf.feols("Y~X1 + X2 | f1", df)
+fit2 = pf.feols("Y~X1 + X2 | f1 + f2", df)
+
+# Default behavior (x and -)
+pf.etable([fit1, fit2])
+
+# Use YES/NO
+pf.etable([fit1, fit2], fe_present="YES", fe_absent="NO")
+
+# Use Y/N
+pf.etable([fit1, fit2], fe_present="Y", fe_absent="N")
+
+# Use checkmark and cross
+pf.etable([fit1, fit2], fe_present="✓", fe_absent="✗")
+
+# Use green check and cross emojis
+pf.etable([fit1, fit2], fe_present="✅", fe_absent="❌")
+
+# Use checkmark with blank for absent
+pf.etable([fit1, fit2], fe_present="✓", fe_absent="")
+
+# Custom text markers
+pf.etable([fit1, fit2], fe_present="Included", fe_absent="Excluded")

--- a/pyfixest/report/summarize.py
+++ b/pyfixest/report/summarize.py
@@ -36,6 +36,8 @@ def etable(
     show_fe: Optional[bool] = True,
     show_se_type: Optional[bool] = True,
     felabels: Optional[dict] = None,
+    fe_present: str = "x",
+    fe_absent: str = "-",
     notes: str = "",
     model_heads: Optional[list] = None,
     head_order: Optional[str] = "dh",
@@ -109,6 +111,12 @@ def etable(
         the FE lines with a different label than the one specied for the respective
         variable in the labels dictionary.
         The command is applied after the `keep` and `drop` commands.
+    fe_present: str, optional
+        Symbol to use when a fixed effect is present in a model. Default is "x".
+        Common alternatives include "Y", "YES", "✓", "✅", or any custom string.
+    fe_absent: str, optional
+        Symbol to use when a fixed effect is absent from a model. Default is "-".
+        Common alternatives include "N", "NO", "✗", "", or any custom string.
     digits: int
         The number of digits to round to.
     thousands_sep: bool, optional
@@ -327,9 +335,9 @@ def etable(
                         and fixef in model._fixef.split("+")
                         and not model._use_mundlak
                     ):
-                        fe_df.loc[i, fixef] = "x"
+                        fe_df.loc[i, fixef] = fe_present
                     else:
-                        fe_df.loc[i, fixef] = "-"
+                        fe_df.loc[i, fixef] = fe_absent
         # Sort by model
         fe_df.sort_index(inplace=True)
         # Transpose


### PR DESCRIPTION
### Add customizable fixed effects markers, instead of only `x` or `-` (fe_present, fe_absent parameters)

**Summary**
This PR adds two new optional parameters to etable() that allow users to customize the symbols used to indicate the presence or absence of fixed effects in regression tables.

**Motivation**
Currently, fixed effects are marked with hardcoded symbols: "x" for present and "-" for absent. While functional, these symbols may not suit all presentation contexts or user preferences. Users might prefer more explicit markers like "YES"/"NO", cleaner symbols like "Y"/"N", visual indicators like ✓/✗, or even emoji like ✅/❌.

**Changes**

1. Added `fe_present` parameter (default: `"x"`): Symbol to display when a fixed effect is present
2. Added `fe_absent` parameter (default: `"-"`): Symbol to display when a fixed effect is absent
3. Updated docstring with parameter descriptions and examples
4. Maintains backward compatibility with existing code

**Usage Examples**
```
# Use YES/NO
pf.etable([fit1, fit2], fe_present="YES", fe_absent="NO")

# Use Y/N  
pf.etable([fit1, fit2], fe_present="Y", fe_absent="N")

# Use checkmarks
pf.etable([fit1, fit2], fe_present="✓", fe_absent="✗")

# Use emoji
pf.etable([fit1, fit2], fe_present="✅", fe_absent="❌")

# Leave absent blank
pf.etable([fit1, fit2], fe_present="✓", fe_absent="")
```

**Backward Compatibility**
The default values match the current behavior, so existing code will continue to work without any changes.