### PR TITLE
Fix/panelview int treat pct treated

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -516,6 +516,9 @@
       "profile": "https://github.com/marie-gar",
       "contributions": [
         "review"
+      ]
+    },
+    {
       "login": "bradhackinen",
       "name": "Brad Hackinen",
       "avatar_url": "https://avatars.githubusercontent.com/u/14437616?v=4",

--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -46,6 +46,13 @@ Passing `use_compression=True` now raises a `DeprecationWarning`.
 
 - Adds support for `offset`s in `pf.fepois()`, thanks to @bradhackinen and @marie-gar.
 
+### panelview Bug Fixes
+
+- Validates that the `treat` column is binary (`{0, 1, True, False}`) and normalizes it to boolean before plotting, matching R's `panelView` behavior. See [#1311](https://github.com/py-econometrics/pyfixest/issues/1311).
+- Fixes `sort_by_timing` to sort units by the period of first treatment (via `argmax`) rather than by the total number of treated periods.
+- Raises an explicit `ValueError` when the `treat` column contains missing values instead of silently dropping them.
+- Fixes a latent bug in `_plot_panelview` where passing a user-supplied `ax` together with `legend=True` referenced an unbound figure variable; the colorbar is now attached via `ax.figure`.
+
 ## PyFixest 0.50.1
 
 ### Bug Fixes

--- a/pyfixest/did/visualize.py
+++ b/pyfixest/did/visualize.py
@@ -114,7 +114,7 @@ def panelview(
             "Cannot use 'collapse_to_cohort' together with 'subsamp' or 'units_to_plot'."
         )
     unique_vals = set(data[treat].dropna().unique())
-    if not unique_vals.issubset({0, 1, True, False}):
+    if not unique_vals.issubset({0, 1}):
         raise ValueError(
             f"Column '{treat}' must be binary (bool or 0/1 integer). "
             f"Found values: {unique_vals}"

--- a/pyfixest/did/visualize.py
+++ b/pyfixest/did/visualize.py
@@ -113,6 +113,14 @@ def panelview(
         raise ValueError(
             "Cannot use 'collapse_to_cohort' together with 'subsamp' or 'units_to_plot'."
         )
+    unique_vals = set(data[treat].dropna().unique())
+    if not unique_vals.issubset({0, 1, True, False}):
+        raise ValueError(
+            f"Column '{treat}' must be binary (bool or 0/1 integer). "
+            f"Found values: {unique_vals}"
+        )
+    # Normalize treat to boolean to handle integer (0/1) columns robustly
+    data = _normalize_treat_column(data, treat)
 
     if outcome:
         data_pivot = _prepare_panelview_df_for_outcome_plot(
@@ -165,6 +173,17 @@ def panelview(
             noticks=noticks,
             title=title,
         )
+
+
+def _normalize_treat_column(data: pd.DataFrame, treat: str) -> pd.DataFrame:
+    """Normalize the treatment column to boolean dtype.
+
+    Accepts boolean or binary integer (0/1) columns. Mutates a copy of the
+    dataframe to avoid modifying the user's data.
+    """
+    data = data.copy()
+    data[treat] = data[treat].astype(bool)
+    return data
 
 
 def _prepare_panelview_df_for_outcome_plot(

--- a/pyfixest/did/visualize.py
+++ b/pyfixest/did/visualize.py
@@ -337,9 +337,10 @@ def _prepare_df_for_panelview(
     if collapse_to_cohort:
         treatment_quilt = treatment_quilt.drop_duplicates()
     if sort_by_timing:
-        treatment_quilt = treatment_quilt.loc[
-            treatment_quilt.sum(axis=1).sort_values().index
-        ]
+        first_treated = treatment_quilt.apply(
+            lambda row: row.argmax() if row.any() else len(row), axis=1
+        )
+        treatment_quilt = treatment_quilt.loc[first_treated.sort_values().index]
 
     return treatment_quilt
 

--- a/pyfixest/did/visualize.py
+++ b/pyfixest/did/visualize.py
@@ -125,7 +125,8 @@ def panelview(
             f"Found values: {unique_vals}"
         )
     # Normalize treat to boolean to handle integer (0/1) columns robustly
-    data = _normalize_treat_column(data, treat)
+    data = data.copy()
+    data[treat] = data[treat].astype(bool)
 
     if outcome:
         data_pivot = _prepare_panelview_df_for_outcome_plot(
@@ -178,17 +179,6 @@ def panelview(
             noticks=noticks,
             title=title,
         )
-
-
-def _normalize_treat_column(data: pd.DataFrame, treat: str) -> pd.DataFrame:
-    """Normalize the treatment column to boolean dtype.
-
-    Accepts boolean or binary integer (0/1) columns. Mutates a copy of the
-    dataframe to avoid modifying the user's data.
-    """
-    data = data.copy()
-    data[treat] = data[treat].astype(bool)
-    return data
 
 
 def _prepare_panelview_df_for_outcome_plot(

--- a/pyfixest/did/visualize.py
+++ b/pyfixest/did/visualize.py
@@ -113,7 +113,12 @@ def panelview(
         raise ValueError(
             "Cannot use 'collapse_to_cohort' together with 'subsamp' or 'units_to_plot'."
         )
-    unique_vals = set(data[treat].dropna().unique())
+    if data[treat].isna().any():
+        raise ValueError(
+            f"Column '{treat}' contains missing values. "
+            "Please drop them before calling panelview."
+        )
+    unique_vals = set(data[treat].unique())
     if not unique_vals.issubset({0, 1}):
         raise ValueError(
             f"Column '{treat}' must be binary (bool or 0/1 integer). "
@@ -356,9 +361,10 @@ def _plot_panelview(
     title: str | None = None,
 ) -> plt.Axes:
     if not ax:
-        f, ax = plt.subplots(figsize=figsize)
+        _, ax = plt.subplots(figsize=figsize)
     cax = ax.matshow(treatment_quilt, cmap="viridis", aspect="auto")
-    f.colorbar(cax) if legend else None
+    if legend:
+        ax.figure.colorbar(cax, ax=ax)
     ax.set_xlabel(xlab) if xlab else None
     ax.set_ylabel(ylab) if ylab else None
 

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -233,17 +233,17 @@ def test_panelview_raises():
     )
 
     # Missing unit/time/treat column
-    with pytest.raises(ValueError, match="Column 'bad_col' not found in data."):
+    with pytest.raises(ValueError, match=r"Column 'bad_col' not found in data."):
         panelview(data, unit="bad_col", time="time", treat="treat")
 
     # Missing outcome column
     with pytest.raises(
-        ValueError, match="Outcome column 'bad_outcome' not found in data."
+        ValueError, match=r"Outcome column 'bad_outcome' not found in data."
     ):
         panelview(data, unit="unit", time="time", treat="treat", outcome="bad_outcome")
 
     # collapse_to_cohort with subsamp
-    with pytest.raises(ValueError, match="Cannot use 'collapse_to_cohort'"):
+    with pytest.raises(ValueError, match=r"Cannot use 'collapse_to_cohort'"):
         panelview(
             data,
             unit="unit",

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -220,3 +220,150 @@ def test_panelview():
     )
     assert isinstance(ax, plt.Axes)
     plt.close()
+
+
+def test_panelview_raises():
+    data = pd.DataFrame(
+        {
+            "unit": [1, 1, 2, 2],
+            "time": [1, 2, 1, 2],
+            "y": [1.0, 1.5, 2.0, 3.0],
+            "treat": [0, 0, 0, 1],
+        }
+    )
+
+    # Missing unit/time/treat column
+    with pytest.raises(ValueError, match="Column 'bad_col' not found in data."):
+        panelview(data, unit="bad_col", time="time", treat="treat")
+
+    # Missing outcome column
+    with pytest.raises(
+        ValueError, match="Outcome column 'bad_outcome' not found in data."
+    ):
+        panelview(data, unit="unit", time="time", treat="treat", outcome="bad_outcome")
+
+    # collapse_to_cohort with subsamp
+    with pytest.raises(ValueError, match="Cannot use 'collapse_to_cohort'"):
+        panelview(
+            data,
+            unit="unit",
+            time="time",
+            treat="treat",
+            collapse_to_cohort=True,
+            subsamp=2,
+        )
+
+    # collapse_to_cohort with units_to_plot
+    with pytest.raises(ValueError, match="Cannot use 'collapse_to_cohort'"):
+        panelview(
+            data,
+            unit="unit",
+            time="time",
+            treat="treat",
+            collapse_to_cohort=True,
+            units_to_plot=[1],
+        )
+
+
+def test_panelview_treat_normalization():
+    """Test that treat column is normalized correctly (bug #1311)."""
+    data = pd.DataFrame(
+        {
+            "unit": [1, 1, 2, 2, 3, 3],
+            "time": [1, 2, 1, 2, 1, 2],
+            "y": [1.0, 1.5, 2.0, 3.0, 1.8, 1.9],
+            "treat_int": [0, 0, 0, 1, 0, 0],
+            "treat_bool": [False, False, False, True, False, False],
+        }
+    )
+
+    # Integer treat should not raise
+    ax = panelview(data, unit="unit", time="time", treat="treat_int")
+    assert isinstance(ax, plt.Axes)
+    plt.close()
+
+    # Integer treat with collapse_to_cohort should not raise
+    ax = panelview(
+        data,
+        outcome="y",
+        unit="unit",
+        time="time",
+        treat="treat_int",
+        collapse_to_cohort=True,
+    )
+    assert isinstance(ax, plt.Axes)
+    plt.close()
+
+    # Integer and bool treat should produce the same number of lines
+    ax_int = panelview(
+        data,
+        outcome="y",
+        unit="unit",
+        time="time",
+        treat="treat_int",
+        collapse_to_cohort=True,
+    )
+    ax_bool = panelview(
+        data,
+        outcome="y",
+        unit="unit",
+        time="time",
+        treat="treat_bool",
+        collapse_to_cohort=True,
+    )
+    assert len(ax_int.lines) == len(ax_bool.lines)
+    plt.close("all")
+
+    # Never-treated column (all zeros) should not raise
+    data["treat_never"] = 0
+    ax = panelview(data, unit="unit", time="time", treat="treat_never")
+    assert isinstance(ax, plt.Axes)
+    plt.close()
+
+    # Always-treated column (all ones) should not raise
+    data["treat_always"] = 1
+    ax = panelview(data, unit="unit", time="time", treat="treat_always")
+    assert isinstance(ax, plt.Axes)
+    plt.close()
+
+    # Non-binary treat should raise a clear ValueError
+    data["treat_invalid"] = [0, 1, 2, 0, 1, 2]
+    with pytest.raises(ValueError, match="binary"):
+        panelview(data, unit="unit", time="time", treat="treat_invalid")
+
+    # Original data should not be mutated
+    original_dtype = data["treat_int"].dtype
+    panelview(data, unit="unit", time="time", treat="treat_int")
+    assert data["treat_int"].dtype == original_dtype
+
+
+def test_panelview_output_plot_params():
+    df_het = pd.read_csv("pyfixest/did/data/df_het.csv")
+
+    # xlim and ylim
+    ax = panelview(
+        df_het,
+        outcome="dep_var",
+        unit="unit",
+        time="year",
+        treat="treat",
+        subsamp=50,
+        xlim=(2000, 2010),
+        ylim=(-5, 5),
+    )
+    assert ax.get_xlim() == (2000, 2010)
+    assert ax.get_ylim() == (-5, 5)
+    plt.close()
+
+    # legend
+    ax = panelview(
+        df_het,
+        outcome="dep_var",
+        unit="unit",
+        time="year",
+        treat="treat",
+        subsamp=50,
+        legend=True,
+    )
+    assert ax.get_legend() is not None
+    plt.close()

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -1,4 +1,5 @@
 import matplotlib.pyplot as plt
+import numpy as np
 import pandas as pd
 import pytest
 
@@ -367,3 +368,33 @@ def test_panelview_output_plot_params():
     )
     assert ax.get_legend() is not None
     plt.close()
+
+
+def test_panelview_user_ax_with_legend():
+    """Legend on user-supplied ax should not raise (was UnboundLocalError on `f`)."""
+    data = pd.DataFrame(
+        {
+            "unit": [1, 1, 2, 2],
+            "time": [1, 2, 1, 2],
+            "treat": [0, 1, 0, 0],
+        }
+    )
+    _, user_ax = plt.subplots()
+    ax = panelview(
+        data, unit="unit", time="time", treat="treat", ax=user_ax, legend=True
+    )
+    assert ax is user_ax
+    plt.close("all")
+
+
+def test_panelview_treat_nan_raises():
+    """NaN in treat must raise instead of being silently coerced to True."""
+    data = pd.DataFrame(
+        {
+            "unit": [1, 1, 2, 2],
+            "time": [1, 2, 1, 2],
+            "treat": [0, 1, 0, np.nan],
+        }
+    )
+    with pytest.raises(ValueError, match="missing values"):
+        panelview(data, unit="unit", time="time", treat="treat")


### PR DESCRIPTION
### Fixed
- `panelview`: integer (0/1) treatment columns now work correctly with 
  `collapse_to_cohort=True` and outcome plots (#1311). A clear `ValueError` 
  is raised for non-binary treatment values.
- `panelview`: `sort_by_timing` now sorts by first treatment period (not 
  total treated periods).