### PR TITLE
Change the link to appliedAI Institute (instead of Initiative) in the description of the PyFixest sprint 2026

### DIFF
--- a/docs/pyfixest-sprint.md
+++ b/docs/pyfixest-sprint.md
@@ -1,7 +1,7 @@
 # PyFixest Sprint in Heilbronn
 
 
-We're organizing a PyFixest development sprint in partnership with [AppliedAI](https://www.appliedai.de/) at their Heilbronn office. This is a chance to help shape the future of econometrics software in Python, and to work alongside PyFixest's core development team and AppliedAI's engineers for a few focused days of coding.
+We're organizing a PyFixest development sprint in partnership with the [appliedAI Institute](https://appliedai-institute.de/) at their Heilbronn office. This is a chance to help shape the future of econometrics software in Python, and to work alongside PyFixest's core development team and AppliedAI's engineers for a few focused days of coding.
 
 **Dates:** Either February 27th–March 1st, March 2nd–4th, or March 4th–6th (we'll confirm by January 14th)
 


### PR DESCRIPTION
@s3alfisc small change. We have to link the appliedAI Institute (gGmbH) instead of the appliedAI Initiative.