### PR TITLE
Raise an informative error in did2s when first stage fixed effects cannot be estimated

### DIFF
--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -39,6 +39,14 @@ As previously announced, we removed:
 - Deprecated the SciPy and CuPy demeaner backends.
 - Deprecated `FeolsCompressed`.
 
+### Bug Fixes
+
+- `did2s()` now raises an informative error when some fixed effect levels cannot be
+  estimated in the first stage regression (e.g. for always-treated units, which have
+  no not-yet-treated observations), instead of failing later with an opaque
+  broadcasting `ValueError` in the vcov computation
+  ([#1244](https://github.com/py-econometrics/pyfixest/issues/1244)).
+
 
 ## PyFixest 0.60.0
 

--- a/pyfixest/did/did2s.py
+++ b/pyfixest/did/did2s.py
@@ -225,33 +225,17 @@ def _did2s_estimate(
     )  # iid as it might be faster than CRV
 
     # obtain estimated fixed effects
-    fixef_dict = fit1.fixef()
+    fit1.fixef()
 
     # demean data
     Y_hat = fit1.predict(newdata=data)
     if np.isnan(Y_hat).any():
         # levels present in the full data but absent from the first stage fit
-        # (fit on not-yet-treated observations only) predict to NaN and would
-        # silently be dropped in the second stage, see #1244
-        missing_by_var = []
-        fixef_vars = [x.strip() for x in _first_stage.split("|")[1].split("+")]
-        for fixef_var in fixef_vars:
-            if fixef_var not in data.columns:
-                continue
-            estimated_levels = set(fixef_dict.get(f"C({fixef_var})", {}))
-            data_levels = set(data[fixef_var].astype(str))
-            missing = sorted(data_levels - estimated_levels)
-            if missing:
-                missing_by_var.append(f"{fixef_var}: {missing}")
-        details = "; ".join(missing_by_var) if missing_by_var else "unknown levels"
+        # (fit on not-yet-treated observations only) predict to NaN
         raise ValueError(
-            "The following fixed effect levels could not be estimated in the "
-            f"first stage regression, which is fit on not-yet-treated observations "
-            f"only: {details}. This happens when a level has no not-yet-treated "
-            "observations (e.g. an always-treated unit) or is collinear in the "
-            "first stage. First stage predictions for the affected observations "
-            "are NaN, hence did2s cannot proceed. Please drop the affected "
-            "observations before calling did2s()."
+            "First-stage predictions contain NaN values because some fixed effect "
+            "levels were not observed in the not-yet-treated first-stage sample. "
+            "Drop those observations before calling did2s()."
         )
     _first_u = data[f"{yname}"].to_numpy().flatten() - Y_hat
     data[f"{yname}_hat"] = _first_u

--- a/pyfixest/did/did2s.py
+++ b/pyfixest/did/did2s.py
@@ -225,10 +225,34 @@ def _did2s_estimate(
     )  # iid as it might be faster than CRV
 
     # obtain estimated fixed effects
-    fit1.fixef()
+    fixef_dict = fit1.fixef()
 
     # demean data
     Y_hat = fit1.predict(newdata=data)
+    if np.isnan(Y_hat).any():
+        # levels present in the full data but absent from the first stage fit
+        # (fit on not-yet-treated observations only) predict to NaN and would
+        # silently be dropped in the second stage, see #1244
+        missing_by_var = []
+        fixef_vars = [x.strip() for x in _first_stage.split("|")[1].split("+")]
+        for fixef_var in fixef_vars:
+            if fixef_var not in data.columns:
+                continue
+            estimated_levels = set(fixef_dict.get(f"C({fixef_var})", {}))
+            data_levels = set(data[fixef_var].astype(str))
+            missing = sorted(data_levels - estimated_levels)
+            if missing:
+                missing_by_var.append(f"{fixef_var}: {missing}")
+        details = "; ".join(missing_by_var) if missing_by_var else "unknown levels"
+        raise ValueError(
+            "The following fixed effect levels could not be estimated in the "
+            f"first stage regression, which is fit on not-yet-treated observations "
+            f"only: {details}. This happens when a level has no not-yet-treated "
+            "observations (e.g. an always-treated unit) or is collinear in the "
+            "first stage. First stage predictions for the affected observations "
+            "are NaN, hence did2s cannot proceed. Please drop the affected "
+            "observations before calling did2s()."
+        )
     _first_u = data[f"{yname}"].to_numpy().flatten() - Y_hat
     data[f"{yname}_hat"] = _first_u
 

--- a/pyfixest/estimation/post_estimation/prediction.py
+++ b/pyfixest/estimation/post_estimation/prediction.py
@@ -147,11 +147,20 @@ def _get_fixed_effects_prediction_component(
     return fe_hat
 
 
-def _apply_fixef_numpy(df_fe_values, fixef_dicts):
+def _apply_fixef_numpy(df_fe_values, fixef_dicts, warn: bool = True):
     fixef_mat = np.zeros_like(df_fe_values, dtype=float)
-    for i, (_, subdict) in enumerate(fixef_dicts.items()):
+    for i, (fe_name, subdict) in enumerate(fixef_dicts.items()):
         unique_levels, inverse = np.unique(df_fe_values[:, i], return_inverse=True)
         mapping = np.array([subdict.get(level, np.nan) for level in unique_levels])
+        if warn and (missing_levels := np.isnan(mapping)).any():
+            # Unseen fixed effect levels are `np.nan` from `subdict.get(level, np.nan)`
+            missing = unique_levels[missing_levels]
+            warnings.warn(
+                f"Unseen levels for fixed effect {fe_name}; predictions for affected "
+                f"observations will be NaN. Unseen levels: {missing}",
+                UserWarning,
+                stacklevel=4,  # emit warning at `predict` caller
+            )
         fixef_mat[:, i] = mapping[inverse]
 
     return fixef_mat

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1095,7 +1095,9 @@ def test_did2s_unestimated_first_stage_fixef():
 
     with pytest.raises(
         ValueError,
-        match=r"could not be estimated in the first stage",
+        match=r"First-stage predictions contain NaN values because some fixed effect "
+        "levels were not observed in the not-yet-treated first-stage sample. "
+        "Drop those observations before calling did2s().",
     ):
         pf.did2s(
             data,

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1072,3 +1072,36 @@ def test_errors_hac():
                 vcov=vcov,
                 vcov_kwargs={"time_id": "time3", "panel_id": "panel", "lag": 5},
             )
+
+
+def test_did2s_unestimated_first_stage_fixef():
+    "did2s raises an informative error when first-stage fixed effects cannot be estimated for some levels (#1244)."
+    rng = np.random.default_rng(42)
+
+    n_units, n_years = 6, 5
+    rows = []
+    for unit in range(1, n_units + 1):
+        if unit == 1:
+            treat_start = 1  # always treated: no not-yet-treated observations
+        elif unit <= 3:
+            treat_start = 4
+        else:
+            treat_start = n_years + 1  # never treated
+        for year in range(1, n_years + 1):
+            treat = year >= treat_start
+            dep_var = 0.5 * unit + 0.3 * year + float(treat) + rng.normal()
+            rows.append((unit, year, treat, dep_var))
+    data = pd.DataFrame(rows, columns=["unit", "year", "treat", "dep_var"])
+
+    with pytest.raises(
+        ValueError,
+        match=r"could not be estimated in the first stage",
+    ):
+        pf.did2s(
+            data,
+            yname="dep_var",
+            first_stage="~ 0 | unit + year",
+            second_stage="~ i(treat)",
+            treatment="treat",
+            cluster="unit",
+        )


### PR DESCRIPTION
## Why

`pf.did2s()` (and `event_study(estimator="did2s")`) crashes with an opaque `ValueError: operands could not be broadcast together with shapes (190,) (200,) ...` deep inside `_did2s_vcov` whenever the first stage cannot estimate some fixed effect levels. As @marcandre259 traced in #1244, the trigger is easy to hit on ordinary DiD data: the first stage is fit on **not-yet-treated observations only**, so e.g. an *always-treated unit* never gets its fixed effect estimated.

## Root cause

- `_did2s_estimate` fits the first stage on the not-yet-treated subset, then predicts on the full data: rows whose fixed-effect level was never seen predict to `NaN`.
- The `NaN`s flow into the second-stage dependent variable, where `feols` silently drops those rows — so `_second_u` comes out shorter than `_first_u` and every full-length array built from `data` in `_did2s_vcov`.
- The mismatch only surfaces later, at `second_u *= weights_array`, as a broadcasting error with no hint of the actual cause.

## What this PR does

- After the first-stage `predict`, check for `NaN` predictions; if any, resolve which fixed-effect levels are present in the data but absent from `fit1.fixef()` and raise a `ValueError` naming them:

  > The following fixed effect levels could not be estimated in the first stage regression, which is fit on not-yet-treated observations only: unit: ['1']. This happens when a level has no not-yet-treated observations (e.g. an always-treated unit) or is collinear in the first stage. First stage predictions for the affected observations are NaN, hence did2s cannot proceed. Please drop the affected observations before calling did2s().

- Adds a regression test (`tests/test_errors.py::test_did2s_unestimated_first_stage_fixef`) with a synthetic panel containing an always-treated unit — it reproduces the broadcast crash on `master` and asserts the informative error with this change.
- Adds a changelog entry under 0.70.0.

## Design note

The reporter suggested an early, informative error, so that is what this implements. If you'd rather handle it gracefully (drop the affected observations with a warning and keep the downstream arrays consistent), I'm happy to rework it that way — it just touches more of `_did2s_vcov`.

## Evidence

- New regression test fails on `master` (broadcast `ValueError`) and passes with the fix.
- `pixi run test-py`: 686 passed, 11 skipped (the 2 collection errors in `test_batched_lsmr.py`/`test_lsmr_compiled.py` are a missing optional `torch` in the default env, unrelated to this change; same on `master`).
- `pixi run lint`: all hooks pass except 2 pre-existing `mypy` errors in `separation.py`/`ritest.py`, untouched by this diff.
- Note on the red pre-commit.ci check: it fails on those same 2 pre-existing `mypy` errors. The hook's `additional_dependencies: [numpy>=1.20, ...]` floats to the newest numpy, whose stricter type stubs introduced them repo-wide (#1366 hit the same failure; #1367 passed earlier on what looks like a cached hook env). `mypy` only checks `pyfixest/`, and this branch differs from `master` there only in `did2s.py`. Happy to send a separate PR fixing the two errors or pinning numpy in the hook.

Closes #1244
