### PR TITLE
Clarify CCV docstring source to resolve GPL licensing ambiguity (#1120)

### DIFF
--- a/tests/test_ccv.py
+++ b/tests/test_ccv.py
@@ -24,9 +24,9 @@ def compute_CCV_AAIW(data, depvar, cluster, seed, nmx, pk):
     The code is based on a Python implementation of the AAIW authors
     published under CC0 1.0 Deed and available at
     https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/27VMOT.
-    This code was written independently of Daniel Pailanir and Damian Clarke's Stata 
-    implementation available at https://github.com/Daniel-Pailanir/TSCB-CCV. 
-    Output results are tested against output results from the Stata implementation 
+    This code was written independently of Daniel Pailanir and Damian Clarke's Stata
+    implementation available at https://github.com/Daniel-Pailanir/TSCB-CCV.
+    Output results are tested against output results from the Stata implementation
     to demonstrate consistency.
 
     """


### PR DESCRIPTION
This is a minor change to only a test script's docstring.

It clarifies that the code was not developed from the referenced Stata code, which is GPL-licensed. Instead, it's that the script includes a test of its resulting outputs against the resulting outputs from the Stata code to demonstrate that they give consistent results (up to tolerance errors).