### PR TITLE
Within options

### DIFF
--- a/docs/explanation/difficult-fixed-effects.md
+++ b/docs/explanation/difficult-fixed-effects.md
@@ -65,11 +65,13 @@ problem:
 
 - **LSMR.** The solver powering `FixedEffectsModels.jl`. It can be accessed in `pyfixest` via `pf.LsmrDemeaner(...)`.
 
-- **CG-Schwarz (Conjugate Gradients with Additive Schwarz Preconditioner).**
+- **Krylov-Schwarz solvers via `within`.**
 The [`within`](https://github.com/py-econometrics/within) crate, used by
 PyFixest's `pf.WithinDemeaner()`, takes a different approach: it
 explicitly builds and exploits the block structure of the normal
-equations to form a high-quality preconditioner for the linear problem. We explain this structure below.
+equations to form a high-quality preconditioner for the linear problem.
+PyFixest defaults to additive Schwarz with CG, and also supports additive
+or multiplicative Schwarz with GMRES.
 
 ## The Normal Equations and Their Block Structure
 

--- a/docs/explanation/difficult-fixed-effects.md
+++ b/docs/explanation/difficult-fixed-effects.md
@@ -71,7 +71,8 @@ PyFixest's `pf.WithinDemeaner()`, takes a different approach: it
 explicitly builds and exploits the block structure of the normal
 equations to form a high-quality preconditioner for the linear problem.
 PyFixest defaults to additive Schwarz with CG, and also supports additive
-or multiplicative Schwarz with GMRES.
+or multiplicative Schwarz with GMRES. The preconditioner can be disabled
+with `preconditioner="off"`.
 
 ## The Normal Equations and Their Block Structure
 

--- a/docs/how-to/demeaner-backends.qmd
+++ b/docs/how-to/demeaner-backends.qmd
@@ -23,7 +23,7 @@ For a deeper discussion on when to use which backend, see [When Are Fixed Effect
 |---|---|
 | `MapDemeaner(backend="numba")` | Default. Works well for dense fixed effects / well connected graphs. |
 | `MapDemeaner(backend="rust")` | Identical algorithm to `MapDemeaner(backend="numba")`, but implemented in Rust. Despite being Rust, performance should be roughly identical to numba. |
-| `WithinDemeaner()` | Best for **sparse** fixed-effect structures (e.g. matched employer-employee data). Supports additive Schwarz with CG or GMRES, and multiplicative Schwarz with GMRES. |
+| `WithinDemeaner()` | Best for **sparse** fixed-effect structures (e.g. matched employer-employee data). Supports additive Schwarz with CG or GMRES, multiplicative Schwarz with GMRES, and unpreconditioned solves via `preconditioner="off"`. |
 | `MapDemeaner(backend="jax")` | MAP on the GPU via JAX (requires `pip install pyfixest[jax]`). |
 | `LsmrDemeaner(backend="torch", device="cuda")` | GPU acceleration via PyTorch. Experimental. |
 | `LsmrDemeaner(backend="cupy", device="cpu")` | LSMR solver on CPU via SciPy. |
@@ -39,12 +39,12 @@ fit = pf.feols("Y ~ X1 | f1", data=df)
 # Rust MAP: roughly same performance as numba
 fit = pf.feols("Y ~ X1 | f1", data=df, demeaner=MapDemeaner(backend="rust"))
 
-# `within` backend - best for sparse FE structures
-fit = pf.feols("Y ~ X1 | f1", data=df, demeaner=WithinDemeaner())
+# `within` backend - best for sparse multi-way FE structures
+fit = pf.feols("Y ~ X1 | f1 + f2", data=df, demeaner=WithinDemeaner())
 
 # Additive Schwarz + GMRES
 fit = pf.feols(
-    "Y ~ X1 | f1",
+    "Y ~ X1 | f1 + f2",
     data=df,
     demeaner=WithinDemeaner(
         krylov="gmres",
@@ -55,7 +55,7 @@ fit = pf.feols(
 
 # Multiplicative Schwarz + GMRES
 fit = pf.feols(
-    "Y ~ X1 | f1",
+    "Y ~ X1 | f1 + f2",
     data=df,
     demeaner=WithinDemeaner(
         krylov="gmres",
@@ -65,7 +65,7 @@ fit = pf.feols(
 )
 ```
 
-The `MapDemeaner` and `WithinDemeaner` backends accept `fixef_tol` and `fixef_maxiter` arguments to control convergence. `WithinDemeaner` additionally accepts `krylov`, `preconditioner`, and `gmres_restart` (used only with `krylov="gmres"`). For compatibility with `scipy`, the `LsmrDemeaner` has two arguments to control the convergence tolerance - `fixef_atol` and `fixef_btol`.
+The `MapDemeaner` and `WithinDemeaner` backends accept `fixef_tol` and `fixef_maxiter` arguments to control convergence. `WithinDemeaner` additionally accepts `krylov`, `preconditioner`, and `gmres_restart` (used only with `krylov="gmres"`). The `preconditioner` argument accepts `"additive"`, `"multiplicative"`, and `"off"`; `"off"` matches `within.Preconditioner.Off`. For compatibility with `scipy`, the `LsmrDemeaner` has two arguments to control the convergence tolerance - `fixef_atol` and `fixef_btol`.
 
 ```{python}
 fit = pf.feols(

--- a/docs/how-to/demeaner-backends.qmd
+++ b/docs/how-to/demeaner-backends.qmd
@@ -23,7 +23,7 @@ For a deeper discussion on when to use which backend, see [When Are Fixed Effect
 |---|---|
 | `MapDemeaner(backend="numba")` | Default. Works well for dense fixed effects / well connected graphs. |
 | `MapDemeaner(backend="rust")` | Identical algorithm to `MapDemeaner(backend="numba")`, but implemented in Rust. Despite being Rust, performance should be roughly identical to numba. |
-| `WithinDemeaner()` | Best for **sparse** fixed-effect structures (e.g. matched employer-employee data). |
+| `WithinDemeaner()` | Best for **sparse** fixed-effect structures (e.g. matched employer-employee data). Supports additive Schwarz with CG or GMRES, and multiplicative Schwarz with GMRES. |
 | `MapDemeaner(backend="jax")` | MAP on the GPU via JAX (requires `pip install pyfixest[jax]`). |
 | `LsmrDemeaner(backend="torch", device="cuda")` | GPU acceleration via PyTorch. Experimental. |
 | `LsmrDemeaner(backend="cupy", device="cpu")` | LSMR solver on CPU via SciPy. |
@@ -39,11 +39,33 @@ fit = pf.feols("Y ~ X1 | f1", data=df)
 # Rust MAP: roughly same performance as numba
 fit = pf.feols("Y ~ X1 | f1", data=df, demeaner=MapDemeaner(backend="rust"))
 
-# CG-Schwarz via `within` - best for sparse FE structures
+# `within` backend - best for sparse FE structures
 fit = pf.feols("Y ~ X1 | f1", data=df, demeaner=WithinDemeaner())
+
+# Additive Schwarz + GMRES
+fit = pf.feols(
+    "Y ~ X1 | f1",
+    data=df,
+    demeaner=WithinDemeaner(
+        krylov="gmres",
+        preconditioner="additive",
+        gmres_restart=30,
+    ),
+)
+
+# Multiplicative Schwarz + GMRES
+fit = pf.feols(
+    "Y ~ X1 | f1",
+    data=df,
+    demeaner=WithinDemeaner(
+        krylov="gmres",
+        preconditioner="multiplicative",
+        gmres_restart=50,
+    ),
+)
 ```
 
-The `MapDemeaner` and `WithinDemeaner` backends accept `fixef_tol` and `fixef_maxiter` arguments to control convergence. For compatibility with `scipy`, the `LsmrDemeaner` has two arguments to control the convergence tolerance - `fixef_atol` and `fixef_btol`.
+The `MapDemeaner` and `WithinDemeaner` backends accept `fixef_tol` and `fixef_maxiter` arguments to control convergence. `WithinDemeaner` additionally accepts `krylov`, `preconditioner`, and `gmres_restart` (used only with `krylov="gmres"`). For compatibility with `scipy`, the `LsmrDemeaner` has two arguments to control the convergence tolerance - `fixef_atol` and `fixef_btol`.
 
 ```{python}
 fit = pf.feols(

--- a/pyfixest/core/_core_impl.pyi
+++ b/pyfixest/core/_core_impl.pyi
@@ -28,6 +28,9 @@ def _demean_within_rs(
     weights: NDArray[np.float64],
     tol: float = 1e-06,
     maxiter: int = 1_000,
+    krylov: str = "cg",
+    preconditioner: str = "additive",
+    gmres_restart: int = 30,
 ) -> tuple[np.ndarray, bool]: ...
 def _count_fixef_fully_nested_all_rs(
     all_fixef_array: NDArray,

--- a/pyfixest/core/demean.py
+++ b/pyfixest/core/demean.py
@@ -85,9 +85,12 @@ def demean_within(
     weights: NDArray[np.float64],
     tol: float = 1e-06,
     maxiter: int = 1_000,
+    krylov: str = "cg",
+    preconditioner: str = "additive",
+    gmres_restart: int = 30,
 ) -> tuple[NDArray, bool]:
     """
-    Demean an array using preconditioned conjugate gradient via the `within` crate.
+    Demean an array using Krylov solvers and Schwarz preconditioning via `within`.
 
     Uses Krylov-based solvers with Schwarz preconditioning. Converges faster
     than alternating projections on weakly-connected or block-diagonal
@@ -108,7 +111,14 @@ def demean_within(
     tol : float, optional
         Convergence tolerance. Defaults to 1e-06.
     maxiter : int, optional
-        Maximum number of CG iterations. Defaults to 1_000.
+        Maximum number of Krylov iterations. Defaults to 1_000.
+    krylov : {"cg", "gmres"}, optional
+        Krylov solver used for multi-way fixed effects. Defaults to ``"cg"``.
+    preconditioner : {"additive", "multiplicative"}, optional
+        Schwarz preconditioner used for multi-way fixed effects. Defaults to
+        ``"additive"``.
+    gmres_restart : int, optional
+        Restart dimension when ``krylov="gmres"``. Ignored for CG.
 
     Returns
     -------
@@ -129,4 +139,7 @@ def demean_within(
         weights.astype(np.float64, copy=False).reshape(-1),
         tol,
         maxiter,
+        krylov,
+        preconditioner,
+        gmres_restart,
     )

--- a/pyfixest/core/demean.py
+++ b/pyfixest/core/demean.py
@@ -114,9 +114,10 @@ def demean_within(
         Maximum number of Krylov iterations. Defaults to 1_000.
     krylov : {"cg", "gmres"}, optional
         Krylov solver used for multi-way fixed effects. Defaults to ``"cg"``.
-    preconditioner : {"additive", "multiplicative"}, optional
-        Schwarz preconditioner used for multi-way fixed effects. Defaults to
-        ``"additive"``.
+    preconditioner : {"additive", "multiplicative", "off"}, optional
+        Schwarz preconditioner used for multi-way fixed effects. ``"off"``
+        disables preconditioning.
+        Defaults to ``"additive"``.
     gmres_restart : int, optional
         Restart dimension when ``krylov="gmres"``. Ignored for CG.
 

--- a/pyfixest/demeaners.py
+++ b/pyfixest/demeaners.py
@@ -9,7 +9,7 @@ LsmrBackend = Literal["cupy", "torch"]
 LsmrPrecision = Literal["float32", "float64"]
 TorchDevice = Literal["auto", "cpu", "mps", "cuda"]
 WithinKrylov = Literal["cg", "gmres"]
-WithinPreconditioner = Literal["additive", "multiplicative"]
+WithinPreconditioner = Literal["additive", "multiplicative", "off"]
 
 
 def _validate_unit_interval_float(value: float, name: str) -> None:

--- a/pyfixest/demeaners.py
+++ b/pyfixest/demeaners.py
@@ -8,6 +8,8 @@ MapBackend = Literal["numba", "rust", "jax"]
 LsmrBackend = Literal["cupy", "torch"]
 LsmrPrecision = Literal["float32", "float64"]
 TorchDevice = Literal["auto", "cpu", "mps", "cuda"]
+WithinKrylov = Literal["cg", "gmres"]
+WithinPreconditioner = Literal["additive", "multiplicative"]
 
 
 def _validate_unit_interval_float(value: float, name: str) -> None:
@@ -61,11 +63,32 @@ class WithinDemeaner(BaseDemeaner):
 
     fixef_tol: float = 1e-06
     fixef_maxiter: int = 1_000
+    krylov: WithinKrylov = "cg"
+    preconditioner: WithinPreconditioner = "additive"
+    gmres_restart: int = 30
     kind: ClassVar[str] = "within"
 
     def __post_init__(self) -> None:
         BaseDemeaner.__post_init__(self)
         _validate_unit_interval_float(self.fixef_tol, "fixef_tol")
+        if not isinstance(self.krylov, str):
+            raise TypeError("`krylov` must be a string.")
+        if self.krylov not in get_args(WithinKrylov):
+            raise ValueError(f"`krylov` must be one of {get_args(WithinKrylov)}.")
+
+        if not isinstance(self.preconditioner, str):
+            raise TypeError("`preconditioner` must be a string.")
+        if self.preconditioner not in get_args(WithinPreconditioner):
+            raise ValueError(
+                f"`preconditioner` must be one of {get_args(WithinPreconditioner)}."
+            )
+
+        _validate_positive_int(self.gmres_restart, "gmres_restart")
+
+        if self.krylov == "cg" and self.preconditioner == "multiplicative":
+            raise ValueError(
+                "`preconditioner='multiplicative'` requires `krylov='gmres'`."
+            )
 
 
 @dataclass(frozen=True, slots=True)
@@ -131,4 +154,6 @@ __all__ = [
     "MapDemeaner",
     "TorchDevice",
     "WithinDemeaner",
+    "WithinKrylov",
+    "WithinPreconditioner",
 ]

--- a/pyfixest/estimation/internals/demean_.py
+++ b/pyfixest/estimation/internals/demean_.py
@@ -182,6 +182,9 @@ def dispatch_demean(
             weights=weights,
             tol=demeaner.fixef_tol,
             maxiter=demeaner.fixef_maxiter,
+            krylov=demeaner.krylov,
+            preconditioner=demeaner.preconditioner,
+            gmres_restart=demeaner.gmres_restart,
         )
 
     if isinstance(demeaner, LsmrDemeaner):

--- a/src/demean_within.rs
+++ b/src/demean_within.rs
@@ -39,13 +39,14 @@ fn demean_within_impl(
         ..within::SolverParams::default()
     };
     let preconditioner = match preconditioner {
-        "additive" => within::Preconditioner::Additive(
+        "additive" => Some(within::Preconditioner::Additive(
             within::LocalSolverConfig::solver_default(),
             within::ReductionStrategy::Auto,
-        ),
-        "multiplicative" => {
-            within::Preconditioner::Multiplicative(within::LocalSolverConfig::solver_default())
-        }
+        )),
+        "multiplicative" => Some(within::Preconditioner::Multiplicative(
+            within::LocalSolverConfig::solver_default(),
+        )),
+        "off" => None,
         _ => panic!("validated in Python: unsupported preconditioner"),
     };
 
@@ -54,7 +55,7 @@ fn demean_within_impl(
         &x_slices,
         Some(&weights_vec),
         &params,
-        Some(&preconditioner),
+        preconditioner.as_ref(),
     )?;
 
     let all_converged = result.converged().iter().all(|&c| c);

--- a/src/demean_within.rs
+++ b/src/demean_within.rs
@@ -2,10 +2,57 @@ use ndarray::{Array2, ArrayView1, ArrayView2, ShapeBuilder};
 use numpy::{PyArray2, PyReadonlyArray1, PyReadonlyArray2};
 use pyo3::prelude::*;
 
+fn py_value_error(message: impl Into<String>) -> PyErr {
+    pyo3::exceptions::PyValueError::new_err(message.into())
+}
+
 fn extract_columns(x: &ArrayView2<f64>) -> Vec<Vec<f64>> {
     (0..x.ncols())
         .map(|col| x.column(col).iter().copied().collect())
         .collect()
+}
+
+fn extract_krylov(krylov: &str, gmres_restart: usize) -> PyResult<within::KrylovMethod> {
+    match krylov {
+        "cg" => Ok(within::KrylovMethod::Cg),
+        "gmres" => Ok(within::KrylovMethod::Gmres {
+            restart: gmres_restart,
+        }),
+        _ => Err(py_value_error("`krylov` must be one of ('cg', 'gmres').")),
+    }
+}
+
+fn extract_preconditioner(preconditioner: &str) -> PyResult<Option<within::Preconditioner>> {
+    match preconditioner {
+        "additive" => Ok(Some(within::Preconditioner::Additive(
+            within::LocalSolverConfig::solver_default(),
+            within::ReductionStrategy::Auto,
+        ))),
+        "multiplicative" => Ok(Some(within::Preconditioner::Multiplicative(
+            within::LocalSolverConfig::solver_default(),
+        ))),
+        "off" => Ok(None),
+        _ => Err(py_value_error(
+            "`preconditioner` must be one of ('additive', 'multiplicative', 'off').",
+        )),
+    }
+}
+
+fn validate_cg_preconditioner(
+    krylov: within::KrylovMethod,
+    preconditioner: Option<&within::Preconditioner>,
+) -> PyResult<()> {
+    if matches!(krylov, within::KrylovMethod::Cg)
+        && matches!(
+            preconditioner,
+            Some(within::Preconditioner::Multiplicative(_))
+        )
+    {
+        return Err(py_value_error(
+            "CG requires a symmetric preconditioner; use 'additive' or switch to GMRES",
+        ));
+    }
+    Ok(())
 }
 
 fn demean_within_impl(
@@ -14,9 +61,8 @@ fn demean_within_impl(
     weights: &ArrayView1<f64>,
     tol: f64,
     maxiter: usize,
-    krylov: &str,
-    preconditioner: &str,
-    gmres_restart: usize,
+    krylov: within::KrylovMethod,
+    preconditioner: Option<&within::Preconditioner>,
 ) -> Result<(Array2<f64>, bool), within::WithinError> {
     let n_obs = x.nrows();
     let n_rhs = x.ncols();
@@ -25,29 +71,11 @@ fn demean_within_impl(
     let x_slices: Vec<&[f64]> = x_columns.iter().map(|col| col.as_slice()).collect();
     let weights_vec: Vec<f64> = weights.iter().copied().collect();
 
-    let krylov = match krylov {
-        "cg" => within::KrylovMethod::Cg,
-        "gmres" => within::KrylovMethod::Gmres {
-            restart: gmres_restart,
-        },
-        _ => panic!("validated in Python: unsupported krylov method"),
-    };
     let params = within::SolverParams {
         krylov,
         tol,
         maxiter,
         ..within::SolverParams::default()
-    };
-    let preconditioner = match preconditioner {
-        "additive" => Some(within::Preconditioner::Additive(
-            within::LocalSolverConfig::solver_default(),
-            within::ReductionStrategy::Auto,
-        )),
-        "multiplicative" => Some(within::Preconditioner::Multiplicative(
-            within::LocalSolverConfig::solver_default(),
-        )),
-        "off" => None,
-        _ => panic!("validated in Python: unsupported preconditioner"),
     };
 
     let result = within::solve_batch(
@@ -55,7 +83,7 @@ fn demean_within_impl(
         &x_slices,
         Some(&weights_vec),
         &params,
-        preconditioner.as_ref(),
+        preconditioner,
     )?;
 
     let all_converged = result.converged().iter().all(|&c| c);
@@ -89,6 +117,9 @@ pub fn _demean_within_rs(
     let x_arr = x.as_array();
     let flist_arr = flist.as_array();
     let weights_arr = weights.as_array();
+    let krylov = extract_krylov(krylov, gmres_restart)?;
+    let preconditioner = extract_preconditioner(preconditioner)?;
+    validate_cg_preconditioner(krylov, preconditioner.as_ref())?;
 
     let (out, success) = py
         .detach(|| {
@@ -99,8 +130,7 @@ pub fn _demean_within_rs(
                 tol,
                 maxiter,
                 krylov,
-                preconditioner,
-                gmres_restart,
+                preconditioner.as_ref(),
             )
         })
         .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;

--- a/src/demean_within.rs
+++ b/src/demean_within.rs
@@ -14,6 +14,9 @@ fn demean_within_impl(
     weights: &ArrayView1<f64>,
     tol: f64,
     maxiter: usize,
+    krylov: &str,
+    preconditioner: &str,
+    gmres_restart: usize,
 ) -> Result<(Array2<f64>, bool), within::WithinError> {
     let n_obs = x.nrows();
     let n_rhs = x.ncols();
@@ -22,15 +25,29 @@ fn demean_within_impl(
     let x_slices: Vec<&[f64]> = x_columns.iter().map(|col| col.as_slice()).collect();
     let weights_vec: Vec<f64> = weights.iter().copied().collect();
 
+    let krylov = match krylov {
+        "cg" => within::KrylovMethod::Cg,
+        "gmres" => within::KrylovMethod::Gmres {
+            restart: gmres_restart,
+        },
+        _ => panic!("validated in Python: unsupported krylov method"),
+    };
     let params = within::SolverParams {
+        krylov,
         tol,
         maxiter,
         ..within::SolverParams::default()
     };
-    let preconditioner = within::Preconditioner::Additive(
-        within::LocalSolverConfig::solver_default(),
-        within::ReductionStrategy::Auto,
-    );
+    let preconditioner = match preconditioner {
+        "additive" => within::Preconditioner::Additive(
+            within::LocalSolverConfig::solver_default(),
+            within::ReductionStrategy::Auto,
+        ),
+        "multiplicative" => {
+            within::Preconditioner::Multiplicative(within::LocalSolverConfig::solver_default())
+        }
+        _ => panic!("validated in Python: unsupported preconditioner"),
+    };
 
     let result = within::solve_batch(
         flist.view(),
@@ -47,7 +64,16 @@ fn demean_within_impl(
 }
 
 #[pyfunction]
-#[pyo3(signature = (x, flist, weights, tol=1e-6, maxiter=1_000))]
+#[pyo3(signature = (
+    x,
+    flist,
+    weights,
+    tol=1e-6,
+    maxiter=1_000,
+    krylov="cg",
+    preconditioner="additive",
+    gmres_restart=30
+))]
 pub fn _demean_within_rs(
     py: Python<'_>,
     x: PyReadonlyArray2<f64>,
@@ -55,13 +81,27 @@ pub fn _demean_within_rs(
     weights: PyReadonlyArray1<f64>,
     tol: f64,
     maxiter: usize,
+    krylov: &str,
+    preconditioner: &str,
+    gmres_restart: usize,
 ) -> PyResult<(Py<PyArray2<f64>>, bool)> {
     let x_arr = x.as_array();
     let flist_arr = flist.as_array();
     let weights_arr = weights.as_array();
 
     let (out, success) = py
-        .detach(|| demean_within_impl(&x_arr, &flist_arr, &weights_arr, tol, maxiter))
+        .detach(|| {
+            demean_within_impl(
+                &x_arr,
+                &flist_arr,
+                &weights_arr,
+                tol,
+                maxiter,
+                krylov,
+                preconditioner,
+                gmres_restart,
+            )
+        })
         .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
 
     let pyarray = PyArray2::from_owned_array(py, out);

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -163,6 +163,14 @@ def test_within_demeaner_accepts_gmres_variants():
     assert multiplicative.gmres_restart == 50
 
 
+def test_within_demeaner_accepts_preconditioner_off():
+    cg_off = pf.WithinDemeaner(krylov="cg", preconditioner="off")
+    gmres_off = pf.WithinDemeaner(krylov="gmres", preconditioner="off")
+
+    assert cg_off.preconditioner == "off"
+    assert gmres_off.preconditioner == "off"
+
+
 @pytest.mark.parametrize(
     "kwargs, message",
     [

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -107,6 +107,9 @@ def test_legacy_demeaner_args_map_with_deprecation_warning():
     assert isinstance(fit._demeaner, pf.WithinDemeaner)
     assert fit._demeaner.fixef_tol == 1e-4
     assert fit._demeaner.fixef_maxiter == 321
+    assert fit._demeaner.krylov == "cg"
+    assert fit._demeaner.preconditioner == "additive"
+    assert fit._demeaner.gmres_restart == 30
 
 
 def test_legacy_demeaner_args_conflict_with_typed_demeaner():
@@ -126,6 +129,7 @@ def test_legacy_demeaner_args_conflict_with_typed_demeaner():
     [
         (lambda: pf.MapDemeaner(fixef_tol=1.0), "fixef_tol"),
         (lambda: pf.WithinDemeaner(fixef_tol=1.0), "fixef_tol"),
+        (lambda: pf.WithinDemeaner(gmres_restart=0), "gmres_restart"),
         (lambda: pf.LsmrDemeaner(fixef_atol=1.0), "fixef_atol"),
         (lambda: pf.LsmrDemeaner(fixef_btol=1.0), "fixef_btol"),
     ],
@@ -133,6 +137,46 @@ def test_legacy_demeaner_args_conflict_with_typed_demeaner():
 def test_typed_demeaners_reject_tolerances_ge_one(builder, invalid_name):
     with pytest.raises(ValueError, match=invalid_name):
         builder()
+
+
+def test_within_demeaner_defaults():
+    demeaner = pf.WithinDemeaner()
+
+    assert demeaner.krylov == "cg"
+    assert demeaner.preconditioner == "additive"
+    assert demeaner.gmres_restart == 30
+
+
+def test_within_demeaner_accepts_gmres_variants():
+    additive = pf.WithinDemeaner(
+        krylov="gmres",
+        preconditioner="additive",
+        gmres_restart=20,
+    )
+    multiplicative = pf.WithinDemeaner(
+        krylov="gmres",
+        preconditioner="multiplicative",
+        gmres_restart=50,
+    )
+
+    assert additive.gmres_restart == 20
+    assert multiplicative.gmres_restart == 50
+
+
+@pytest.mark.parametrize(
+    "kwargs, message",
+    [
+        (
+            {"krylov": "cg", "preconditioner": "multiplicative"},
+            "requires `krylov='gmres'`",
+        ),
+        ({"krylov": "bicg"}, "`krylov`"),
+        ({"preconditioner": "ilu"}, "`preconditioner`"),
+    ],
+)
+def test_within_demeaner_rejects_invalid_solver_options(kwargs, message):
+    with pytest.raises(ValueError, match=message):
+        pf.WithinDemeaner(**kwargs)
 
 
 def test_lean():

--- a/tests/test_demean.py
+++ b/tests/test_demean.py
@@ -146,6 +146,16 @@ def test_torch_device_backends_match_pyhdfe(backend_name, rtol, atol, demean_dat
             1e-6,
             1e-8,
         ),
+        (
+            WithinDemeaner(
+                krylov="cg",
+                preconditioner="off",
+                fixef_tol=1e-10,
+                fixef_maxiter=10_000,
+            ),
+            1e-6,
+            1e-8,
+        ),
     ],
 )
 def test_within_solver_variants_match_pyhdfe(demeaner, rtol, atol, demean_data):

--- a/tests/test_demean.py
+++ b/tests/test_demean.py
@@ -5,6 +5,7 @@ import pytest
 
 import pyfixest as pf
 from pyfixest.core import demean as demean_rs
+from pyfixest.core.demean import demean_within
 from pyfixest.demeaners import LsmrDemeaner, MapDemeaner, WithinDemeaner
 from pyfixest.estimation.cupy.demean_cupy_ import demean_cupy32, demean_cupy64
 from pyfixest.estimation.internals.demean_ import (
@@ -212,6 +213,29 @@ def test_within_single_fe_fallback_ignores_nondefault_solver_options():
     )
     assert success
     np.testing.assert_allclose(within_result, map_result, rtol=1e-10, atol=1e-10)
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"krylov": "bicg"}, "`krylov`"),
+        ({"preconditioner": "ilu"}, "`preconditioner`"),
+        (
+            {"krylov": "cg", "preconditioner": "multiplicative"},
+            "CG requires a symmetric preconditioner",
+        ),
+    ],
+)
+def test_demean_within_rejects_invalid_solver_options(kwargs, message, demean_data):
+    x, flist, weights = demean_data
+
+    with pytest.raises(ValueError, match=message):
+        demean_within(
+            x=x,
+            flist=flist.astype(np.uint32, copy=False),
+            weights=weights,
+            **kwargs,
+        )
 
 
 @pytest.mark.skipif(not HAS_TORCH, reason="torch not available")

--- a/tests/test_demean.py
+++ b/tests/test_demean.py
@@ -124,6 +124,86 @@ def test_torch_device_backends_match_pyhdfe(backend_name, rtol, atol, demean_dat
     np.testing.assert_allclose(res_torch, res_pyhdfe, rtol=rtol, atol=atol)
 
 
+@pytest.mark.parametrize(
+    ("demeaner", "rtol", "atol"),
+    [
+        (WithinDemeaner(), 1e-6, 1e-8),
+        (
+            WithinDemeaner(
+                krylov="gmres",
+                preconditioner="additive",
+                gmres_restart=20,
+            ),
+            1e-6,
+            1e-8,
+        ),
+        (
+            WithinDemeaner(
+                krylov="gmres",
+                preconditioner="multiplicative",
+                gmres_restart=30,
+            ),
+            1e-6,
+            1e-8,
+        ),
+    ],
+)
+def test_within_solver_variants_match_pyhdfe(demeaner, rtol, atol, demean_data):
+    x, flist, weights = demean_data
+
+    algorithm = pyhdfe.create(flist)
+    expected_unweighted = algorithm.residualize(x)
+    result_unweighted, success = dispatch_demean(
+        x=x,
+        flist=flist,
+        weights=np.ones(x.shape[0]),
+        demeaner=demeaner,
+    )
+    assert success
+    np.testing.assert_allclose(
+        result_unweighted, expected_unweighted, rtol=rtol, atol=atol
+    )
+
+    expected_weighted = algorithm.residualize(x, weights.reshape((x.shape[0], 1)))
+    result_weighted, success = dispatch_demean(
+        x=x,
+        flist=flist,
+        weights=weights,
+        demeaner=demeaner,
+    )
+    assert success
+    np.testing.assert_allclose(result_weighted, expected_weighted, rtol=rtol, atol=atol)
+
+
+def test_within_single_fe_fallback_ignores_nondefault_solver_options():
+    rng = np.random.default_rng(1234)
+    x = rng.normal(size=(100, 3))
+    flist = rng.integers(0, 10, size=(100, 1), dtype=np.uint64)
+    weights = rng.uniform(0.5, 1.5, size=100)
+
+    within_result, success = dispatch_demean(
+        x=x,
+        flist=flist,
+        weights=weights,
+        demeaner=WithinDemeaner(
+            krylov="gmres",
+            preconditioner="multiplicative",
+            gmres_restart=17,
+        ),
+    )
+    assert success
+
+    map_result, success = demean_rs(
+        x,
+        flist,
+        weights,
+        tol=1e-6,
+        maxiter=1_000,
+    )
+    assert success
+    np.testing.assert_allclose(within_result, map_result, rtol=1e-10, atol=1e-10)
+
+
 @pytest.mark.skipif(not HAS_TORCH, reason="torch not available")
 def test_sparse_dummy_reencodes_non_contiguous_groups():
     from pyfixest.estimation.torch._sparse_dummy import _build_sparse_dummy


### PR DESCRIPTION
Add options to run multiplicative schwarz and grmres. @schroedk fyi, it would look like this: 

```python
fit = pf.feols(
    "Y ~ X1 | f1 + f2",
    data=df,
    demeaner=pf.WithinDemeaner(
        krylov="gmres",
        preconditioner="multiplicative",
        gmres_restart=50,
    ),
)
```
So setting within demeaner options is slightly less strongly typed than in within-py. 