### PR TITLE
[codex] Document Feols result attributes

### DIFF
--- a/docs/getting-started.qmd
+++ b/docs/getting-started.qmd
@@ -77,6 +77,10 @@ pf.etable(
 
 We see that the estimated return to education is smaller once we include twin fixed effects, consistent with an upward bias in naive OLS of education on earnings from unobserved ability differences across individuals.
 
+`pf.feols()` returns a [Feols](/reference/estimation.models.feols_.Feols.qmd)
+result object. The `Feols` reference lists available methods and attributes,
+including model-level statistics such as adjusted R-squared (`._adj_r2`).
+
 Now, what if we had the unobserved confounder at hand? In this case, we could simply control for it in our regression model. In real life, we likely wouldn't be so lucky to have it, but alas, here we have access to it as we are working with synthetic data:
 ```{python}
 fit_latent = pf.feols(

--- a/docs/quickstart.qmd
+++ b/docs/quickstart.qmd
@@ -83,7 +83,9 @@ type(fit)
 
 The first part of the formula contains the dependent variable and "regular" covariates, while the second part contains fixed effects.
 
-`feols()` returns an instance of the `Fixest` class.
+`feols()` returns an instance of the [Feols](/reference/estimation.models.feols_.Feols.qmd)
+class. The `Feols` reference lists available methods and attributes, including
+model-level statistics such as adjusted R-squared (`._adj_r2`).
 
 ## Inspecting Model Results
 

--- a/pyfixest/estimation/api/feols.py
+++ b/pyfixest/estimation/api/feols.py
@@ -56,6 +56,8 @@ def feols(
 
     Returns an object of type [Feols](/reference/estimation.models.feols_.Feols.qmd) or
     [Feiv](/reference/estimation.models.feiv_.Feiv.qmd) (when using instrumental variables).
+    The Feols reference documents the available result methods and attributes, including
+    model-level statistics such as adjusted R-squared (``._adj_r2``).
 
     Parameters
     ----------


### PR DESCRIPTION
## Summary

- update the getting-started and quickstart docs to point `pf.feols()` users to the `Feols` reference
- correct the old quickstart wording from `Fixest` to `Feols`
- mention that model-level statistics such as `._adj_r2` are documented in the `Feols` attributes

Closes #959

## Validation

- `python3 -m py_compile pyfixest/estimation/api/feols.py`
- `git diff --check`

Docs/lint tasks were attempted but did not complete in this local environment:

- `pixi run docs-build` failed while building the local editable package; `rustc -vV` was killed with SIGKILL before docs generation.
- `pixi run -e lint lint` failed while initializing the `pre-commit/mirrors-mypy` hook; `git-submodule` was killed with signal 9 before hooks ran.
