### PR TITLE
Fix/fe dtype mismatch

### DIFF
--- a/pyfixest/estimation/formula/model_matrix.py
+++ b/pyfixest/estimation/formula/model_matrix.py
@@ -93,6 +93,9 @@ class ModelMatrix:
         self._offset = self._get_columns(model_matrix, _ModelMatrixKey.offset)
 
     def _collect_data(self, model_matrix: formulaic.ModelMatrix) -> None:
+        # formulaic internal: `_flatten()` is private and its iteration order is
+        # documented as unstable. We don't depend on order - columns are accessed by
+        # name and duplicates are value-identical (deduped below).
         datas: list[pd.DataFrame] = list(model_matrix._flatten())
         if not all(datas[0].index.identical(other.index) for other in datas[1:]):
             raise ValueError("All design matrix data must have the same index.")

--- a/pyfixest/estimation/formula/parse.py
+++ b/pyfixest/estimation/formula/parse.py
@@ -135,7 +135,9 @@ class Formula:
     @property
     def is_instrumental_variable(self) -> bool:
         """Boolean indicating whether the formula is an instrumental variable specification."""
-        # A MULTISTAGE formula is a formulaic.formula.StructuredFormula on the right hand side
+        # formulaic internal: MULTISTAGE encodes the first stage as a StructuredFormula
+        # (reached via its `.deps` substructure); both are undocumented and were
+        # experimental in formulaic 1.1.0 - may shift across releases.
         return isinstance(self._right_hand_side, formulaic.formula.StructuredFormula)
 
     @property
@@ -158,7 +160,9 @@ class Formula:
         exogenous = self._right_hand_side
         if self.is_instrumental_variable:
             # remove endogenous variables from exogenous
-            # formulaic deterministically renames endogenous variables in the second stage
+            # formulaic internal: the multistage parser renames endogenous vars to
+            # "<name>_hat" in the second stage; we reconstruct that suffix to drop them.
+            # If formulaic changes the suffix, this filter silently leaks the endog term.
             # https://github.com/matthewwardrop/formulaic/blob/1f04a0b6d1d55ec4e43bf9f81898f6738c1f839a/formulaic/parser/parser.py#L360
             endogenous = {f"{c}_hat" for c in self.endogenous.required_variables}
             exogenous = formulaic.formula.SimpleFormula(
@@ -182,6 +186,8 @@ class Formula:
             raise AttributeError(
                 "Endogenous variables are available only in instrumental variables specifications."
             )
+        # formulaic internal: `.deps[0]` is the parsed `[endog ~ instr]` sub-formula of a
+        # MULTISTAGE RHS (undocumented structure set by formulaic's parser).
         return self._right_hand_side.deps[0].lhs
 
     @property
@@ -191,6 +197,7 @@ class Formula:
             raise AttributeError(
                 "Endogenous variables are available only in instrumental variables specifications"
             )
+        # formulaic internal: see `endogenous` - `.deps[0]` is the MULTISTAGE sub-formula.
         return self._right_hand_side.deps[0].rhs
 
     @property

--- a/pyfixest/estimation/formula/transforms/factor_interaction.py
+++ b/pyfixest/estimation/formula/transforms/factor_interaction.py
@@ -79,6 +79,8 @@ def _get_series_name(data: Any, default: str = "var") -> str:
     if data is None:
         return default
     if isinstance(data, FactorValues):
+        # formulaic internal: unwrap the wrapt proxy to the raw values
+        # (FactorValue unwrapping behavior changed in formulaic 1.2.0).
         data = data.__wrapped__
     if isinstance(data, pd.Series) and data.name is not None:
         return str(data.name)
@@ -105,6 +107,7 @@ def _encode_i(
     dummy encoding, then applies fixest-style naming and handles interactions.
     """
     # Extract values - may be wrapped in dict for null detection
+    # formulaic internal: `.__wrapped__` reaches through the FactorValues wrapt proxy.
     unwrapped = values.__wrapped__ if isinstance(values, FactorValues) else values
     data = unwrapped["__data__"] if var2_name is not None else unwrapped
     var2 = unwrapped.get("__var2__") if var2_name is not None else None
@@ -208,6 +211,9 @@ def _encode_factor(
     # --- Binning (optional) ---
     if bins is not None:
         data = _apply_binning(data, bins, encoder_state)
+    # formulaic internal: we stash a per-variable contrast sub-state under our own
+    # "__contrasts_<var>__" key inside formulaic's encoder_state dict. post_estimation/
+    # prediction.py reads these keys back to detect unseen levels - keep both in sync.
     contrasts_key: Final[str] = f"__contrasts_{data.name}__"
     contrasts_state = encoder_state.get(contrasts_key)
     if contrasts_state is None:
@@ -215,6 +221,8 @@ def _encode_factor(
         contrasts_state = encoder_state.setdefault(contrasts_key, {})
     # Drop a level if: (1) model has intercept (reduced_rank=True), OR (2) ref is explicitly specified
     # This replicates the old monkey-patched behavior: drop=reduced_rank or ref is not None
+    # formulaic internal: encode_contrasts is called directly with the `_state`/`_spec`
+    # injection params normally supplied by the stateful_transform machinery.
     encoded = encode_contrasts(
         data,
         contrasts=TreatmentContrasts(base=ref if ref is not None else UNSET),
@@ -224,7 +232,7 @@ def _encode_factor(
         _state=contrasts_state,
         _spec=model_spec,
     )
-    dummies = encoded.__wrapped__
+    dummies = encoded.__wrapped__  # formulaic internal: unwrap wrapt proxy
     if "levels" not in contrasts_state:
         # Store the full category list (including the reference level dropped by
         # reduced_rank) so that during prediction encode_contrasts can correctly

--- a/pyfixest/estimation/models/feols_.py
+++ b/pyfixest/estimation/models/feols_.py
@@ -80,24 +80,25 @@ def _check_fe_dtype_compatibility(
     newdata: pd.DataFrame,
     fe_columns: list[str],
 ) -> None:
-    """Warn if FE column dtypes differ between fit data and newdata.
+    """Raise if FE columns in newdata cannot be matched against the fit data.
 
-    A dtype mismatch (e.g. int32 vs int64, or string vs numeric) causes the
-    left-merge in ``encode_fixed_effects`` to match nothing, yielding all-NaN
-    predictions without a clear explanation.
+    Mixing numeric and non-numeric dtypes (e.g. fitting on a float column and
+    predicting with strings) makes the left-merge in `encode_fixed_effects`
+    fail with a low-level pandas/formulaic error; raise a clear pyfixest-level
+    message instead. Numeric-numeric differences (e.g. int32 vs int64, int vs
+    float) merge fine and are not flagged.
     """
     for col in fe_columns:
-        if col not in newdata.columns:
+        if col not in newdata.columns or col not in fit_data.columns:
             continue
-        fit_dtype = fit_data[col].dtype
-        new_dtype = newdata[col].dtype
-        if fit_dtype != new_dtype:
-            warnings.warn(
-                f"Fixed effect column '{col}' has dtype {new_dtype} in newdata "
-                f"but {fit_dtype} in the fitted data. This may cause all "
-                f"predictions to be NaN due to unmatched fixed-effect levels.",
-                UserWarning,
-                stacklevel=3,
+        fit_is_numeric = pd.api.types.is_numeric_dtype(fit_data[col])
+        new_is_numeric = pd.api.types.is_numeric_dtype(newdata[col])
+        if fit_is_numeric != new_is_numeric:
+            raise ValueError(
+                f"Fixed effect column '{col}' has dtype {newdata[col].dtype} in "
+                f"newdata but {fit_data[col].dtype} in the data used for fitting, "
+                "so its levels cannot be matched. Convert the column to a "
+                "matching type before calling predict()."
             )
 
 
@@ -1942,19 +1943,30 @@ class Feols(ResultAccessorMixin):
             )
             valid_idx = valid_idx[~unseen[valid_idx]]
             if self._has_fixef:
+                # Check dtype compatibility before materializing the FE matrix:
+                # a numeric-vs-non-numeric mismatch would otherwise surface as a
+                # cryptic FactorEvaluationError from the merge inside
+                # encode_fixed_effects.
+                fe_var_names = [
+                    str(factor)
+                    for term in self.FixestFormula.fixed_effects
+                    for factor in term.factors
+                ]
+                _check_fe_dtype_compatibility(self._data, newdata, fe_var_names)
                 fe_mm = self._model_spec[
                     _ModelMatrixKey.fixed_effects
                 ].get_model_matrix(newdata, context=context, na_action="drop")
+                n_valid_before_fe = len(valid_idx)
                 valid_idx = np.intersect1d(valid_idx, fe_mm.index.to_numpy())
-
-                # Warn if FE dtypes differ between fit data and newdata, as
-                # this causes the left-merge in encode_fixed_effects to match
-                # nothing -> all predictions silently NaN.
-                fe_var_names = [
-                    str(t).split(":")[0].strip()
-                    for t in self.FixestFormula.fixed_effects
-                ]
-                _check_fe_dtype_compatibility(self._data, newdata, fe_var_names)
+                if n_valid_before_fe > 0 and len(valid_idx) == 0:
+                    warnings.warn(
+                        "No row in newdata matches a fixed-effect level seen "
+                        "during fitting; all predictions are NaN. If this is "
+                        "unexpected, check that the fixed-effect columns in "
+                        "newdata hold the same values as the fitted data.",
+                        UserWarning,
+                        stacklevel=2,
+                    )
 
                 if self._sumFE is None:
                     self.fixef(atol, btol)

--- a/pyfixest/estimation/models/feols_.py
+++ b/pyfixest/estimation/models/feols_.py
@@ -75,6 +75,32 @@ decomposition_type = Literal["gelbach"]
 prediction_type = Literal["response", "link"]
 
 
+def _check_fe_dtype_compatibility(
+    fit_data: pd.DataFrame,
+    newdata: pd.DataFrame,
+    fe_columns: list[str],
+) -> None:
+    """Warn if FE column dtypes differ between fit data and newdata.
+
+    A dtype mismatch (e.g. int32 vs int64, or string vs numeric) causes the
+    left-merge in ``encode_fixed_effects`` to match nothing, yielding all-NaN
+    predictions without a clear explanation.
+    """
+    for col in fe_columns:
+        if col not in newdata.columns:
+            continue
+        fit_dtype = fit_data[col].dtype
+        new_dtype = newdata[col].dtype
+        if fit_dtype != new_dtype:
+            warnings.warn(
+                f"Fixed effect column '{col}' has dtype {new_dtype} in newdata "
+                f"but {fit_dtype} in the fitted data. This may cause all "
+                f"predictions to be NaN due to unmatched fixed-effect levels.",
+                UserWarning,
+                stacklevel=3,
+            )
+
+
 class Feols(ResultAccessorMixin):
     """
     Non user-facing class to estimate a linear regression via OLS.
@@ -1920,6 +1946,15 @@ class Feols(ResultAccessorMixin):
                     _ModelMatrixKey.fixed_effects
                 ].get_model_matrix(newdata, context=context, na_action="drop")
                 valid_idx = np.intersect1d(valid_idx, fe_mm.index.to_numpy())
+
+                # Warn if FE dtypes differ between fit data and newdata, as
+                # this causes the left-merge in encode_fixed_effects to match
+                # nothing -> all predictions silently NaN.
+                fe_var_names = [
+                    str(t).split(":")[0].strip()
+                    for t in self.FixestFormula.fixed_effects
+                ]
+                _check_fe_dtype_compatibility(self._data, newdata, fe_var_names)
 
                 if self._sumFE is None:
                     self.fixef(atol, btol)

--- a/pyfixest/estimation/post_estimation/prediction.py
+++ b/pyfixest/estimation/post_estimation/prediction.py
@@ -27,6 +27,8 @@ def _rows_with_unseen_categories(
     """
     mask = np.zeros(newdata.shape[0], dtype=bool)
     for factor_expr, value in rhs_spec.encoder_state.items():
+        # formulaic internal: encoder_state values are (Factor.Kind, state_dict)
+        # 2-tuples set by formulaic's materializer; this shape is undocumented.
         kind, state = value
         if kind is not Factor.Kind.CATEGORICAL:
             continue
@@ -53,6 +55,9 @@ def _categorical_levels(
             if variable in newdata.columns:
                 yield variable, set(state["categories"])
     else:
+        # formulaic internal: pyfixest's i() stores per-variable contrast state under
+        # "__contrasts_<var>__" keys inside formulaic's encoder_state dict (see
+        # transforms/factor_interaction.py); we read those keys back here.
         for key, substate in state.items():
             if key.startswith("__contrasts_") and key.endswith("__"):
                 variable = key[len("__contrasts_") : -len("__")]

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -270,6 +270,36 @@ def test_rwolf_error():
         pf.rwolf(fit.to_list(), "X1", reps=9999, seed=123)
 
 
+def test_predict_fe_dtype_mismatch():
+    """FE dtype handling in predict(newdata=...).
+
+    Numeric-vs-non-numeric mismatches raise a clear pyfixest error (instead of
+    a cryptic FactorEvaluationError from the merge inside encode_fixed_effects);
+    numeric-numeric differences predict fine; fully unmatched FE levels warn.
+    """
+    data = get_data()
+    fit = feols("Y ~ X1 | f1", data=data)
+
+    # numeric-numeric dtype difference (float fit vs int newdata): no complaint
+    newdata = data.dropna(subset=["f1"]).iloc[0:100].copy()
+    newdata["f1"] = newdata["f1"].astype(int)
+    pred = fit.predict(newdata=newdata)
+    assert np.isfinite(pred).any()
+
+    # numeric fit data vs string newdata: clear pyfixest error
+    newdata_str = data.dropna(subset=["f1"]).iloc[0:100].copy()
+    newdata_str["f1"] = newdata_str["f1"].astype(str)
+    with pytest.raises(ValueError, match="Fixed effect column 'f1'"):
+        fit.predict(newdata=newdata_str)
+
+    # no matching FE level at all: warning + all-NaN predictions
+    newdata_shift = data.dropna(subset=["f1"]).iloc[0:100].copy()
+    newdata_shift["f1"] = newdata_shift["f1"] + 1000
+    with pytest.warns(UserWarning, match="No row in newdata matches"):
+        pred_shift = fit.predict(newdata=newdata_shift)
+    assert np.all(np.isnan(pred_shift))
+
+
 def test_wildboottest_errors():
     data = get_data()
     fit = feols("Y ~ X1", data=data)


### PR DESCRIPTION
@leostimpfle - this fixes a small regression introduced in your PR. 

Before the refactor, pyfixest warned when FE columns in newdata had incompatible dtypes versus the fit data. The prediction rewrite removed that guard, so mismatches could either produce all-NaN predictions silently or crash inside formulaic/pandas with a cryptic error. 

We also annotate all lines of code where we use formulaic internals. 