### PR TITLE
fix: add env bin to PATH in sitecustomize

### DIFF
--- a/scripts/setup_maturin_hook.py
+++ b/scripts/setup_maturin_hook.py
@@ -41,6 +41,12 @@ try:
     if not os.environ.get("CONDA_PREFIX") and not os.environ.get("VIRTUAL_ENV"):
         os.environ["CONDA_PREFIX"] = sys.prefix
 
+    # Ensure the environment's bin directory is on PATH so that maturin can be found.
+    # PyCharm (via pixi-pycharm shim) may not include it.
+    env_bin = os.path.join(sys.prefix, "bin")
+    if env_bin not in os.environ.get("PATH", "").split(os.pathsep):
+        os.environ["PATH"] = env_bin + os.pathsep + os.environ.get("PATH", "")
+
     excluded_dirs = DefaultProjectFileSearcher.DEFAULT_SOURCE_EXCLUDED_DIR_NAMES | {".pixi"}
     file_searcher = DefaultProjectFileSearcher(source_excluded_dir_names=excluded_dirs)
 


### PR DESCRIPTION
The pixi-pycharm conda shim does not source the environment's activate.d scripts, so sys.prefix/bin is absent from PATH. The maturin-import-hook calls find_maturin() at import time and raises MaturinError when the binary is not on PATH. Prepend sys.prefix/bin to PATH in the generated sitecustomize.py to fix this. The same fix also ensures R (needed by rpy2) is discoverable without a separate R_HOME workaround.