### PR TITLE
Pass fixef_tol to scipy/cupy LSMR demeaning wrappers

### DIFF
--- a/pyfixest/estimation/cupy/demean_cupy_.py
+++ b/pyfixest/estimation/cupy/demean_cupy_.py
@@ -288,9 +288,11 @@ def demean_cupy(
     fe_df = pd.DataFrame(flist, columns=[f"f{i + 1}" for i in range(n_fe)], copy=False)
     fe_sparse_matrix = create_fe_sparse_matrix(fe_df)
 
-    return CupyFWLDemeaner(dtype=dtype).demean(
-        x, flist, weights, tol, maxiter, fe_sparse_matrix=fe_sparse_matrix
-    )
+    return CupyFWLDemeaner(
+        dtype=dtype,
+        solver_atol=tol,
+        solver_btol=tol,
+    ).demean(x, flist, weights, tol, maxiter, fe_sparse_matrix=fe_sparse_matrix)
 
 
 def demean_cupy32(
@@ -344,5 +346,9 @@ def demean_scipy(
 
     # Force CPU usage (use_gpu=False) and disable warnings
     return CupyFWLDemeaner(
-        use_gpu=False, warn_on_cpu_fallback=False, dtype=np.float64
+        use_gpu=False,
+        warn_on_cpu_fallback=False,
+        dtype=np.float64,
+        solver_atol=tol,
+        solver_btol=tol,
     ).demean(x, flist, weights, tol, maxiter, fe_sparse_matrix=fe_sparse_matrix)


### PR DESCRIPTION
## Summary
- pass `tol` through to `CupyFWLDemeaner` as both `solver_atol` and `solver_btol` in `demean_cupy`
- do the same for `demean_scipy` so CPU and GPU wrappers respect the caller-provided fixed-effect tolerance
- keep the change scoped to wrapper construction; no solver behavior changes beyond honoring existing function arguments

## Testing
- `python -m compileall pyfixest/estimation/cupy/demean_cupy_.py`
- `python - <<'PY'` AST parse check for `pyfixest/estimation/cupy/demean_cupy_.py`
- Full pytest was not run in this runner because importing `pyfixest` requires built extension module `pyfixest.core._core_impl`.

## Related
Fixes #1138
