### PR TITLE
Fold Fepois under Feglm; unify IRLS kernel

### DIFF
--- a/pyfixest/estimation/FixestMulti_.py
+++ b/pyfixest/estimation/FixestMulti_.py
@@ -18,6 +18,7 @@ from pyfixest.estimation.internals.literals import (
 )
 from pyfixest.estimation.internals.vcov_utils import _get_vcov_type
 from pyfixest.estimation.models.fegaussian_ import Fegaussian
+from pyfixest.estimation.models.feglm_ import Feglm
 from pyfixest.estimation.models.feiv_ import Feiv
 from pyfixest.estimation.models.felogit_ import Felogit
 from pyfixest.estimation.models.feols_ import (
@@ -425,7 +426,7 @@ class FixestMulti:
                     FIT = ModelClass(**model_kwargs)
 
                     FIT.prepare_model_matrix()
-                    if isinstance(FIT, (Felogit, Feprobit, Fegaussian)):
+                    if isinstance(FIT, Feglm):
                         FIT._check_dependent_variable()
                     FIT.get_fit()
                     # if X is empty: no inference (empty X only as shorthand for demeaning)

--- a/pyfixest/estimation/internals/families.py
+++ b/pyfixest/estimation/internals/families.py
@@ -81,12 +81,6 @@ def _gaussian_deviance(
 
 
 def _pois_deviance(y: np.ndarray, mu: np.ndarray, weights: np.ndarray | None) -> float:
-    return pois_deviance_weighted(y, mu, weights)
-
-
-def pois_deviance_weighted(
-    y: np.ndarray, mu: np.ndarray, weights: np.ndarray | None
-) -> float:
     "Poisson deviance, optionally weighted. Defined as 2·(LL_saturated - LL_fitted)."
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")

--- a/pyfixest/estimation/internals/families.py
+++ b/pyfixest/estimation/internals/families.py
@@ -21,7 +21,7 @@ class GlmFamily:
     inv_link: Callable[[np.ndarray], np.ndarray]
     gprime: Callable[[np.ndarray], np.ndarray]
     variance: Callable[[np.ndarray], np.ndarray]
-    deviance: Callable[[np.ndarray, np.ndarray], float]
+    deviance: Callable[[np.ndarray, np.ndarray, np.ndarray | None], float]
     mu_start: Callable[[np.ndarray], np.ndarray]
     check_y: Callable[[np.ndarray], None]
 
@@ -43,31 +43,45 @@ def _mu_start_binary(Y: np.ndarray) -> np.ndarray:
 
 
 def _mu_start_mean(Y: np.ndarray) -> np.ndarray:
-    return np.full_like(Y.flatten(), float(np.mean(Y)), dtype=float)
+    return np.full_like(Y.flatten(), np.mean(Y), dtype=float)
 
 
-def _logit_deviance(y: np.ndarray, mu: np.ndarray) -> float:
-    return float(-2 * np.sum(y * np.log(mu) + (1 - y) * np.log(1 - mu)))
+def _flatten_weights(weights: np.ndarray | None) -> np.ndarray | float:
+    return weights.flatten() if weights is not None else 1.0
 
 
-def _probit_deviance(y: np.ndarray, mu: np.ndarray) -> float:
-    ll_fitted = np.sum(y * np.log(mu) + (1 - y) * np.log(1 - mu))
+def _logit_deviance(y: np.ndarray, mu: np.ndarray, weights: np.ndarray | None) -> float:
+    w = _flatten_weights(weights)
+    return float(-2 * np.sum(w * (y * np.log(mu) + (1 - y) * np.log(1 - mu))))
+
+
+def _probit_deviance(
+    y: np.ndarray, mu: np.ndarray, weights: np.ndarray | None
+) -> float:
+    w = _flatten_weights(weights)
+    ll_fitted = np.sum(w * (y * np.log(mu) + (1 - y) * np.log(1 - mu)))
     # divide by zero warnings because of the log(0) terms
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
         ll_saturated = np.sum(
-            np.where(y == 0, 0, y * np.log(y))
-            + np.where(y == 1, 0, (1 - y) * np.log(1 - y))
+            w
+            * (
+                np.where(y == 0, 0, y * np.log(y))
+                + np.where(y == 1, 0, (1 - y) * np.log(1 - y))
+            )
         )
     return float(-2.0 * (ll_fitted - ll_saturated))
 
 
-def _gaussian_deviance(y: np.ndarray, mu: np.ndarray) -> float:
-    return float(np.sum((y - mu) ** 2))
+def _gaussian_deviance(
+    y: np.ndarray, mu: np.ndarray, weights: np.ndarray | None
+) -> float:
+    w = _flatten_weights(weights)
+    return float(np.sum(w * (y - mu) ** 2))
 
 
-def _pois_deviance(y: np.ndarray, mu: np.ndarray) -> float:
-    return pois_deviance_weighted(y, mu, None)
+def _pois_deviance(y: np.ndarray, mu: np.ndarray, weights: np.ndarray | None) -> float:
+    return pois_deviance_weighted(y, mu, weights)
 
 
 def pois_deviance_weighted(
@@ -76,10 +90,7 @@ def pois_deviance_weighted(
     "Poisson deviance, optionally weighted. Defined as 2·(LL_saturated - LL_fitted)."
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
-        if weights is None:
-            w: np.ndarray | float = 1.0
-        else:
-            w = weights.flatten()
+        w = _flatten_weights(weights)
         y_flat = y.flatten()
         mu_flat = mu.flatten()
         return float(
@@ -100,8 +111,8 @@ def _check_y_nonneg(Y: np.ndarray) -> None:
 
 
 def _mu_start_pois(Y: np.ndarray) -> np.ndarray:
-    y_flat = Y.flatten()
-    return ((y_flat + float(np.mean(y_flat))) / 2).astype(float)
+    y = Y.flatten().astype(float)
+    return (y + y.mean()) / 2
 
 
 LOGIT = GlmFamily(

--- a/pyfixest/estimation/internals/families.py
+++ b/pyfixest/estimation/internals/families.py
@@ -66,6 +66,44 @@ def _gaussian_deviance(y: np.ndarray, mu: np.ndarray) -> float:
     return float(np.sum((y - mu) ** 2))
 
 
+def _pois_deviance(y: np.ndarray, mu: np.ndarray) -> float:
+    return pois_deviance_weighted(y, mu, None)
+
+
+def pois_deviance_weighted(
+    y: np.ndarray, mu: np.ndarray, weights: np.ndarray | None
+) -> float:
+    "Poisson deviance, optionally weighted. Defined as 2·(LL_saturated - LL_fitted)."
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        if weights is None:
+            w: np.ndarray | float = 1.0
+        else:
+            w = weights.flatten()
+        y_flat = y.flatten()
+        mu_flat = mu.flatten()
+        return float(
+            2
+            * np.sum(
+                w
+                * (
+                    np.where(y_flat == 0, 0, y_flat * np.log(y_flat / mu_flat))
+                    - (y_flat - mu_flat)
+                )
+            )
+        )
+
+
+def _check_y_nonneg(Y: np.ndarray) -> None:
+    if np.any(Y < 0):
+        raise ValueError("The dependent variable must be weakly positive.")
+
+
+def _mu_start_pois(Y: np.ndarray) -> np.ndarray:
+    y_flat = Y.flatten()
+    return ((y_flat + float(np.mean(y_flat))) / 2).astype(float)
+
+
 LOGIT = GlmFamily(
     name="logit",
     link=lambda mu: np.log(mu / (1 - mu)),
@@ -97,4 +135,15 @@ GAUSSIAN = GlmFamily(
     deviance=_gaussian_deviance,
     mu_start=_mu_start_mean,
     check_y=_check_y_noop,
+)
+
+POISSON = GlmFamily(
+    name="poisson",
+    link=np.log,
+    inv_link=np.exp,
+    gprime=lambda mu: 1 / mu,
+    variance=lambda mu: mu,
+    deviance=_pois_deviance,
+    mu_start=_mu_start_pois,
+    check_y=_check_y_nonneg,
 )

--- a/pyfixest/estimation/internals/fit_glm_.py
+++ b/pyfixest/estimation/internals/fit_glm_.py
@@ -77,21 +77,20 @@ def _rel_dev_change(deviance: float, deviance_old: float) -> float:
 def _check_convergence(
     rel_dev_change: float,
     tol: float,
-    r: int,
-    maxiter: int,
     is_gaussian: bool,
 ) -> bool:
     if is_gaussian:
         return True
-    converged = rel_dev_change < tol
-    if r == maxiter:
-        raise NonConvergenceError(
-            f"""
-            The IRLS algorithm did not converge with {maxiter}
-            iterations. Try to increase the maximum number of iterations.
-            """
-        )
-    return converged
+    return rel_dev_change < tol
+
+
+def _raise_non_convergence(maxiter: int) -> None:
+    raise NonConvergenceError(
+        f"""
+        The IRLS algorithm did not converge with {maxiter}
+        iterations. Try to increase the maximum number of iterations.
+        """
+    )
 
 
 def _step_halving(
@@ -216,8 +215,6 @@ def fit_glm_irls(
                 converged = _check_convergence(
                     rel_dev_change=rel_dev_change,
                     tol=tol,
-                    r=r,
-                    maxiter=maxiter,
                     is_gaussian=family.name == "gaussian",
                 )
                 if converged:
@@ -290,6 +287,17 @@ def fit_glm_irls(
         X_tilde_final = X_tilde
         W_final = W
         sqrt_W_final = sqrt_W
+
+    if not converged:
+        if not step_halved_prev:
+            rel_dev_change = _rel_dev_change(deviance, deviance_old)
+            converged = _check_convergence(
+                rel_dev_change=rel_dev_change,
+                tol=tol,
+                is_gaussian=family.name == "gaussian",
+            )
+        if not converged:
+            _raise_non_convergence(maxiter)
 
     return GlmFit(
         beta=beta_final,

--- a/pyfixest/estimation/internals/fit_glm_.py
+++ b/pyfixest/estimation/internals/fit_glm_.py
@@ -134,6 +134,8 @@ def fit_glm_irls(
     coefnames: list[str],
     collin_tol: float,
     accelerate: bool,
+    offset: np.ndarray | None = None,
+    weights: np.ndarray | None = None,
     solver: SolverOptions = "np.linalg.solve",
     maxiter: int = 25,
     tol: float = 1e-8,
@@ -166,9 +168,19 @@ def fit_glm_irls(
     accelerate : bool
         Enable ppmlhdfe-style warm-start acceleration. Only meaningful when
         ``demean`` is non-trivial (i.e., there are fixed effects).
+    offset : np.ndarray, optional
+        Additive offset on the link scale, shape (N,) or (N, 1). ``None``
+        (default) is equivalent to a zero offset.
+    weights : np.ndarray, optional
+        User-supplied observation weights, shape (N,) or (N, 1). ``None``
+        (default) is equivalent to unit weights.
     solver, maxiter, tol, fixef_tol : see Feglm docs.
     """
     Y_flat = Y.flatten()
+    N = Y_flat.shape[0]
+    offset_flat = offset.flatten() if offset is not None else np.zeros(N)
+    weights_flat = weights.flatten() if weights is not None else np.ones(N)
+
     mu = family.mu_start(Y)
     eta = family.link(mu)
     deviance = family.deviance(Y_flat, mu)
@@ -209,10 +221,10 @@ def fit_glm_irls(
                 inner_tol = inner_tol / 10
 
         gprime = family.gprime(mu)
-        W = 1 / (gprime**2 * family.variance(mu))
+        W = weights_flat / (gprime**2 * family.variance(mu))
         sqrt_W = np.sqrt(W)
 
-        z = eta + (Y_flat - mu) * gprime
+        z = (eta - offset_flat) + (Y_flat - mu) * gprime
 
         if accelerate and r > 0:
             assert z_tilde_prev is not None and z_prev is not None
@@ -238,21 +250,26 @@ def fit_glm_irls(
         beta = solve_ols(WX.T @ WX, WX.T @ WZ, solver)
 
         e_new = z_tilde - X_tilde @ beta
-        eta_new = z - e_new
+        eta_new = (z - e_new) + offset_flat
 
         mu_new = family.inv_link(eta_new)
         deviance_new = family.deviance(Y_flat, mu_new)
 
-        eta_new, mu_new, deviance_new = _step_halving(
-            family=family,
-            y_flat=Y_flat,
-            eta=eta,
-            eta_new=eta_new,
-            mu_new=mu_new,
-            deviance=deviance,
-            deviance_new=deviance_new,
-            tol=tol,
-        )
+        # Skip step-halving on the first iteration: the initial mu is a crude
+        # heuristic (e.g. (Y + mean(Y))/2 for Poisson), and IRLS often overshoots
+        # the initial deviance on the first step before settling. From iter 1
+        # onward, step-halving guards against divergence as expected.
+        if r > 0:
+            eta_new, mu_new, deviance_new = _step_halving(
+                family=family,
+                y_flat=Y_flat,
+                eta=eta,
+                eta_new=eta_new,
+                mu_new=mu_new,
+                deviance=deviance,
+                deviance_new=deviance_new,
+                tol=tol,
+            )
 
         z_prev = z
         z_tilde_prev = z_tilde

--- a/pyfixest/estimation/internals/fit_glm_.py
+++ b/pyfixest/estimation/internals/fit_glm_.py
@@ -167,13 +167,12 @@ def fit_glm_irls(
     collin_tol : float
         Tolerance for the collinearity drop.
     accelerate : bool
-        Enable ppmlhdfe-style warm-start acceleration. Only meaningful when
-        ``demean`` is non-trivial (i.e., there are fixed effects).
+        Enable ppmlhdfe-style warm-start acceleration.
     offset : np.ndarray, optional
-        Additive offset on the link scale, shape (N,) or (N, 1). ``None``
+        Additive offset on the link scale, shape (N,) or (N, 1). `None`
         (default) is equivalent to a zero offset.
     weights : np.ndarray, optional
-        User-supplied observation weights, shape (N,) or (N, 1). ``None``
+        User-supplied regression weights, shape (N,) or (N, 1). `None`
         (default) is equivalent to unit weights.
     solver, maxiter, tol, fixef_tol : see Feglm docs.
     """

--- a/pyfixest/estimation/internals/fit_glm_.py
+++ b/pyfixest/estimation/internals/fit_glm_.py
@@ -103,6 +103,7 @@ def _step_halving(
     deviance: float,
     deviance_new: float,
     tol: float,
+    weights: np.ndarray | None,
     step_halving_tol: float = 1e-12,
 ) -> tuple[np.ndarray, np.ndarray, float]:
     if deviance_new < deviance:
@@ -113,7 +114,7 @@ def _step_halving(
         alpha /= 2.0
         eta_try = eta + alpha * (eta_new - eta)
         mu_try = family.inv_link(eta_try)
-        deviance_try = family.deviance(y_flat, mu_try)
+        deviance_try = family.deviance(y_flat, mu_try, weights)
         if deviance_try < deviance:
             return eta_try, mu_try, deviance_try
 
@@ -183,7 +184,7 @@ def fit_glm_irls(
 
     mu = family.mu_start(Y)
     eta = family.link(mu)
-    deviance = family.deviance(Y_flat, mu)
+    deviance = family.deviance(Y_flat, mu, weights)
     deviance_old = deviance + 1.0
 
     z_prev: np.ndarray | None = None
@@ -253,7 +254,7 @@ def fit_glm_irls(
         eta_new = (z - e_new) + offset_flat
 
         mu_new = family.inv_link(eta_new)
-        deviance_new = family.deviance(Y_flat, mu_new)
+        deviance_new = family.deviance(Y_flat, mu_new, weights)
 
         # Skip step-halving on the first iteration: the initial mu is a crude
         # heuristic (e.g. (Y + mean(Y))/2 for Poisson), and IRLS often overshoots
@@ -269,6 +270,7 @@ def fit_glm_irls(
                 deviance=deviance,
                 deviance_new=deviance_new,
                 tol=tol,
+                weights=weights,
             )
 
         z_prev = z

--- a/pyfixest/estimation/internals/fit_glm_.py
+++ b/pyfixest/estimation/internals/fit_glm_.py
@@ -255,10 +255,6 @@ def fit_glm_irls(
         mu_new = family.inv_link(eta_new)
         deviance_new = family.deviance(Y_flat, mu_new, weights)
 
-        # Skip step-halving on the first iteration: the initial mu is a crude
-        # heuristic (e.g. (Y + mean(Y))/2 for Poisson), and IRLS often overshoots
-        # the initial deviance on the first step before settling. From iter 1
-        # onward, step-halving guards against divergence as expected.
         if r > 0:
             eta_new, mu_new, deviance_new = _step_halving(
                 family=family,

--- a/pyfixest/estimation/internals/fit_glm_.py
+++ b/pyfixest/estimation/internals/fit_glm_.py
@@ -105,9 +105,9 @@ def _step_halving(
     tol: float,
     weights: np.ndarray | None,
     step_halving_tol: float = 1e-12,
-) -> tuple[np.ndarray, np.ndarray, float]:
+) -> tuple[np.ndarray, np.ndarray, float, bool]:
     if deviance_new < deviance:
-        return eta_new, mu_new, deviance_new
+        return eta_new, mu_new, deviance_new, False
 
     alpha = 1.0
     while alpha > step_halving_tol:
@@ -116,10 +116,10 @@ def _step_halving(
         mu_try = family.inv_link(eta_try)
         deviance_try = family.deviance(y_flat, mu_try, weights)
         if deviance_try < deviance:
-            return eta_try, mu_try, deviance_try
+            return eta_try, mu_try, deviance_try, True
 
     if _rel_dev_change(deviance_new, deviance) < tol:
-        return eta_new, mu_new, deviance_new
+        return eta_new, mu_new, deviance_new, False
 
     raise RuntimeError(
         f"Step-halving failed. Deviance: {deviance_new:.6f} vs {deviance:.6f}"
@@ -195,6 +195,7 @@ def fit_glm_irls(
     collin_vars: list[str] = []
     collin_index: list[bool] = []
     converged = False
+    step_halved_prev = False
 
     # Buffers populated each iteration; used after the loop.
     beta_final: np.ndarray
@@ -207,15 +208,20 @@ def fit_glm_irls(
     for r in range(maxiter):
         if r > 0:
             rel_dev_change = _rel_dev_change(deviance, deviance_old)
-            converged = _check_convergence(
-                rel_dev_change=rel_dev_change,
-                tol=tol,
-                r=r,
-                maxiter=maxiter,
-                is_gaussian=family.name == "gaussian",
-            )
-            if converged:
-                break
+            # Only check convergence when the previous update was a full IWLS step.
+            # After step-halving, eta/mu reflect the shortened step, but beta and
+            # the final WLS objects still reflect the unhalved solve; one more
+            # IWLS pass is needed to bring the returned state back into alignment.
+            if not step_halved_prev:
+                converged = _check_convergence(
+                    rel_dev_change=rel_dev_change,
+                    tol=tol,
+                    r=r,
+                    maxiter=maxiter,
+                    is_gaussian=family.name == "gaussian",
+                )
+                if converged:
+                    break
 
             if accelerate and rel_dev_change < 10 * inner_tol:
                 inner_tol = inner_tol / 10
@@ -255,8 +261,9 @@ def fit_glm_irls(
         mu_new = family.inv_link(eta_new)
         deviance_new = family.deviance(Y_flat, mu_new, weights)
 
+        step_halved = False
         if r > 0:
-            eta_new, mu_new, deviance_new = _step_halving(
+            eta_new, mu_new, deviance_new, step_halved = _step_halving(
                 family=family,
                 y_flat=Y_flat,
                 eta=eta,
@@ -271,6 +278,7 @@ def fit_glm_irls(
         z_prev = z
         z_tilde_prev = z_tilde
         X_tilde_prev = X_tilde
+        step_halved_prev = step_halved
 
         deviance_old = deviance
         eta = eta_new

--- a/pyfixest/estimation/models/feglm_.py
+++ b/pyfixest/estimation/models/feglm_.py
@@ -159,6 +159,8 @@ class Feglm(Feols):
             coefnames=self._coefnames,
             collin_tol=self._collin_tol,
             accelerate=self._accelerate and self._fe is not None,
+            offset=self._offset,
+            weights=self._weights if self._has_weights else None,
             solver=self._solver,
             maxiter=self.maxiter,
             tol=self.tol,

--- a/pyfixest/estimation/models/feglm_.py
+++ b/pyfixest/estimation/models/feglm_.py
@@ -125,10 +125,20 @@ class Feglm(Feols):
             self._X.drop(na_separation, axis=0, inplace=True)
             self._fe.drop(na_separation, axis=0, inplace=True)
             self._data.drop(na_separation, axis=0, inplace=True)
+            if self._weights_df is not None:
+                self._weights_df.drop(na_separation, axis=0, inplace=True)
+            if self._offset_df is not None:
+                self._offset_df.drop(na_separation, axis=0, inplace=True)
             self._N = self._Y.shape[0]
+            self._N_rows = self._N
+            # Re-set weights after dropping rows (handles both weighted and unweighted)
+            self._weights = self._set_weights()
 
             self.na_index = np.concatenate([self.na_index, np.array(na_separation)])
             self.n_separation_na = len(na_separation)
+            # possible to have dropped fixed effects level due to separation
+            self._k_fe = self._fe.nunique(axis=0) if self._has_fixef else None
+            self._n_fe = np.sum(self._k_fe > 1) if self._has_fixef else 0
 
     def to_array(self):
         "Turn estimation DataFrames to np arrays."
@@ -207,7 +217,7 @@ class Feglm(Feols):
 
         self._tZX = self._Z.T @ self._X
         self._tZXinv = np.linalg.inv(self._tZX)
-        self._Xbeta = fit.eta
+        self._Xbeta = fit.eta.reshape(-1, 1)
 
         self._hessian = X_wls.T @ X_wls
         self.deviance = fit.deviance

--- a/pyfixest/estimation/models/feglm_.py
+++ b/pyfixest/estimation/models/feglm_.py
@@ -147,6 +147,8 @@ class Feglm(Feols):
             self._X.to_numpy(),
             self._X.to_numpy(),
         )
+        if self._offset_df is not None:
+            self._offset = self._offset_df.to_numpy().reshape((-1, 1))
         if self._fe is not None:
             self._fe = self._fe.to_numpy()
             if self._fe.ndim == 1:

--- a/pyfixest/estimation/models/feols_.py
+++ b/pyfixest/estimation/models/feols_.py
@@ -374,8 +374,8 @@ class Feols(ResultAccessorMixin):
         self._adj_r2 = np.nan
         self._adj_r2_within = np.nan
 
-        # special for poisson
-        self.deviance = None
+        # special for poisson / glm
+        self.deviance: float | None = None
 
         # special for did
         self._res_cohort_eventtime_dict: dict[str, Any] | None = None

--- a/pyfixest/estimation/models/fepois_.py
+++ b/pyfixest/estimation/models/fepois_.py
@@ -10,7 +10,7 @@ from scipy.special import gammaln
 from pyfixest.core.demean import Preconditioner
 from pyfixest.demeaners import AnyDemeaner
 from pyfixest.estimation.formula.parse import Formula as FixestFormula
-from pyfixest.estimation.internals.families import POISSON, pois_deviance_weighted
+from pyfixest.estimation.internals.families import POISSON
 from pyfixest.estimation.internals.literals import (
     SolverOptions,
 )
@@ -184,9 +184,7 @@ class Fepois(Feglm):
             user_weights * (y_orig - self._Y_hat_response) ** 2 / self._Y_hat_response
         )
 
-        # The in-loop deviance set by Feglm is unweighted; Fepois reports the
-        # user-weighted version.
-        self.deviance = pois_deviance_weighted(
+        self.deviance = self._family.deviance(
             y_orig, self._Y_hat_response, user_weights
         )
 

--- a/pyfixest/estimation/models/fepois_.py
+++ b/pyfixest/estimation/models/fepois_.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import warnings
 from collections.abc import Mapping
 from typing import Any
 
@@ -10,17 +9,14 @@ from scipy.special import gammaln
 
 from pyfixest.core.demean import Preconditioner
 from pyfixest.demeaners import AnyDemeaner
-from pyfixest.errors import (
-    NonConvergenceError,
-)
 from pyfixest.estimation.formula.parse import Formula as FixestFormula
-from pyfixest.estimation.internals.collinearity import drop_multicollinear_variables
+from pyfixest.estimation.internals.families import POISSON, pois_deviance_weighted
 from pyfixest.estimation.internals.literals import (
     SolverOptions,
 )
 from pyfixest.estimation.internals.separation import check_for_separation
-from pyfixest.estimation.internals.solvers import solve_ols
 from pyfixest.estimation.internals.vcov_ import vcov_iid_glm
+from pyfixest.estimation.models.feglm_ import Feglm
 from pyfixest.estimation.models.feols_ import (
     Feols,
     PredictionErrorOptions,
@@ -29,14 +25,14 @@ from pyfixest.estimation.models.feols_ import (
 from pyfixest.utils.dev_utils import DataFrameType, _check_series_or_dataframe
 
 
-class Fepois(Feols):
+class Fepois(Feglm):
     """
     Estimate a Poisson regression model.
 
     Non user-facing class to estimate a Poisson regression model via Iterated
     Weighted Least Squares (IWLS).
 
-    Inherits from the Feols class. Users should not directly instantiate this class,
+    Inherits from the Feglm class. Users should not directly instantiate this class,
     but rather use the [fepois()](/reference/estimation.api.fepois.fepois.qmd) function.
     Note that no demeaning is performed in this class: demeaning is performed in the
     FixestMulti class (to allow for caching of demeaned variables for multiple estimation).
@@ -120,50 +116,38 @@ class Fepois(Feols):
             weights_type=weights_type,
             collin_tol=collin_tol,
             lookup_demeaned_data=lookup_demeaned_data,
+            tol=tol,
+            maxiter=maxiter,
             solver=solver,
             store_data=store_data,
             copy_data=copy_data,
             lean=lean,
             sample_split_var=sample_split_var,
             sample_split_value=sample_split_value,
+            separation_check=separation_check,
             context=context,
             demeaner=demeaner,
             lookup_preconditioner=lookup_preconditioner,
         )
 
-        # input checks
-        _fepois_input_checks(
-            drop_singletons=drop_singletons,
-            tol=tol,
-            maxiter=maxiter,
-        )
-
-        self.maxiter = maxiter
-        self.tol = tol
+        # Poisson-specific overrides on top of the Feglm-set defaults.
         self._method = "fepois"
-        self.convergence = False
-        self.separation_check = separation_check
+        self._family = POISSON
         self._offset_name = offset
-
-        self._support_crv3_inference = True
-        self._support_iid_inference = True
         self._supports_cluster_causal_variance = False
         self._support_decomposition = False
 
-        self._Y_hat_response = np.array([])
-        self.deviance = None
-        self._Xbeta = np.array([])
-
     def prepare_model_matrix(self):
         "Prepare model inputs for estimation."
-        super().prepare_model_matrix()
+        # Skip Feglm.prepare_model_matrix's separation handling; Fepois does its
+        # own below with additional drops (offset_df, weights_df).
+        Feols.prepare_model_matrix(self)
 
         # check that self._Y is a pandas Series or DataFrame
         self._Y = _check_series_or_dataframe(self._Y)
 
-        # check that self._Y is a weakly positive number
-        if np.any(self._Y < 0):
-            raise ValueError("The dependent variable must be a weakly positive number.")
+        # Y >= 0 enforcement is delegated to POISSON.check_y, invoked by
+        # Feglm._check_dependent_variable after prepare_model_matrix.
 
         # check for separation
         na_separation: list[int] = []
@@ -202,192 +186,34 @@ class Fepois(Feols):
             self._n_fe = np.sum(self._k_fe > 1) if self._has_fixef else 0
 
     def to_array(self):
-        "Turn estimation DataFrames to np arrays."
-        self._Y, self._X, self._Z = (
-            self._Y.to_numpy(),
-            self._X.to_numpy(),
-            self._X.to_numpy(),
-        )
-        if self._fe is not None:
-            self._fe = self._fe.to_numpy()
-            if self._fe.ndim == 1:
-                self._fe = self._fe.reshape((self._N, 1))
+        "Turn estimation DataFrames to np arrays and resolve the offset."
+        super().to_array()
         if self._offset_df is not None:
             self._offset = self._offset_df.to_numpy().reshape((-1, 1))
         else:
             self._offset = np.zeros((self._N, 1))
 
-    def _compute_deviance(
-        self, Y: np.ndarray, mu: np.ndarray, weights: np.ndarray | None = None
-    ):
-        """
-        Deviance is defined as twice the difference in log likelihood between the
-        saturated model and the model being fit.
-
-        deviance = 2 * (log_likelihood_saturated - log_likelihood_fitted)
-
-        See [1] chapter 5.6 for more details.
-        [1] Dobson, Annette J., and Adrian G. Barnett. An introduction to generalized linear models. Chapman and Hall/CRC, 2018.
-        """
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            if weights is None:
-                weights = np.ones_like(Y)
-            weights = weights.flatten()
-            Y_flat = Y.flatten()
-            mu_flat = mu.flatten()
-            deviance = np.float64(
-                2
-                * np.sum(
-                    weights
-                    * (
-                        np.where(Y_flat == 0, 0, Y_flat * np.log(Y_flat / mu_flat))
-                        - (Y_flat - mu_flat)
-                    )
-                )
-            )
-        return deviance
-
     def get_fit(self) -> None:
-        """
-        Fit a Poisson Regression Model via Iterated Weighted Least Squares (IWLS).
+        "Fit via Feglm IRLS, then add Poisson-specific post-fit summary stats."
+        # Stash original Y and user weights before super().get_fit() overwrites
+        # self._Y / self._weights with the WLS-transformed versions used for
+        # inference.
+        y_orig = np.asarray(self._Y).flatten()
+        user_weights = self._weights.flatten().copy()
 
-        Returns
-        -------
-        None
+        super().get_fit()
 
-        Attributes
-        ----------
-        beta_hat : np.ndarray
-            Estimated coefficients.
-        Y_hat : np.ndarray
-            Estimated dependent variable.
-        u_hat : np.ndarray
-            Estimated residuals.
-        weights : np.ndarray
-            Weights (from the last iteration of the IRLS algorithm).
-        X : np.ndarray
-            Demeaned independent variables (from the last iteration of the IRLS
-            algorithm).
-        Z : np.ndarray
-            Demeaned independent variables (from the last iteration of the IRLS
-            algorithm).
-        Y : np.ndarray
-            Demeaned dependent variable (from the last iteration of the IRLS
-            algorithm).
-        """
-        self.to_array()
-
-        stop_iterating = False
-        crit = 1
-
-        for i in range(self.maxiter):
-            if stop_iterating:
-                self.convergence = True
-                break
-            if i == self.maxiter:
-                raise NonConvergenceError(
-                    f"""
-                    The IRLS algorithm did not converge with {self.maxiter}
-                    iterations. Try to increase the maximum number of iterations.
-                    """
-                )
-
-            if i == 0:
-                _mean = np.mean(self._Y)
-                mu = (self._Y + _mean) / 2
-                eta = np.log(mu)
-                Z = eta - self._offset + self._Y / mu - 1
-                reg_Z = Z.copy()
-                last = self._compute_deviance(self._Y, mu)
-            else:
-                # update w and Z
-                Z = eta - self._offset + self._Y / mu - 1  # eq (8)
-                reg_Z = Z.copy()  # eq (9)
-
-            # tighten HDFE tolerance - currently not possible with PyHDFE
-            # if crit < 10 * inner_tol:
-            #    inner_tol = inner_tol / 10
-
-            # Step 1: weighted demeaning
-            ZX = np.concatenate([reg_Z, self._X], axis=1)
-
-            combined_weights = self._weights * mu
-
-            if self._fe is None:
-                ZX_resid = ZX
-            else:
-                ZX_resid = self._demean_cache.demean_array(
-                    x=ZX,
-                    flist=self._fe,
-                    weights=combined_weights.flatten(),
-                    na_index=self._na_index,
-                    demeaner=self._demeaner,
-                )
-
-            Z_resid = ZX_resid[:, 0].reshape((self._N, 1))  # z_resid
-            X_resid = ZX_resid[:, 1:]  # x_resid
-
-            if i == 0:
-                # Check multicollinearity
-                # We do this here after the first demeaning to also catch collinearity with fixed effects
-                X_resid, self._coefnames, self._collin_vars, self._collin_index = (
-                    drop_multicollinear_variables(
-                        X_resid,
-                        self._coefnames,
-                        self._collin_tol,
-                    )
-                )
-                if self._collin_index:
-                    # Drop covariates collinear with fixed effects
-                    self._X = self._X[:, ~np.array(self._collin_index)]
-                self._X_is_empty = self._X.shape[1] == 0
-                self._k = self._X.shape[1]
-            WX = np.sqrt(combined_weights) * X_resid
-            WZ = np.sqrt(combined_weights) * Z_resid
-
-            XWX = WX.transpose() @ WX
-            XWZ = WX.transpose() @ WZ
-
-            delta_new = solve_ols(XWX, XWZ, self._solver).reshape(
-                (-1, 1)
-            )  # eq (10), delta_new -> reg_z
-            resid = Z_resid - X_resid @ delta_new
-
-            # more updating
-            eta = Z - resid + self._offset
-            mu = np.exp(eta)
-
-            # same criterion as fixest
-            # https://github.com/lrberge/fixest/blob/6b852fa277b947cea0bad8630986225ddb2d6f1b/R/ESTIMATION_FUNS.R#L2746
-            deviance = self._compute_deviance(self._Y, mu)
-            crit = np.abs(deviance - last) / (0.1 + np.abs(last))
-            last = deviance
-
-            stop_iterating = crit < self.tol
-
-        self._beta_hat = delta_new.flatten()
-        self._Y_hat_response = mu.flatten()
-        self._Y_hat_link = eta.flatten()
-        # (Y - self._Y_hat)
-        # needed for the calculation of the vcov
-
-        # update for inference
-        user_weights = self._weights.flatten()
-        self._irls_weights = combined_weights.flatten()
-
-        self._u_hat = (WZ - WX @ delta_new).flatten()
-        self._u_hat_working = resid
-        self._u_hat_response = self._Y - np.exp(eta)
-
-        y = self._Y.flatten()
         self._y_hat_null = np.full_like(
-            y, np.average(y, weights=user_weights), dtype=float
+            y_orig, np.average(y_orig, weights=user_weights), dtype=float
         )
 
         self._loglik = np.sum(
             user_weights
-            * (y * np.log(self._Y_hat_response) - self._Y_hat_response - gammaln(y + 1))
+            * (
+                y_orig * np.log(self._Y_hat_response)
+                - self._Y_hat_response
+                - gammaln(y_orig + 1)
+            )
         )
 
         # cant replicate fixest atm
@@ -397,29 +223,22 @@ class Fepois(Feols):
         else:
             self._loglik_null = np.sum(
                 user_weights
-                * (y * np.log(self._y_hat_null) - self._y_hat_null - gammaln(y + 1))
+                * (
+                    y_orig * np.log(self._y_hat_null)
+                    - self._y_hat_null
+                    - gammaln(y_orig + 1)
+                )
             )
             self._pseudo_r2 = 1 - (self._loglik / self._loglik_null)
         self._pearson_chi2 = np.sum(
-            user_weights * (y - self._Y_hat_response) ** 2 / self._Y_hat_response
+            user_weights * (y_orig - self._Y_hat_response) ** 2 / self._Y_hat_response
         )
 
-        self._weights = combined_weights
-        self.deviance = self._compute_deviance(y, mu, user_weights)
-
-        self._Y = WZ
-        self._X = WX
-        self._Z = self._X
-
-        self._tZX = np.transpose(self._Z) @ self._X
-        self._tZXinv = np.linalg.inv(self._tZX)
-        self._Xbeta = eta
-
-        self._scores = self._u_hat[:, None] * self._X
-        self._hessian = XWX
-
-        if self.convergence:
-            self._convergence = True
+        # The in-loop deviance set by Feglm is unweighted; Fepois reports the
+        # user-weighted version.
+        self.deviance = pois_deviance_weighted(
+            y_orig, self._Y_hat_response, user_weights
+        )
 
     def resid(self, type: str = "response") -> np.ndarray:
         """
@@ -514,14 +333,3 @@ class Fepois(Feols):
         return super().predict(newdata=newdata, type=type, atol=atol, btol=btol)
 
 
-def _fepois_input_checks(drop_singletons: bool, tol: float, maxiter: int):
-    if not isinstance(drop_singletons, bool):
-        raise TypeError("drop_singletons must be logical.")
-    if not isinstance(tol, (int, float)):
-        raise TypeError("tol must be numeric.")
-    if tol <= 0 or tol >= 1:
-        raise AssertionError("tol must be between 0 and 1.")
-    if not isinstance(maxiter, int):
-        raise TypeError("maxiter must be integer.")
-    if maxiter <= 0:
-        raise AssertionError("maxiter must be greater than 0.")

--- a/pyfixest/estimation/models/fepois_.py
+++ b/pyfixest/estimation/models/fepois_.py
@@ -135,14 +135,6 @@ class Fepois(Feglm):
         self._supports_cluster_causal_variance = False
         self._support_decomposition = False
 
-    def to_array(self):
-        "Turn estimation DataFrames to np arrays and resolve the offset."
-        super().to_array()
-        if self._offset_df is not None:
-            self._offset = self._offset_df.to_numpy().reshape((-1, 1))
-        else:
-            self._offset = np.zeros((self._N, 1))
-
     def get_fit(self) -> None:
         "Fit via Feglm IRLS, then add Poisson-specific post-fit summary stats."
         # Stash original Y and user weights before super().get_fit() overwrites

--- a/pyfixest/estimation/models/fepois_.py
+++ b/pyfixest/estimation/models/fepois_.py
@@ -137,9 +137,6 @@ class Fepois(Feglm):
 
     def get_fit(self) -> None:
         "Fit via Feglm IRLS, then add Poisson-specific post-fit summary stats."
-        # Stash original Y and user weights before super().get_fit() overwrites
-        # self._Y / self._weights with the WLS-transformed versions used for
-        # inference.
         y_orig = np.asarray(self._Y).flatten()
         user_weights = self._weights.flatten().copy()
 

--- a/pyfixest/estimation/models/fepois_.py
+++ b/pyfixest/estimation/models/fepois_.py
@@ -331,5 +331,3 @@ class Fepois(Feglm):
             )
 
         return super().predict(newdata=newdata, type=type, atol=atol, btol=btol)
-
-

--- a/pyfixest/estimation/models/fepois_.py
+++ b/pyfixest/estimation/models/fepois_.py
@@ -14,15 +14,13 @@ from pyfixest.estimation.internals.families import POISSON, pois_deviance_weight
 from pyfixest.estimation.internals.literals import (
     SolverOptions,
 )
-from pyfixest.estimation.internals.separation import check_for_separation
 from pyfixest.estimation.internals.vcov_ import vcov_iid_glm
 from pyfixest.estimation.models.feglm_ import Feglm
 from pyfixest.estimation.models.feols_ import (
-    Feols,
     PredictionErrorOptions,
     PredictionType,
 )
-from pyfixest.utils.dev_utils import DataFrameType, _check_series_or_dataframe
+from pyfixest.utils.dev_utils import DataFrameType
 
 
 class Fepois(Feglm):
@@ -136,54 +134,6 @@ class Fepois(Feglm):
         self._offset_name = offset
         self._supports_cluster_causal_variance = False
         self._support_decomposition = False
-
-    def prepare_model_matrix(self):
-        "Prepare model inputs for estimation."
-        # Skip Feglm.prepare_model_matrix's separation handling; Fepois does its
-        # own below with additional drops (offset_df, weights_df).
-        Feols.prepare_model_matrix(self)
-
-        # check that self._Y is a pandas Series or DataFrame
-        self._Y = _check_series_or_dataframe(self._Y)
-
-        # Y >= 0 enforcement is delegated to POISSON.check_y, invoked by
-        # Feglm._check_dependent_variable after prepare_model_matrix.
-
-        # check for separation
-        na_separation: list[int] = []
-        if (
-            self._fe is not None
-            and self.separation_check is not None
-            and self.separation_check  # not an empty list
-        ):
-            na_separation = check_for_separation(
-                Y=self._Y,
-                X=self._X,
-                fe=self._fe,
-                fml=self._fml,
-                data=self._data,
-                methods=self.separation_check,
-            )
-
-        if na_separation:
-            self._Y.drop(na_separation, axis=0, inplace=True)
-            self._X.drop(na_separation, axis=0, inplace=True)
-            self._fe.drop(na_separation, axis=0, inplace=True)
-            self._data.drop(na_separation, axis=0, inplace=True)
-            if self._weights_df is not None:
-                self._weights_df.drop(na_separation, axis=0, inplace=True)
-            if self._offset_df is not None:
-                self._offset_df.drop(na_separation, axis=0, inplace=True)
-            self._N = self._Y.shape[0]
-            self._N_rows = self._N
-            # Re-set weights after dropping rows (handles both weighted and unweighted)
-            self._weights = self._set_weights()
-
-            self.na_index = np.concatenate([self.na_index, np.array(na_separation)])
-            self.n_separation_na = len(na_separation)
-            # possible to have dropped fixed effects level due to separation
-            self._k_fe = self._fe.nunique(axis=0) if self._has_fixef else None
-            self._n_fe = np.sum(self._k_fe > 1) if self._has_fixef else 0
 
     def to_array(self):
         "Turn estimation DataFrames to np arrays and resolve the offset."

--- a/tests/test_feols_feglm_internally.py
+++ b/tests/test_feols_feglm_internally.py
@@ -2,6 +2,8 @@ import numpy as np
 import pytest
 
 import pyfixest as pf
+from pyfixest.estimation.internals import fit_glm_ as fit_glm_module
+from pyfixest.estimation.internals.families import POISSON
 
 
 def check_absolute_diff(x1, x2, tol, msg=None):
@@ -93,3 +95,90 @@ def test_glm_fe_vs_onehot(fml, family):
             1e-08,
             f"SE {coef_name} mismatch for fml={fml} and family={family}",
         )
+
+
+def test_step_halving_forces_follow_up_wls(monkeypatch):
+    """Do not declare convergence immediately after accepting a shortened step."""
+    x = np.linspace(-1.0, 1.0, 30)
+    X = np.column_stack([np.ones_like(x), x])
+    Y = np.array(
+        [
+            0,
+            1,
+            0,
+            2,
+            1,
+            3,
+            0,
+            2,
+            1,
+            4,
+            2,
+            3,
+            1,
+            2,
+            4,
+            5,
+            3,
+            4,
+            2,
+            6,
+            4,
+            5,
+            3,
+            7,
+            4,
+            6,
+            5,
+            8,
+            6,
+            9,
+        ],
+        dtype=float,
+    )
+
+    demean_calls = 0
+
+    def _identity_demean(v, X, weights, tol):
+        nonlocal demean_calls
+        demean_calls += 1
+        return v, X
+
+    step_calls = 0
+
+    def _fake_step_halving(
+        family,
+        y_flat,
+        eta,
+        eta_new,
+        mu_new,
+        deviance,
+        deviance_new,
+        tol,
+        weights,
+        step_halving_tol=1e-12,
+    ):
+        nonlocal step_calls
+        step_calls += 1
+        if step_calls == 1:
+            eta_accepted = eta + 0.5 * (eta_new - eta)
+            mu_accepted = family.inv_link(eta_accepted)
+            return eta_accepted, mu_accepted, deviance - 1e-12, True
+        return eta_new, mu_new, min(deviance_new, deviance - 1e-12), False
+
+    monkeypatch.setattr(fit_glm_module, "_step_halving", _fake_step_halving)
+
+    fit_glm_module.fit_glm_irls(
+        X=X,
+        Y=Y,
+        family=POISSON,
+        demean=_identity_demean,
+        coefnames=["Intercept", "X"],
+        collin_tol=1e-9,
+        accelerate=False,
+        maxiter=3,
+        tol=1e-8,
+    )
+
+    assert step_calls == 2
+    assert demean_calls == 3

--- a/tests/test_feols_feglm_internally.py
+++ b/tests/test_feols_feglm_internally.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 
 import pyfixest as pf
+from pyfixest.errors import NonConvergenceError
 from pyfixest.estimation.internals import fit_glm_ as fit_glm_module
 from pyfixest.estimation.internals.families import POISSON
 
@@ -164,7 +165,7 @@ def test_step_halving_forces_follow_up_wls(monkeypatch):
             eta_accepted = eta + 0.5 * (eta_new - eta)
             mu_accepted = family.inv_link(eta_accepted)
             return eta_accepted, mu_accepted, deviance - 1e-12, True
-        return eta_new, mu_new, min(deviance_new, deviance - 1e-12), False
+        return eta_new, mu_new, deviance - 1e-12, False
 
     monkeypatch.setattr(fit_glm_module, "_step_halving", _fake_step_halving)
 
@@ -182,3 +183,60 @@ def test_step_halving_forces_follow_up_wls(monkeypatch):
 
     assert step_calls == 2
     assert demean_calls == 3
+
+
+def test_glm_raises_after_iwls_maxiter_without_convergence():
+    """Exhausting maxiter should not return a silently unconverged fit."""
+    x = np.linspace(-1.0, 1.0, 30)
+    X = np.column_stack([np.ones_like(x), x])
+    Y = np.array(
+        [
+            0,
+            1,
+            0,
+            2,
+            1,
+            3,
+            0,
+            2,
+            1,
+            4,
+            2,
+            3,
+            1,
+            2,
+            4,
+            5,
+            3,
+            4,
+            2,
+            6,
+            4,
+            5,
+            3,
+            7,
+            4,
+            6,
+            5,
+            8,
+            6,
+            9,
+        ],
+        dtype=float,
+    )
+
+    def _identity_demean(v, X, weights, tol):
+        return v, X
+
+    with pytest.raises(NonConvergenceError, match="did not converge"):
+        fit_glm_module.fit_glm_irls(
+            X=X,
+            Y=Y,
+            family=POISSON,
+            demean=_identity_demean,
+            coefnames=["Intercept", "X"],
+            collin_tol=1e-9,
+            accelerate=False,
+            maxiter=1,
+            tol=1e-14,
+        )


### PR DESCRIPTION
Move the core poisson routine, `Fepois`, into `Feglm`. 

As a result, Poisson gains 
- step-halving 
-  inner-tolerance tightening
- and ppmlhdfe-style warm-start acceleration

`Feglm` gets a `offset` argument that does nothing / is only active for Poisson. 