### PR TITLE
Improve import error for unsupported Python versions

### DIFF
--- a/pyfixest/__init__.py
+++ b/pyfixest/__init__.py
@@ -1,5 +1,9 @@
 import importlib as _importlib
+import sys
 from importlib.metadata import PackageNotFoundError, version
+
+if sys.version_info < (3, 10):
+    raise ImportError("pyfixest requires Python >=3.10. Please upgrade Python to use this package.")
 
 # Version handling (keep eager - it's cheap)
 try:

--- a/tests/test_python_version_guard.py
+++ b/tests/test_python_version_guard.py
@@ -1,0 +1,12 @@
+import importlib
+import sys
+
+import pytest
+
+
+def test_import_has_clear_error_on_python39(monkeypatch):
+    monkeypatch.setattr(sys, "version_info", (3, 9, 23))
+    sys.modules.pop("pyfixest", None)
+
+    with pytest.raises(ImportError, match=r"requires Python >=3\.10"):
+        importlib.import_module("pyfixest")


### PR DESCRIPTION
## Summary
- add an early runtime guard in `pyfixest/__init__.py` to detect Python versions below 3.10
- raise a clear `ImportError` message (`pyfixest requires Python >=3.10`) before deeper imports hit 3.10-only typing syntax
- add a focused regression test that simulates Python 3.9 and asserts the clear error message

## Testing
- `python - <<'PY' ... import pyfixest ... PY` (import succeeds on supported interpreter)
- `python -m compileall -q pyfixest/__init__.py tests/test_python_version_guard.py`
- `python -m pytest -q tests/test_python_version_guard.py` *(not runnable in this environment because `pytest` is not installed)*

## Related
Fixes #1041
