### PR TITLE
Close #1283

### DIFF
--- a/pyfixest/estimation/models/_result_accessor_mixin.py
+++ b/pyfixest/estimation/models/_result_accessor_mixin.py
@@ -170,20 +170,22 @@ class ResultAccessorMixin:
                 UserWarning,
             )
 
-        tidy_df = pd.DataFrame(
-            {
-                "Coefficient": self._coefnames,
-                "Estimate": self._beta_hat,
-                "Std. Error": self._se,
-                "t value": self._tstat,
-                "Pr(>|t|)": self._pvalue,
-                # use slice because self._conf_int might be empty
-                f"{lb * 100:.1f}%": self._conf_int[:1].flatten(),
-                f"{ub * 100:.1f}%": self._conf_int[1:2].flatten(),
-            }
-        )
-
-        return tidy_df.set_index("Coefficient")
+        data = {
+            "Coefficient": self._coefnames,
+            "Estimate": self._beta_hat,
+            "Std. Error": self._se,
+            "t value": self._tstat,
+            "Pr(>|t|)": self._pvalue,
+            # use slice because self._conf_int might be empty
+            f"{lb * 100:.1f}%": self._conf_int[:1].flatten(),
+            f"{ub * 100:.1f}%": self._conf_int[1:2].flatten(),
+        }
+        if (
+            getattr(self, "_sample_split_var", None) is not None
+            and (sample := getattr(self, "_sample_split_value", None)) is not None
+        ):
+            data["Sample"] = sample
+        return pd.DataFrame(data).set_index("Coefficient")
 
     def coef(self) -> pd.Series:
         """


### PR DESCRIPTION
This adds a new column `Sample` to the tidy results frame but only if `fsplit/split` was used. Note that I have decided to not add it as a `MultiIndex` level because I expect that we will sooner or later move away from `pandas` and alternatives (`polars`/`duckdb`) don't really use indices anyway. Closes #1283.