### PR TITLE
Deprecate use_compression in feols()

### DIFF
--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -36,6 +36,12 @@ fit = pf.feols("Y ~ X1 | f1", data=df, demeaner=LsmrDemeaner(backend="torch", de
 
 **Deprecations:** The `demeaner_backend`, `fixef_tol`, and `fixef_maxiter` arguments to `feols()` and related functions are deprecated and will be removed in a future release. Likewise, the `_fixef_tol` and `_fixef_maxiter` attributes on fitted model objects are deprecated — use `model.demeaner.fixef_tol` and `model.demeaner.fixef_maxiter` instead.
 
+### Regression Compression Deprecation
+
+The `use_compression` argument to `feols()` is deprecated and will be removed in a future release. This feature implemented the in-memory regression compression approach from [Wong et al. (2021)](https://arxiv.org/abs/2102.11297) via a Mundlak/sufficient-statistics transform. Out-of-memory regression on large datasets is better served by the [`duckreg`](https://github.com/py-econometrics/duckreg) package, which provides a more general and actively maintained solution. See [#1302](https://github.com/py-econometrics/pyfixest/issues/1302) for context.
+
+Passing `use_compression=True` now raises a `DeprecationWarning`.
+
 - Adds experimental GPU acceleration via PyTorch on CUDA and MPS, plus a PyTorch-based CPU LSMR demeaning backend.
 
 - Adds support for `offset`s in `pf.fepois()`, thanks to @bradhackinen and @marie-gar.

--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -38,7 +38,7 @@ fit = pf.feols("Y ~ X1 | f1", data=df, demeaner=LsmrDemeaner(backend="torch", de
 
 ### Regression Compression Deprecation
 
-The `use_compression` argument to `feols()` is deprecated and will be removed in a future release. This feature implemented the in-memory regression compression approach from [Wong et al. (2021)](https://arxiv.org/abs/2102.11297) via a Mundlak/sufficient-statistics transform. Out-of-memory regression on large datasets is better served by the [`duckreg`](https://github.com/py-econometrics/duckreg) package, which provides a more general and actively maintained solution. See [#1302](https://github.com/py-econometrics/pyfixest/issues/1302) for context.
+The `use_compression` argument to `feols()` is deprecated and will be removed in a future release. This feature implemented the in-memory regression compression approach from [Wong et al. (2021)](https://arxiv.org/abs/2102.11297) via a Mundlak/sufficient-statistics transform. For large-dataset use cases, the [`duckreg`](https://github.com/py-econometrics/duckreg) package provides a more general out-of-memory solution. See [#1302](https://github.com/py-econometrics/pyfixest/issues/1302) for context.
 
 Passing `use_compression=True` now raises a `DeprecationWarning`.
 

--- a/pyfixest/estimation/api/feols.py
+++ b/pyfixest/estimation/api/feols.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from collections.abc import Mapping
 from typing import Any
 
@@ -143,6 +144,11 @@ def feols(
         `MapDemeaner()` (numba MAP algorithm, tol=1e-6, maxiter=10_000).
 
     use_compression: bool
+        .. deprecated::
+            ``use_compression`` is deprecated and will be removed in a future release.
+            For out-of-memory regression on large datasets, consider using the
+            `duckreg <https://github.com/py-econometrics/duckreg>`_ package instead.
+
         Whether to use sufficient statistics to losslessly fit the regression model
         on compressed data. False by default. If True, the model is estimated on
         compressed data, which can lead to a significant speed-up for large data sets.
@@ -489,6 +495,18 @@ def feols(
         fixef_maxiter=fixef_maxiter,
     )
     _warn_if_experimental_torch_demeaner(demeaner)
+
+    if use_compression:
+        warnings.warn(
+            (
+                "The `use_compression` argument is deprecated and will be removed in a future release. "
+                "For out-of-memory regression on large datasets, consider using the "
+                "`duckreg` package (https://github.com/py-econometrics/duckreg) instead. "
+                "See https://github.com/py-econometrics/pyfixest/issues/1302 for context."
+            ),
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
     _estimation_input_checks(
         fml=fml,


### PR DESCRIPTION
## Summary

- Adds a `DeprecationWarning` to `feols()` when `use_compression=True` is passed, directing users to the [`duckreg`](https://github.com/py-econometrics/duckreg) package as the recommended alternative for large-dataset regression.
- Updates the `use_compression` docstring with a `.. deprecated::` notice.
- Announces the deprecation in the `0.60.0` changelog section with rationale and a link to the tracking issue.

## Context

Closes #1302.