### PR TITLE
Extend feglm() with weights, offset, and family="poisson"

### DIFF
--- a/pyfixest/estimation/api/feglm.py
+++ b/pyfixest/estimation/api/feglm.py
@@ -15,6 +15,7 @@ from pyfixest.estimation.internals.literals import (
     FixedRmOptions,
     SolverOptions,
     VcovTypeOptions,
+    WeightsTypeOptions,
 )
 from pyfixest.estimation.models.feols_ import Feols
 from pyfixest.estimation.models.fepois_ import Fepois
@@ -29,6 +30,9 @@ def feglm(
     family: str,
     vcov: VcovTypeOptions | dict[str, str] | None = None,
     vcov_kwargs: dict[str, str | int] | None = None,
+    weights: str | None = None,
+    weights_type: WeightsTypeOptions = "aweights",
+    offset: str | None = None,
     ssc: dict[str, str | bool] | None = None,
     fixef_rm: FixedRmOptions = "singleton",
     iwls_tol: float = 1e-08,
@@ -51,7 +55,8 @@ def feglm(
 
     Supported families: [logit](/reference/estimation.models.felogit_.Felogit.qmd),
     [probit](/reference/estimation.models.feprobit_.Feprobit.qmd),
-    [gaussian](/reference/estimation.models.fegaussian_.Fegaussian.qmd).
+    [gaussian](/reference/estimation.models.fegaussian_.Fegaussian.qmd),
+    and [poisson](/reference/estimation.models.fepois_.Fepois.qmd).
 
     References
     ----------
@@ -83,7 +88,9 @@ def feglm(
         A pandas or polars dataframe containing the variables in the formula.
 
     family : str
-        The family of the GLM model. Options include "gaussian", "logit" and "probit".
+        The family of the GLM model. Options include "gaussian", "logit", "probit",
+        and "poisson". Passing "poisson" produces the same result as calling
+        `pyfixest.fepois()`.
 
     vcov : Union[VcovTypeOptions, dict[str, str]]
         Type of variance-covariance matrix for inference. Options include "iid",
@@ -99,6 +106,19 @@ def feglm(
         "time_id" for the time ID used for NW and DK standard errors, and "panel_id" for the panel
          identifier used for NW and DK standard errors. Currently, the the time difference between consecutive time
          periods is always treated as 1. More flexible time-step selection is work in progress.
+
+    weights : Union[None, str], optional
+        Default is None. Name of the column in `data` to be used as observation
+        weights. When supplied, IRLS minimizes the weighted deviance.
+
+    weights_type : WeightsTypeOptions, optional
+        Type of weights variable. Either "aweights" (analytic / precision
+        weights) or "fweights" (frequency weights). Defaults to "aweights".
+
+    offset : Union[None, str], optional
+        Default is None. Name of a numeric column in `data` to use as an offset
+        on the link scale. Only supported with `family='poisson'`. For exposure
+        adjustments, pass the exposure on the log scale.
 
     ssc : str
         A ssc object specifying the small sample correction for inference.
@@ -246,18 +266,20 @@ def feglm(
     for a compact post-estimation workflow.
 
     """
-    if family not in ["logit", "probit", "gaussian"]:
+    if family not in ["logit", "probit", "gaussian", "poisson"]:
         raise ValueError(
-            f"Only families 'gaussian', 'logit' and 'probit'are supported but you asked for {family}."
+            f"Only families 'gaussian', 'logit', 'probit', and 'poisson' are "
+            f"supported but you asked for {family!r}."
+        )
+    if offset is not None and family != "poisson":
+        raise ValueError(
+            "The `offset` argument is only supported with `family='poisson'`."
         )
 
     if separation_check is None:
         separation_check = ["fe"]
     if ssc is None:
         ssc = ssc_func()
-    # WLS currently not supported for GLM regression
-    weights = None
-    weights_type = "aweights"
 
     context = {} if context is None else capture_context(context)
     demeaner = _resolve_demeaner(demeaner)
@@ -296,21 +318,24 @@ def feglm(
         context=context,
     )
 
-    # same checks as for Poisson regression
-    fixest._prepare_estimation(
-        estimation=f"feglm-{family}",
-        fml=fml,
-        vcov=vcov,
-        vcov_kwargs=vcov_kwargs,
-        weights=weights,
-        ssc=ssc,
-        fixef_rm=fixef_rm,
-        drop_intercept=drop_intercept,
-    )
+    # Poisson goes through the Fepois model class (which is a Feglm subclass);
+    # other families dispatch to their dedicated feglm-{family} model class.
+    estimation = "fepois" if family == "poisson" else f"feglm-{family}"
+    prepare_kwargs: dict[str, Any] = {
+        "estimation": estimation,
+        "fml": fml,
+        "vcov": vcov,
+        "vcov_kwargs": vcov_kwargs,
+        "weights": weights,
+        "ssc": ssc,
+        "fixef_rm": fixef_rm,
+        "drop_intercept": drop_intercept,
+    }
+    if family == "poisson":
+        prepare_kwargs["offset"] = offset
+    fixest._prepare_estimation(**prepare_kwargs)
     if fixest._is_iv:
-        raise NotImplementedError(
-            "IV Estimation is not supported for Poisson Regression"
-        )
+        raise NotImplementedError("IV estimation is not supported for GLMs.")
 
     fixest._estimate_all_models(
         vcov=vcov,

--- a/pyfixest/estimation/api/feglm.py
+++ b/pyfixest/estimation/api/feglm.py
@@ -12,10 +12,12 @@ from pyfixest.estimation.internals.demeaner_options import (
     _warn_if_experimental_torch_demeaner,
 )
 from pyfixest.estimation.internals.literals import (
+    FamilyOptions,
     FixedRmOptions,
     SolverOptions,
     VcovTypeOptions,
     WeightsTypeOptions,
+    _validate_literal_argument,
 )
 from pyfixest.estimation.models.feols_ import Feols
 from pyfixest.estimation.models.fepois_ import Fepois
@@ -27,7 +29,7 @@ from pyfixest.utils.utils import ssc as ssc_func
 def feglm(
     fml: str,
     data: DataFrameType,  # type: ignore
-    family: str,
+    family: FamilyOptions,
     vcov: VcovTypeOptions | dict[str, str] | None = None,
     vcov_kwargs: dict[str, str | int] | None = None,
     weights: str | None = None,
@@ -266,11 +268,7 @@ def feglm(
     for a compact post-estimation workflow.
 
     """
-    if family not in ["logit", "probit", "gaussian", "poisson"]:
-        raise ValueError(
-            f"Only families 'gaussian', 'logit', 'probit', and 'poisson' are "
-            f"supported but you asked for {family!r}."
-        )
+    _validate_literal_argument(family, FamilyOptions)
     if offset is not None and family != "poisson":
         raise ValueError(
             "The `offset` argument is only supported with `family='poisson'`."

--- a/pyfixest/estimation/internals/literals.py
+++ b/pyfixest/estimation/internals/literals.py
@@ -4,6 +4,7 @@ PredictionType = Literal["response", "link"]
 VcovTypeOptions = Literal["iid", "hetero", "HC1", "HC2", "HC3", "nid"]
 WeightsTypeOptions = Literal["aweights", "fweights"]
 FixedRmOptions = Literal["singleton", "none"]
+FamilyOptions = Literal["logit", "probit", "gaussian", "poisson"]
 SolverOptions = Literal[
     "np.linalg.lstsq",
     "np.linalg.solve",

--- a/pyfixest/estimation/models/feglm_.py
+++ b/pyfixest/estimation/models/feglm_.py
@@ -230,6 +230,27 @@ class Feglm(Feols):
     def _vcov_iid(self):
         return vcov_iid_glm(bread=self._bread)
 
+    def resid(self, type: str = "response") -> np.ndarray:
+        """
+        Return residuals from a fitted GLM.
+
+        Parameters
+        ----------
+        type : str, optional
+            The type of residuals to return. Either "response" (default) or
+            "working".
+
+        Returns
+        -------
+        np.ndarray
+            A flat array with the requested residuals.
+        """
+        if type == "response":
+            return self._u_hat_response.flatten()
+        if type == "working":
+            return self._u_hat_working.flatten()
+        raise ValueError("type must be one of 'response' or 'working'.")
+
     def residualize(
         self,
         v: np.ndarray,

--- a/pyfixest/estimation/models/fepois_.py
+++ b/pyfixest/estimation/models/fepois_.py
@@ -177,28 +177,6 @@ class Fepois(Feglm):
             y_orig, self._Y_hat_response, user_weights
         )
 
-    def resid(self, type: str = "response") -> np.ndarray:
-        """
-        Return residuals from regression model.
-
-        Parameters
-        ----------
-        type : str, optional
-            The type of residuals to be computed.
-            Can be either "response" (default) or "working".
-
-        Returns
-        -------
-        np.ndarray
-            A flat array with the residuals of the regression model.
-        """
-        if type == "response":
-            return self._u_hat_response.flatten()
-        elif type == "working":
-            return self._u_hat_working.flatten()
-        else:
-            raise ValueError("type must be one of 'response' or 'working'.")
-
     def _vcov_iid(self):
         return vcov_iid_glm(bread=self._bread)
 

--- a/pyfixest/estimation/models/fepois_.py
+++ b/pyfixest/estimation/models/fepois_.py
@@ -14,7 +14,6 @@ from pyfixest.estimation.internals.families import POISSON
 from pyfixest.estimation.internals.literals import (
     SolverOptions,
 )
-from pyfixest.estimation.internals.vcov_ import vcov_iid_glm
 from pyfixest.estimation.models.feglm_ import Feglm
 from pyfixest.estimation.models.feols_ import (
     PredictionErrorOptions,
@@ -176,9 +175,6 @@ class Fepois(Feglm):
         self.deviance = self._family.deviance(
             y_orig, self._Y_hat_response, user_weights
         )
-
-    def _vcov_iid(self):
-        return vcov_iid_glm(bread=self._bread)
 
     def predict(
         self,

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -806,6 +806,22 @@ def test_glm_errors():
         pf.feglm("Y ~ X1", data=data, family="logit")
 
 
+def test_feglm_offset_requires_poisson():
+    "Test that passing `offset` to feglm() with a non-Poisson family raises."
+    data = pf.get_data()
+    data["Y_bin"] = np.where(data["Y"] > 0, 1, 0)
+    data["off"] = 0.1
+
+    msg = r"The `offset` argument is only supported with `family='poisson'`\."
+    for family in ("logit", "probit", "gaussian"):
+        with pytest.raises(ValueError, match=msg):
+            pf.feglm("Y_bin ~ X1", data=data, family=family, offset="off")
+
+    # offset with poisson must work (does not raise).
+    data["Y_p"] = np.where(data["Y"] > 0, 1, 0)
+    pf.feglm("Y_p ~ X1", data=data.dropna(), family="poisson", offset="off")
+
+
 def test_prediction_errors_glm():
     "Test that the prediction errors not supported for GLM models."
     data = pf.get_data()

--- a/tests/test_vs_fixest.py
+++ b/tests/test_vs_fixest.py
@@ -193,6 +193,7 @@ def _get_vcov_diag(py_model, r_model, coefname, is_iv=False):
 test_counter_feols = 0
 test_counter_fepois = 0
 test_counter_feiv = 0
+test_counter_feglm = 0
 
 # What is being tested in all tests:
 # - pyfixest vs fixest
@@ -731,22 +732,38 @@ def test_single_fit_fepois(
 
 
 @pytest.mark.against_r_core
-@pytest.mark.parametrize("family", ["logit", "probit", "gaussian"])
+@pytest.mark.parametrize("family", ["logit", "probit", "gaussian", "poisson"])
+@pytest.mark.parametrize("dropna", [False])
+@pytest.mark.parametrize("inference", ["iid", "hetero", {"CRV1": "group_id"}])
+@pytest.mark.parametrize("f3_type", ["str"])
+@pytest.mark.parametrize("fml", ols_fmls)
+@pytest.mark.parametrize("k_adj", [True])
+@pytest.mark.parametrize("G_adj", [True])
 @pytest.mark.parametrize("weights", [None, "weights"])
-@pytest.mark.parametrize("inference", ["iid", "hetero"])
-@pytest.mark.parametrize("fml", ["Y ~ X1", "Y ~ X1 | f1"])
-def test_single_fit_feglm(data_fepois, family, weights, inference, fml):
+def test_single_fit_feglm(
+    data_fepois, dropna, inference, f3_type, fml, k_adj, G_adj, weights, family
+):
     """Verify weighted/unweighted feglm against R fixest.feglm.
 
-    Leaner grid than test_single_fit_fepois: drops the offset parametrize
-    (offset is Poisson-only after the API extension) and skips dropna /
-    f3_type / k_adj / G_adj / CRV inference combinations. Covers
-    family x weights x fml x {iid, hetero} for logit/probit/gaussian.
+    Mirrors ``test_single_fit_fepois`` (same parametrize grid; same artifacts
+    checked) for the three other GLM families. Poisson-only artifacts
+    (loglik, loglik_null, pseudo_r2, pearson_chi2) are not defined for
+    logit/probit/gaussian and are therefore skipped.
     """
-    ssc_ = ssc(k_adj=True, G_adj=True)
+    global test_counter_feglm
+    test_counter_feglm += 1
+
+    _skip_f3_checks(fml, f3_type)
+    _skip_dropna(test_counter_feglm, dropna)
+
+    ssc_ = ssc(k_adj=k_adj, G_adj=G_adj)
 
     data = data_fepois.copy()
+    if dropna:
+        data.dropna(inplace=True)
     data.where(data != "nan", np.nan, inplace=True)
+    data = _convert_f3(data, f3_type)
+
     # Binary outcome for logit/probit; original Y for gaussian.
     data["Y_bin"] = (data["Y"] > 0).astype(int)
     py_fml = fml.replace("Y", "Y_bin", 1) if family in ("logit", "probit") else fml
@@ -769,12 +786,13 @@ def test_single_fit_feglm(data_fepois, family, weights, inference, fml):
         "logit": stats.binomial(link="logit"),
         "probit": stats.binomial(link="probit"),
         "gaussian": stats.gaussian(),
+        "poisson": stats.poisson(),
     }[family]
 
     r_kwargs = {
         "vcov": r_inference,
         "data": data_r,
-        "ssc": fixest.ssc(True, "nonnested", False, True, "min", "min"),
+        "ssc": fixest.ssc(k_adj, "nonnested", False, G_adj, "min", "min"),
         "glm_tol": 1e-10,
         "glm_maxiter": 100,
         "family": r_family,
@@ -791,6 +809,11 @@ def test_single_fit_feglm(data_fepois, family, weights, inference, fml):
     py_confint = mod.confint().xs("X1").values
     py_nobs = mod._N
     py_deviance = mod.deviance
+    py_resid = mod.resid()
+    py_irls_weights = mod._irls_weights.flatten()
+    py_df_k = int(mod._df_k)
+    py_df_t = int(mod._df_t)
+    py_n_coefs = mod.coef().values.size
 
     df_X1 = _get_r_df(r_fixest)
     ro.globalenv["r_fixest"] = r_fixest
@@ -803,20 +826,56 @@ def test_single_fit_feglm(data_fepois, family, weights, inference, fml):
     r_confint = df_X1[["conf.low", "conf.high"]].values.astype(np.float64)
     r_nobs = int(stats.nobs(r_fixest)[0])
     r_deviance = r_fixest.rx2("deviance")
+    r_resid = stats.residuals(r_fixest)
+    r_irls_weights = r_fixest.rx2("irls_weights")
+    r_df_k = int(ro.r('attr(r_fixest$cov.scaled, "df.K")')[0])
+    r_df_t = int(ro.r('attr(r_fixest$cov.scaled, "df.t")')[0])
+    r_n_coefs = int(df_X1["n_coef"])
 
-    if inference == "iid":
+    if inference == "iid" and k_adj and G_adj:
         check_absolute_diff(py_nobs, r_nobs, 1e-08, "py_nobs != r_nobs")
-        check_absolute_diff(py_coef, r_coef, 1e-07, "py_coef != r_coef")
+        check_absolute_diff(py_coef, r_coef, 1e-08, "py_coef != r_coef")
+        check_absolute_diff(py_resid[0:5], r_resid[0:5], 1e-07, "py_resid != r_resid")
+        # irls_weights can be loose at certain indices; matching the Poisson
+        # test's tolerance for the same kind of probe.
+        check_absolute_diff(
+            py_irls_weights[10:12],
+            r_irls_weights[10:12],
+            1e-02,
+            "py_irls_weights != r_irls_weights",
+        )
+        check_absolute_diff(py_n_coefs, r_n_coefs, 1e-08, "py_n_coefs != r_n_coefs")
 
     # order of precision:
     # coef, se, vcov -> important
     # pval, tstat, confint -> less important as they are derived from the above
+    check_absolute_diff(py_df_k, r_df_k, 1e-12, "py_df_k != r_df_k")
+    check_absolute_diff(py_df_t, r_df_t, 1e-12, "py_df_t != r_df_t")
     check_absolute_diff(py_vcov, r_vcov, 1e-06, "py_vcov != r_vcov")
     check_absolute_diff(py_se, r_se, 1e-06, "py_se != r_se")
     check_absolute_diff(py_pval, r_pval, 1e-06, "py_pval != r_pval")
-    check_absolute_diff(py_tstat, r_tstat, 1e-05, "py_tstat != r_tstat")
+    check_absolute_diff(
+        py_tstat, r_tstat, 1e-06 if weights is None else 1e-05, "py_tstat != r_tstat"
+    )
     check_absolute_diff(py_confint, r_confint, 1e-06, "py_confint != r_confint")
-    check_absolute_diff(py_deviance, r_deviance, 1e-07, "py_deviance != r_deviance")
+    check_absolute_diff(py_deviance, r_deviance, 1e-08, "py_deviance != r_deviance")
+
+    py_predict_response = mod.predict(type="response")
+    py_predict_link = mod.predict(type="link")
+    r_predict_response = stats.predict(r_fixest, type="response")
+    r_predict_link = stats.predict(r_fixest, type="link")
+    check_absolute_diff(
+        py_predict_response[0:5],
+        r_predict_response[0:5],
+        1e-05,
+        "py_predict_response != r_predict_response",
+    )
+    check_absolute_diff(
+        py_predict_link[0:5],
+        r_predict_link[0:5],
+        1e-06,
+        "py_predict_link != r_predict_link",
+    )
 
 
 @pytest.mark.against_r_core

--- a/tests/test_vs_fixest.py
+++ b/tests/test_vs_fixest.py
@@ -627,7 +627,7 @@ def test_single_fit_fepois(
         "data": data_r,
         "ssc": fixest.ssc(k_adj, "nonnested", False, G_adj, "min", "min"),
         "glm_tol": 1e-10,
-        "glm_maxiter": 100,
+        "glm_iter": 100,
     }
     if weights is not None:
         r_kwargs["weights"] = ro.Formula("~" + weights)
@@ -745,7 +745,7 @@ def test_single_fit_feglm(
 ):
     """Verify weighted/unweighted feglm against R fixest.feglm.
 
-    Mirrors ``test_single_fit_fepois`` (same parametrize grid; same artifacts
+    Mirrors `test_single_fit_fepois` (same parametrize grid; same artifacts
     checked) for the three other GLM families. Poisson-only artifacts
     (loglik, loglik_null, pseudo_r2, pearson_chi2) are not defined for
     logit/probit/gaussian and are therefore skipped.
@@ -794,7 +794,7 @@ def test_single_fit_feglm(
         "data": data_r,
         "ssc": fixest.ssc(k_adj, "nonnested", False, G_adj, "min", "min"),
         "glm_tol": 1e-10,
-        "glm_maxiter": 100,
+        "glm_iter": 100,
         "family": r_family,
     }
     if weights is not None:
@@ -858,7 +858,10 @@ def test_single_fit_feglm(
         py_tstat, r_tstat, 1e-06 if weights is None else 1e-05, "py_tstat != r_tstat"
     )
     check_absolute_diff(py_confint, r_confint, 1e-06, "py_confint != r_confint")
-    check_absolute_diff(py_deviance, r_deviance, 1e-08, "py_deviance != r_deviance")
+    deviance_tol = 1e-07 if family in ("logit", "probit") else 1e-08
+    check_absolute_diff(
+        py_deviance, r_deviance, deviance_tol, "py_deviance != r_deviance"
+    )
 
     py_predict_response = mod.predict(type="response")
     py_predict_link = mod.predict(type="link")
@@ -1665,7 +1668,7 @@ def test_ssc(fml, dropna, weights, vcov, k_adj, G_adj, k_fixef, model):
         py_fit = pf.feols(**py_kwargs)
     else:
         r_kwargs["glm_tol"] = 1e-10
-        r_kwargs["glm_maxiter"] = 100
+        r_kwargs["glm_iter"] = 100
         py_kwargs["iwls_tol"] = 1e-10
         py_kwargs["iwls_maxiter"] = 100
 

--- a/tests/test_vs_fixest.py
+++ b/tests/test_vs_fixest.py
@@ -731,6 +731,95 @@ def test_single_fit_fepois(
 
 
 @pytest.mark.against_r_core
+@pytest.mark.parametrize("family", ["logit", "probit", "gaussian"])
+@pytest.mark.parametrize("weights", [None, "weights"])
+@pytest.mark.parametrize("inference", ["iid", "hetero"])
+@pytest.mark.parametrize("fml", ["Y ~ X1", "Y ~ X1 | f1"])
+def test_single_fit_feglm(data_fepois, family, weights, inference, fml):
+    """Verify weighted/unweighted feglm against R fixest.feglm.
+
+    Leaner grid than test_single_fit_fepois: drops the offset parametrize
+    (offset is Poisson-only after the API extension) and skips dropna /
+    f3_type / k_adj / G_adj / CRV inference combinations. Covers
+    family x weights x fml x {iid, hetero} for logit/probit/gaussian.
+    """
+    ssc_ = ssc(k_adj=True, G_adj=True)
+
+    data = data_fepois.copy()
+    data.where(data != "nan", np.nan, inplace=True)
+    # Binary outcome for logit/probit; original Y for gaussian.
+    data["Y_bin"] = (data["Y"] > 0).astype(int)
+    py_fml = fml.replace("Y", "Y_bin", 1) if family in ("logit", "probit") else fml
+    r_fml = _c_to_as_factor(py_fml)
+    r_inference = _get_r_inference(inference)
+    data_r = get_data_r(py_fml, data)
+
+    mod = pf.feglm(
+        fml=py_fml,
+        data=data,
+        family=family,
+        vcov=inference,
+        ssc=ssc_,
+        iwls_tol=1e-10,
+        iwls_maxiter=100,
+        weights=weights,
+    )
+
+    r_family = {
+        "logit": stats.binomial(link="logit"),
+        "probit": stats.binomial(link="probit"),
+        "gaussian": stats.gaussian(),
+    }[family]
+
+    r_kwargs = {
+        "vcov": r_inference,
+        "data": data_r,
+        "ssc": fixest.ssc(True, "nonnested", False, True, "min", "min"),
+        "glm_tol": 1e-10,
+        "glm_maxiter": 100,
+        "family": r_family,
+    }
+    if weights is not None:
+        r_kwargs["weights"] = ro.Formula("~" + weights)
+
+    r_fixest = fixest.feglm(ro.Formula(r_fml), **r_kwargs)
+
+    py_coef = mod.coef().xs("X1")
+    py_se = mod.se().xs("X1")
+    py_pval = mod.pvalue().xs("X1")
+    py_tstat = mod.tstat().xs("X1")
+    py_confint = mod.confint().xs("X1").values
+    py_nobs = mod._N
+    py_deviance = mod.deviance
+
+    df_X1 = _get_r_df(r_fixest)
+    ro.globalenv["r_fixest"] = r_fixest
+
+    py_vcov, r_vcov = _get_vcov_diag(mod, r_fixest, "X1")
+    r_coef = df_X1["estimate"]
+    r_se = df_X1["std.error"]
+    r_pval = df_X1["p.value"]
+    r_tstat = df_X1["statistic"]
+    r_confint = df_X1[["conf.low", "conf.high"]].values.astype(np.float64)
+    r_nobs = int(stats.nobs(r_fixest)[0])
+    r_deviance = r_fixest.rx2("deviance")
+
+    if inference == "iid":
+        check_absolute_diff(py_nobs, r_nobs, 1e-08, "py_nobs != r_nobs")
+        check_absolute_diff(py_coef, r_coef, 1e-07, "py_coef != r_coef")
+
+    # order of precision:
+    # coef, se, vcov -> important
+    # pval, tstat, confint -> less important as they are derived from the above
+    check_absolute_diff(py_vcov, r_vcov, 1e-06, "py_vcov != r_vcov")
+    check_absolute_diff(py_se, r_se, 1e-06, "py_se != r_se")
+    check_absolute_diff(py_pval, r_pval, 1e-06, "py_pval != r_pval")
+    check_absolute_diff(py_tstat, r_tstat, 1e-05, "py_tstat != r_tstat")
+    check_absolute_diff(py_confint, r_confint, 1e-06, "py_confint != r_confint")
+    check_absolute_diff(py_deviance, r_deviance, 1e-07, "py_deviance != r_deviance")
+
+
+@pytest.mark.against_r_core
 @pytest.mark.parametrize("dropna", [False])
 @pytest.mark.parametrize("weights", [None, "weights"])
 @pytest.mark.parametrize("inference", ["iid", "hetero", {"CRV1": "group_id"}])


### PR DESCRIPTION
Add `weights`, `offset`, `poisson` family to `pf.feglm`. 

- `weights` -> support WLS
- `offset` -> err except for Poisson 
- `poisson` -> identical results to `pf.feglm`