### PR TITLE
Fix two mypy errors surfaced by newer numpy type stubs

### DIFF
--- a/pyfixest/estimation/internals/separation.py
+++ b/pyfixest/estimation/internals/separation.py
@@ -138,7 +138,7 @@ def _check_for_separation_fe(
             null_column = ctab.xs(0)
             # sep_candidate if
             # fixed effect level has only observations with Y > 0
-            sep_candidate = (np.sum(ctab > 0, axis=0).values == 1) & (
+            sep_candidate = ((ctab > 0).sum(axis=0).to_numpy() == 1) & (
                 null_column > 0
             ).to_numpy().flatten()
             # droplist: list of levels to drop

--- a/pyfixest/estimation/post_estimation/ritest.py
+++ b/pyfixest/estimation/post_estimation/ritest.py
@@ -368,7 +368,7 @@ def _get_ritest_pvalue(
     method: str,
     level: float,
     h0_value: float,
-) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+) -> tuple[np.float64, np.float64, np.ndarray]:
     """
     Compute the p-value of the test statistic and
     standard error and CI of the p-value.


### PR DESCRIPTION
## Why

The `mypy` pre-commit hook floats numpy (`additional_dependencies: [numpy>=1.20, ...]`), so pre-commit.ci recently started failing on two pre-existing spots when its hook env picks up the newest numpy's stricter type stubs — e.g. on #1366 and my #1368, in files those PRs don't touch:

```
pyfixest/estimation/internals/separation.py:141: error: "ndarray[...]" has no attribute "values"  [attr-defined]
pyfixest/estimation/post_estimation/ritest.py:395: error: Incompatible return value type (got "tuple[float64, Any, ndarray[...]]", expected "tuple[ndarray[...], ndarray[...], ndarray[...]]")  [return-value]
```

## What this PR does

- **`separation.py`**: `np.sum(ctab > 0, axis=0)` returns a pandas `Series` at runtime (pandas dispatch) but numpy's stubs type it as `ndarray`, so `.values` fails the check. Replaced with the pandas-native `(ctab > 0).sum(axis=0).to_numpy()` — behaviorally identical (verified equal outputs on randomized crosstabs).
- **`ritest.py`**: `_get_ritest_pvalue` returns two scalars and an array (`probs.mean()`, the p-value SE, and the CI array) but was annotated `tuple[np.ndarray, np.ndarray, np.ndarray]`. Corrected to `tuple[np.float64, np.float64, np.ndarray]`. Annotation-only.

No behavior changes.

## Evidence

- `pixi run lint`: `mypy` hook fails on `master` with exactly these 2 errors, passes with this change; all other hooks pass.
- `pytest tests/test_ritest.py`: 54 passed. `pytest tests/test_errors.py tests/test_plan.py` (cover the separation path in the quick suite): 66 passed, 1 skipped.

An alternative (or complement) would be pinning numpy in the hook's `additional_dependencies` for reproducible lint runs — happy to add that here if you prefer.