### PR TITLE
remove deprecated demeaner_backend, fixef_tol, fixef_maxiter args

### DIFF
--- a/benchmarks/modular/feols_benchmarkers.py
+++ b/benchmarks/modular/feols_benchmarkers.py
@@ -172,6 +172,26 @@ def _normalize_vcov(vcov: str | dict[str, str]) -> str:
     return vcov
 
 
+def _demeaner_from_backend(backend: str, fixef_maxiter: int | None = None):
+    """Map a benchmark backend name to a typed demeaner configuration."""
+    import pyfixest as pf
+
+    kwargs = {} if fixef_maxiter is None else {"fixef_maxiter": fixef_maxiter}
+    if backend == "rust":
+        return pf.MapDemeaner(**kwargs)
+    if backend == "within":
+        return pf.LsmrDemeaner(**kwargs)
+    if backend == "torch_cpu":
+        return pf.LsmrDemeaner(backend="torch", device="cpu", **kwargs)
+    if backend == "torch_mps":
+        return pf.LsmrDemeaner(
+            backend="torch", device="mps", precision="float32", **kwargs
+        )
+    if backend == "torch_cuda":
+        return pf.LsmrDemeaner(backend="torch", device="cuda", **kwargs)
+    raise ValueError(f"Unknown demeaner backend: {backend!r}")
+
+
 class PyFeolsBenchmarkerFullApi:
     """Benchmark pf.feols() end-to-end using one configured demeaner backend."""
 
@@ -188,6 +208,11 @@ class PyFeolsBenchmarkerFullApi:
         self, datasets: list[BenchmarkDataset], spec: FeolsSpec
     ) -> list[FeolsResult]:
         import pyfixest as pf
+
+        feols_kwargs = dict(self._feols_kwargs)
+        demeaner = _demeaner_from_backend(
+            self._demeaner_backend, feols_kwargs.pop("fixef_maxiter", None)
+        )
 
         results: list[FeolsResult] = []
 
@@ -223,8 +248,8 @@ class PyFeolsBenchmarkerFullApi:
                         vcov=spec.vcov,
                         copy_data=False,
                         store_data=False,
-                        demeaner_backend=self._demeaner_backend,
-                        **self._feols_kwargs,
+                        demeaner=demeaner,
+                        **feols_kwargs,
                     )
                 elapsed = time.perf_counter() - t0
 

--- a/pyfixest/estimation/api/feglm.py
+++ b/pyfixest/estimation/api/feglm.py
@@ -38,9 +38,6 @@ def feglm(
     separation_check: list[str] | None = None,
     solver: SolverOptions = "scipy.linalg.solve",
     demeaner: AnyDemeaner | None = None,
-    demeaner_backend: str | None = None,
-    fixef_tol: float | None = None,
-    fixef_maxiter: int | None = None,
     drop_intercept: bool = False,
     copy_data: bool = True,
     store_data: bool = True,
@@ -271,12 +268,7 @@ def feglm(
     weights_type = "aweights"
 
     context = {} if context is None else capture_context(context)
-    demeaner = _resolve_demeaner(
-        demeaner=demeaner,
-        demeaner_backend=demeaner_backend,
-        fixef_tol=fixef_tol,
-        fixef_maxiter=fixef_maxiter,
-    )
+    demeaner = _resolve_demeaner(demeaner)
     _warn_if_experimental_torch_demeaner(demeaner)
     _warn_if_deprecated_demeaner_backend(demeaner)
     _warn_if_deprecated_solver(solver)

--- a/pyfixest/estimation/api/feols.py
+++ b/pyfixest/estimation/api/feols.py
@@ -41,9 +41,6 @@ def feols(
     weights_type: WeightsTypeOptions = "aweights",
     solver: SolverOptions = "scipy.linalg.solve",
     demeaner: AnyDemeaner | None = None,
-    demeaner_backend: str | None = None,
-    fixef_tol: float | None = None,
-    fixef_maxiter: int | None = None,
     use_compression: bool = False,
     reps: int = 100,
     context: int | Mapping[str, Any] | None = None,
@@ -509,12 +506,7 @@ def feols(
     if ssc is None:
         ssc = ssc_func()
     context = {} if context is None else capture_context(context)
-    demeaner = _resolve_demeaner(
-        demeaner=demeaner,
-        demeaner_backend=demeaner_backend,
-        fixef_tol=fixef_tol,
-        fixef_maxiter=fixef_maxiter,
-    )
+    demeaner = _resolve_demeaner(demeaner)
     _warn_if_experimental_torch_demeaner(demeaner)
     _warn_if_deprecated_demeaner_backend(demeaner)
     _warn_if_deprecated_solver(solver)

--- a/pyfixest/estimation/api/fepois.py
+++ b/pyfixest/estimation/api/fepois.py
@@ -41,9 +41,6 @@ def fepois(
     separation_check: list[str] | None = None,
     solver: SolverOptions = "scipy.linalg.solve",
     demeaner: AnyDemeaner | None = None,
-    demeaner_backend: str | None = None,
-    fixef_tol: float | None = None,
-    fixef_maxiter: int | None = None,
     drop_intercept: bool = False,
     copy_data: bool = True,
     store_data: bool = True,
@@ -260,12 +257,7 @@ def fepois(
     if ssc is None:
         ssc = ssc_func()
     context = {} if context is None else capture_context(context)
-    demeaner = _resolve_demeaner(
-        demeaner=demeaner,
-        demeaner_backend=demeaner_backend,
-        fixef_tol=fixef_tol,
-        fixef_maxiter=fixef_maxiter,
-    )
+    demeaner = _resolve_demeaner(demeaner)
     _warn_if_experimental_torch_demeaner(demeaner)
     _warn_if_deprecated_demeaner_backend(demeaner)
     _warn_if_deprecated_solver(solver)

--- a/pyfixest/estimation/internals/demeaner_options.py
+++ b/pyfixest/estimation/internals/demeaner_options.py
@@ -1,105 +1,17 @@
 from __future__ import annotations
 
 import warnings
-from typing import cast
 
 from pyfixest.demeaners import (
     AnyDemeaner,
-    LsmrBackend,
     LsmrDemeaner,
-    LsmrPrecision,
-    MapBackend,
     MapDemeaner,
-    TorchDevice,
 )
 
-# Legacy string backend → (LsmrBackend, TorchDevice, LsmrPrecision)
-_LSMR_PRESETS: dict[str, tuple[LsmrBackend, TorchDevice, LsmrPrecision]] = {
-    "within": ("within", "auto", "float64"),
-    # Pre-0.60 alias: the within backend used to be named "rust-cg" when it
-    # was still wrapping a CG/Schwarz solver. Keep it as a silent alias of
-    # "within" for one more release cycle; the surrounding `demeaner_backend=`
-    # argument already raises a DeprecationWarning.
-    "rust-cg": ("within", "auto", "float64"),
-    "cupy": ("cupy", "auto", "float64"),
-    "cupy64": ("cupy", "auto", "float64"),
-    "cupy32": ("cupy", "auto", "float32"),
-    "scipy": ("cupy", "cpu", "float64"),
-    "torch": ("torch", "auto", "float64"),
-    "torch_cpu": ("torch", "cpu", "float64"),
-    "torch_mps": ("torch", "mps", "float32"),
-    "torch_cuda": ("torch", "cuda", "float64"),
-    "torch_cuda32": ("torch", "cuda", "float32"),
-}
 
-
-def _resolve_demeaner(
-    *,
-    demeaner: AnyDemeaner | None,
-    demeaner_backend: str | None = None,
-    fixef_tol: float | None = None,
-    fixef_maxiter: int | None = None,
-) -> AnyDemeaner:
-    legacy_args_used = any(
-        arg is not None for arg in (demeaner_backend, fixef_tol, fixef_maxiter)
-    )
-
-    if demeaner is not None:
-        if legacy_args_used:
-            raise ValueError(
-                "Pass either `demeaner` or the deprecated legacy arguments "
-                "`demeaner_backend`, `fixef_tol`, and `fixef_maxiter`, not both."
-            )
-        return demeaner
-
-    if not legacy_args_used:
-        return MapDemeaner()
-
-    if fixef_tol is not None:
-        if isinstance(fixef_tol, bool) or not isinstance(fixef_tol, float):
-            raise TypeError("fixef_tol must be a float")
-        if fixef_tol <= 0 or fixef_tol >= 1:
-            raise ValueError("fixef_tol must be greater than zero and less than one")
-
-    if fixef_maxiter is not None:
-        if isinstance(fixef_maxiter, bool) or not isinstance(fixef_maxiter, int):
-            raise TypeError("fixef_maxiter must be an int")
-        if fixef_maxiter <= 0:
-            raise ValueError("fixef_maxiter must be greater than zero")
-
-    warnings.warn(
-        (
-            "The `demeaner_backend`, `fixef_tol`, and `fixef_maxiter` arguments "
-            "are deprecated and will be removed in a future release. "
-            "Pass a typed `demeaner=` configuration instead."
-        ),
-        DeprecationWarning,
-        stacklevel=3,
-    )
-
-    backend = "rust" if demeaner_backend is None else demeaner_backend
-    effective_fixef_tol = 1e-06 if fixef_tol is None else fixef_tol
-    effective_fixef_maxiter = 10_000 if fixef_maxiter is None else fixef_maxiter
-
-    if backend in {"numba", "rust", "jax"}:
-        return MapDemeaner(
-            backend=cast(MapBackend, backend),
-            fixef_tol=effective_fixef_tol,
-            fixef_maxiter=effective_fixef_maxiter,
-        )
-
-    if backend in _LSMR_PRESETS:
-        lsmr_backend, device, precision = _LSMR_PRESETS[backend]
-        return LsmrDemeaner(
-            backend=lsmr_backend,
-            device=device,
-            precision=precision,
-            fixef_atol=effective_fixef_tol,
-            fixef_btol=effective_fixef_tol,
-            fixef_maxiter=effective_fixef_maxiter,
-        )
-
-    raise ValueError(f"Invalid demeaner backend: {backend}")
+def _resolve_demeaner(demeaner: AnyDemeaner | None) -> AnyDemeaner:
+    """Return the typed demeaner configuration, defaulting to MapDemeaner."""
+    return demeaner if demeaner is not None else MapDemeaner()
 
 
 def _warn_if_experimental_torch_demeaner(demeaner: object) -> None:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -35,7 +35,7 @@ def test_feols_args():
     Arguments to check:
     - copy_data
     - store_data
-    - fixef_tol
+    - demeaner
     - solver
     """
     df = pf.get_data()
@@ -45,7 +45,12 @@ def test_feols_args():
 
     assert (fit1.coef() == fit2.coef()).all()
 
-    fit3 = pf.feols(fml="Y ~ X1 | f1 + f2", data=df, store_data=False, fixef_tol=1e-02)
+    fit3 = pf.feols(
+        fml="Y ~ X1 | f1 + f2",
+        data=df,
+        store_data=False,
+        demeaner=pf.MapDemeaner(fixef_tol=1e-02),
+    )
     if hasattr(fit3, "_data"):
         raise AttributeError(
             "The 'fit3' object has the attribute '_data', which should not be present."
@@ -67,7 +72,7 @@ def test_fepois_args():
     Arguments to check:
     - copy_data
     - store_data
-    - fixef_tol
+    - demeaner
     - solver
     """
     df = pf.get_data(model="Fepois")
@@ -77,7 +82,12 @@ def test_fepois_args():
 
     assert (fit1.coef() == fit2.coef()).all()
 
-    fit3 = pf.fepois(fml="Y ~ X1 | f1 + f2", data=df, store_data=False, fixef_tol=1e-02)
+    fit3 = pf.fepois(
+        fml="Y ~ X1 | f1 + f2",
+        data=df,
+        store_data=False,
+        demeaner=pf.MapDemeaner(fixef_tol=1e-02),
+    )
     if hasattr(fit3, "_data"):
         raise AttributeError(
             "The 'fit3' object has the attribute '_data', which should not be present."
@@ -92,44 +102,6 @@ def test_fepois_args():
     np.testing.assert_allclose(fit4.coef(), fit5.coef(), rtol=1e-12)
 
 
-def test_legacy_demeaner_backend_within_chains_to_lsmr_warning():
-    data = pf.get_data()
-
-    with pytest.warns(DeprecationWarning):
-        fit = pf.feols(
-            "Y ~ X1 | f1 + f2",
-            data=data,
-            demeaner_backend="within",
-            fixef_tol=1e-4,
-            fixef_maxiter=321,
-        )
-
-    assert isinstance(fit._demeaner, pf.LsmrDemeaner)
-    assert fit._demeaner.backend == "within"
-    assert fit._demeaner.fixef_atol == 1e-4
-    assert fit._demeaner.fixef_btol == 1e-4
-    assert fit._demeaner.fixef_maxiter == 321
-
-
-def test_legacy_demeaner_backend_rust_cg_aliases_to_within():
-    data = pf.get_data()
-
-    with pytest.warns(DeprecationWarning):
-        fit = pf.feols(
-            "Y ~ X1 | f1 + f2",
-            data=data,
-            demeaner_backend="rust-cg",
-            fixef_tol=1e-4,
-            fixef_maxiter=321,
-        )
-
-    assert isinstance(fit._demeaner, pf.LsmrDemeaner)
-    assert fit._demeaner.backend == "within"
-    assert fit._demeaner.fixef_atol == 1e-4
-    assert fit._demeaner.fixef_btol == 1e-4
-    assert fit._demeaner.fixef_maxiter == 321
-
-
 def test_map_demeaner_defaults_to_rust():
     data = pf.get_data()
 
@@ -139,18 +111,6 @@ def test_map_demeaner_defaults_to_rust():
 
     assert isinstance(fit._demeaner, pf.MapDemeaner)
     assert fit._demeaner.backend == "rust"
-
-
-def test_legacy_demeaner_args_conflict_with_typed_demeaner():
-    data = pf.get_data()
-
-    with pytest.raises(ValueError, match="Pass either `demeaner`"):
-        pf.feols(
-            "Y ~ X1 | f1 + f2",
-            data=data,
-            demeaner=pf.MapDemeaner(),
-            fixef_tol=1e-4,
-        )
 
 
 def _run_with_deprecated_kwargs(estimator_name, **kwargs):
@@ -218,47 +178,6 @@ def test_demeaner_backend_scipy_emits_deprecation_warning():
             pf.LsmrDemeaner(backend="cupy", device="cpu")
         )
     assert any("default within backend" in str(r.message) for r in rec)
-
-
-@pytest.mark.parametrize("estimator_name", _DEPRECATION_ESTIMATORS)
-def test_legacy_demeaner_backend_jax_emits_both_deprecation_warnings(estimator_name):
-    with pytest.warns(DeprecationWarning) as records:
-        _run_with_deprecated_kwargs(estimator_name, demeaner_backend="jax")
-
-    messages = [str(r.message) for r in records]
-    assert any("demeaner_backend" in m for m in messages)
-    assert any("`jax` MAP demeaner backend" in m for m in messages)
-
-
-@pytest.mark.parametrize("legacy_backend", ["cupy", "scipy"])
-def test_legacy_demeaner_backend_cupy_preset_chains_to_cupy_warning(legacy_backend):
-    from pyfixest.estimation.internals.demeaner_options import _resolve_demeaner
-
-    with pytest.warns(DeprecationWarning) as records:
-        resolved = _resolve_demeaner(demeaner=None, demeaner_backend=legacy_backend)
-
-    assert isinstance(resolved, pf.LsmrDemeaner)
-    assert resolved.backend == "cupy"
-    messages = [str(r.message) for r in records]
-    assert any("demeaner_backend" in m for m in messages)
-
-
-@pytest.mark.parametrize("estimator_name", _DEPRECATION_ESTIMATORS)
-@pytest.mark.parametrize(
-    "legacy_backend, expected_label, expected_replacement",
-    [
-        ("cupy", "`cupy` LSMR demeaner backend", "torch', device='cuda"),
-        ("scipy", "`scipy` LSMR demeaner backend", "default within backend"),
-    ],
-)
-def test_legacy_demeaner_backend_cupy_preset_replacement_message(
-    estimator_name, legacy_backend, expected_label, expected_replacement
-):
-    with pytest.warns(DeprecationWarning) as records:
-        _run_with_deprecated_kwargs(estimator_name, demeaner_backend=legacy_backend)
-    messages = [str(r.message) for r in records]
-    assert any(expected_label in m for m in messages)
-    assert any(expected_replacement in m for m in messages)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -166,15 +166,6 @@ def test_feols_errors():
     with pytest.raises(TypeError):
         pf.feols(fml="Y ~ X1", data=data, lean=1)
 
-    with pytest.raises(TypeError):
-        pf.feols(fml="Y ~ X1", data=data, fixef_tol="a")
-
-    with pytest.raises(ValueError):
-        pf.feols(fml="Y ~ X1", data=data, fixef_tol=1.0)
-
-    with pytest.raises(ValueError):
-        pf.feols(fml="Y ~ X1", data=data, fixef_tol=0.0)
-
     with pytest.raises(ValueError):
         pf.feols(fml="Y ~ X1", data=data, weights_type="qweights", weights="weights")
 


### PR DESCRIPTION
Some announced deprecations of `demeaner_backend`, `fixef_tol`, `fixef_maxiter` args to `feols`, `fepois`.