### PR TITLE
Add pyfixest agent toolkit (.claude/ commands + sub-agents)

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -1,0 +1,171 @@
+# pyfixest agent toolkit — thin modular layer over .agents/feature-pr.md
+
+## Design decision
+
+This is a **hybrid**, not a pymc-marketing-style full toolkit.
+
+`.agents/feature-pr.md` stays the single, tool-neutral source of truth for
+the workflow, **unmodified by this toolkit** — it is written and owned by the
+maintainer, and that ownership is worth protecting (pymc-marketing's
+`.claude/` shows what happens without a single source of truth: workflow
+logic duplicated across 40+ files drifted until several files still
+referenced a different project entirely).
+
+What this layer adds is only what a single linear file cannot provide, plus a
+small number of behaviors that go *beyond* what `feature-pr.md` currently
+documents. Those are called out explicitly below as **proposed changes** —
+implemented at the command level so the toolkit can use them today, but not
+folded into `feature-pr.md` itself. That file changes only when the
+maintainer reviews the diff and decides to merge it.
+
+| Borrowed from pymc-marketing | Where it lives here |
+|---|---|
+| Phase-level entry points (jump into any phase) | one slash-command per phase |
+| Locator/analyzer sub-agent split for parallel discovery | `.claude/agents/` |
+| Plans persisted as checkbox files (survive lost shell state) | `.claude/plans/<branch>.md` |
+| Standalone "did we build what we planned" audit with a report template | inside `/review-pr` |
+| Explicit ask/don't-ask rules per phase | stated in each command |
+| Structured stop-and-present on plan mismatch | inside `/implement-slice` |
+
+Rule that keeps this from rotting: **commands never restate workflow rules —
+they point to the phase and add orchestration only.** If a command's addition
+is really a workflow *rule* rather than orchestration, it belongs in
+`feature-pr.md` — which means proposing it there, not editing it unilaterally.
+
+## Layout
+
+```
+.claude/
+  README.md             # this file
+  commands/
+    feature-pr.md        # full pipeline (Phases 1–5)
+    discover.md          # Phase 1 + sub-agents + persisted plan + staleness check
+    implement-slice.md   # Phase 2, one slice, bounded
+    validate-numerics.md # Phase 3 + validation report
+    review-pr.md         # Phase 4 + plan-vs-implementation audit + Phase 3 check
+    rewrite-history.md   # Phase 5 + confirmation gate
+  agents/
+    codebase-locator.md  # WHERE code lives (grep/glob only)
+    codebase-analyzer.md # HOW code works (file:line, no edits)
+  plans/                 # local scratch — gitignored
+```
+
+`.agents/feature-pr.md` itself ships **unchanged** in this PR.
+
+## Status
+
+Dry-run and full-run tested end to end on a real PR (#1275,
+`weightingboottest`): `/discover` → `/review-pr` (twice) → `/implement-slice`
+(four slices) → a mid-flight upstream rebase → `/review-pr` again. The
+proposed changes below are what that run surfaced as missing.
+
+## Proposed changes to .agents/feature-pr.md
+
+`.agents/feature-pr.md` is the maintainer's reference. Everything here is a
+**proposal**: a quoted diff, the reason, and — for the three marked
+"(evidence: #1275)" — what actually happened on a live PR that the current
+file didn't anticipate. The maintainer decides what, if anything, to merge.
+Until then, the behaviors already work at the command level (noted per item)
+so the toolkit isn't blocked on the decision.
+
+**1. Phase 1, step 6** — after "Write a plan of at most ten lines... Then
+start.", add:
+> Persist it to `.claude/plans/<branch>.md` (or an equivalent local scratch
+> path in other tools) with each slice as a checkbox; later phases restore
+> `BASE_REF`/`MERGE_BASE` from this file.
+
+*Implemented today in:* `discover.md` ("Persisted plan" section).
+
+**2. New "Interaction rules" paragraph**, after the Inputs paragraph:
+> Interaction rules: during Phase 1, ask no clarification questions — resolve
+> ambiguity by reading the repo; ask only if the task itself is undecidable.
+> From Phase 2 on, the only interruptions are the plan-mismatch report and
+> the Escalation report; Phase 5's rewrite additionally requires explicit
+> user confirmation before `git reset --soft`.
+
+*Implemented today in:* `discover.md` ("Interaction rule"),
+`implement-slice.md` ("Interaction rule"), `rewrite-history.md`
+(confirmation gate).
+
+**3. Phase 2** — a fourth stop condition alongside the three-failure rule:
+> A fourth stop condition, alongside the three-failure rule: if reality
+> contradicts the plan (the analogue doesn't fit, a wiring point doesn't
+> exist), stop and present expected vs. found vs. options; do not silently
+> re-plan.
+
+*Implemented today in:* `implement-slice.md` ("Plan mismatch").
+
+**4. Phase 1, step 1** — a staleness check, new paragraph after computing
+`MERGE_BASE` (evidence: #1275):
+> Also check staleness before planning: if
+> `git rev-list --count HEAD..$BASE_REF` is large (rule of thumb: more than
+> ~15 commits) or `git merge-tree --write-tree HEAD "$BASE_REF"` reports
+> conflicts, record it in the plan under a `## Staleness` heading (commits-
+> behind count, and either "no conflicts" or the conflicting file list)
+> before writing the rest of the plan. A large distance with real conflicts
+> means the diff may need re-deriving after a merge, not just re-run against
+> a stale base — say so up front rather than discovering it mid-
+> implementation or at Phase 4.
+
+Why: on #1275, `master` moved 58 commits (a full GLM architecture refactor —
+`Fepois` folded under `Feglm`, a shared `GlmFamily`/`fit_glm_irls` kernel)
+while the PR was in flight. Nothing in the current Phase 1 or Phase 4 would
+have surfaced that before implementation started; it was only discovered when
+`git push` came back `CONFLICTING`.
+
+*Implemented today in:* `discover.md` ("Staleness check").
+
+**5. Phase 4** — a sixth review point (evidence: #1275):
+> Confirm Phase 3 actually completed: the plan file has a
+> `## Numerical validation` section, and it lists no unresolved open items.
+> A missing or still-open Phase 3 is itself a Checks failure — report it as
+> `Phase 3: not completed — [open items]`, not a footnote left unresolved
+> across review passes.
+
+Why: on #1275, Phase 3 was flagged "open, non-blocking" in the very first
+`/discover` pass and never revisited — including after a rebase that
+replaced the hand-rolled IRLS fitting with a shared kernel, exactly the kind
+of change that should trigger re-validation. Existing tests passing is a
+signal, not the reference-backed validation Phase 3 asks for, and nothing
+forced the reckoning.
+
+*Implemented today in:* `review-pr.md` (`### Checks` addition).
+
+**6. Escalation rule** — a named tier distinct from the three existing
+triggers (evidence: #1275):
+> A distinct, non-failure case: the codebase has changed shape since Phase
+> 1's plan was written (a large upstream merge, a landed refactor touching
+> the same files — see the Phase 1 staleness check). This is not something to
+> escalate-and-report; it is a signal to re-enter Phase 1 with the new state
+> — write a fresh plan (a new `## Restart` block in the same plan file,
+> keeping prior slices' checkmarks for the record) and confirm it with the
+> user before resuming Phase 2, the same way the original plan would be.
+> This is a bigger jolt than Phase 2's plan-mismatch stop (a single slice's
+> analogue not fitting) — distinguish the two.
+
+Why: this is exactly what #1275 needed when the merge conflict turned out to
+span a full GLM refactor, not a two-file conflict. Nothing in the workflow
+names this case, so the response (stop, investigate deeply, write a fresh
+plan, get explicit sign-off before implementing) came from judgment in the
+moment rather than a documented playbook. It worked, but a first-time agent
+without that judgment call available has nowhere to look.
+
+*Not implemented at the command level* — this is a cross-cutting behavior,
+not one command's addition, so there's no natural file to house a shadow
+implementation in. It's proposed as-is; until decided, treat a large base
+shift as this section describes by default.
+
+## Testing it on a live PR
+
+```
+claude
+> /discover clean up PR #<n>          # or: gh pr checkout <n> first
+# inspect .claude/plans/<branch>.md, adjust if needed
+> /implement-slice                     # repeat per slice (skip if only reviewing)
+> /validate-numerics
+> /review-pr
+> /rewrite-history                     # only if the branch is yours to rewrite
+```
+
+For a pure review of an existing PR without changing it, `/discover` then
+`/review-pr` alone already produce the plan audit and hygiene report.

--- a/.claude/agents/codebase-analyzer.md
+++ b/.claude/agents/codebase-analyzer.md
@@ -1,0 +1,52 @@
+---
+name: codebase-analyzer
+description: Explains HOW specific pyfixest code works. Use during Phase 1 discovery after codebase-locator has identified files — typically to read the nearest analogue end to end, or to trace how an option threads through the estimation pipeline. Returns explanations with file:line references. It does NOT propose or write changes.
+tools: Read, Grep, Glob, LS
+---
+
+You explain how existing pyfixest code works, with precise `file:line`
+references. You never write code or recommend changes — you describe what is.
+
+When tracing an estimation-time option or a vcov type, follow the pipeline
+defined in `AGENTS.md`:
+
+`feols()` → `EstimationConfig` → `parse_formula` (`plan_.py`) → `FixestMulti`
+→ `runner.run_estimation` / `plan_.fit_one` →
+`prepare_model_matrix → demean → to_array → wls_transform →
+drop_multicol_vars → get_fit → vcov` → post-estimation methods.
+
+When analyzing a Rust kernel, trace the full chain:
+`src/<topic>.rs` → `src/lib.rs` → `pyfixest/core/_core_impl.pyi` →
+`pyfixest/core/<topic>.py` → the NumPy reference implementation kept for tests.
+
+Always report, where applicable:
+- entry points and the wiring points a similar new feature would need
+  (validation site, dispatch site, ssc threading, exports)
+- which shared utilities the analogue reuses (`estimation/formula/`,
+  `_narwhals_to_pandas`, `capture_context`, `prepare_cluster_state`,
+  `run_crv_loop`, `_validate_literal_argument`) — the implementer must reuse
+  these too, not re-derive them
+- how the analogue's tests establish numerical correctness (which reference:
+  R via rpy2, stored output in `tests/data/`, closed-form collapse, …)
+
+Output format:
+
+```
+## Analysis: [component]
+
+### Overview
+2–3 sentences.
+
+### Flow
+- file.py:NN — what happens here
+- ...
+
+### Wiring points a sibling feature would touch
+- ...
+
+### Numerical reference used by its tests
+- ...
+```
+
+Read files fully. If something is unclear, say what you could not determine
+rather than filling the gap with a plausible story.

--- a/.claude/agents/codebase-locator.md
+++ b/.claude/agents/codebase-locator.md
@@ -1,0 +1,42 @@
+---
+name: codebase-locator
+description: Finds WHERE code lives in the pyfixest repo. Use during Phase 1 discovery whenever you would otherwise run grep/glob more than once. Give it a plain-language description of the feature or task; it returns file paths grouped by subsystem. It does NOT read or analyze file contents.
+tools: Grep, Glob, LS
+---
+
+You locate files relevant to a task in the pyfixest repository. You never
+analyze contents or propose changes — you only find and categorize paths.
+
+Group every finding under exactly one of the subsystems defined in
+`AGENTS.md` → "Repo map":
+
+- `estimation/api` — public entry points (`feols`, `fepois`, `feglm`, `quantreg`)
+- `estimation/models` — model/result classes (`feols_.py`, `feiv_.py`, …)
+- `estimation/internals` — `vcov_utils.py`, `solvers.py`, `literals.py`, …
+- `estimation/post_estimation` — `ritest`, `ccv`, `prediction`, `multcomp`, …
+- `estimation/formula` — formula parsing / model matrix
+- `core` + `src` — Python wrappers, `_core_impl.pyi` stubs, Rust kernels
+- `tests` — including reference scripts and stored outputs in `tests/data/`
+- `docs` — Quarto site (`_quarto.yml`, `how-to/`, …)
+
+Also identify, when it exists, the **nearest analogue** to the requested
+feature (the in-repo precedent the implementer should read end to end), using
+the templates named in `AGENTS.md` → "Where new code goes" as a starting point.
+
+Output format:
+
+```
+## Locations for [task]
+
+### <subsystem>
+- path/to/file.py — one-line reason it is relevant
+
+### Nearest analogue
+- path — why it is the closest precedent
+
+### Tests implicated
+- existing test files that changes here would put at risk
+```
+
+Full paths from the repo root. If a search comes up empty, say so — do not
+guess paths.

--- a/.claude/commands/discover.md
+++ b/.claude/commands/discover.md
@@ -1,0 +1,51 @@
+# /discover — Phase 1 (Discovery) of .agents/feature-pr.md
+
+Execute Phase 1 of `.agents/feature-pr.md` exactly as written. This command
+adds four things: parallel sub-agents, a persisted plan file, an interaction
+rule, and a staleness check.
+
+## Sub-agents
+
+After establishing `BASE_REF`/`MERGE_BASE` and collecting the change surface
+(steps 1–2), dispatch in parallel:
+
+- **codebase-locator** — map every touched or implicated file to a subsystem
+  (step 3) and propose the nearest analogue (step 5).
+- **codebase-analyzer** — read the nearest analogue end to end and report its
+  wiring points and the numerical reference its tests use.
+
+Then read the key files the agents identified yourself before writing the
+plan. Sub-agent summaries inform the plan; they do not replace reading.
+
+## Persisted plan
+
+Write the ten-line plan from step 6 to `.claude/plans/<branch-name>.md`
+(create the directory if needed; it is local scratch, never committed).
+Format: the plan lines, each future slice as a `- [ ]` checkbox, and the
+literal `BASE_REF` and `MERGE_BASE` values. Later phases restore
+`MERGE_BASE` from this file instead of recomputing from a possibly-changed
+HEAD.
+
+## Staleness check
+
+Right after computing `MERGE_BASE`, check whether the base has moved far
+enough that the plan itself might need to account for it: if
+`git rev-list --count HEAD..$BASE_REF` is large (rule of thumb: more than
+~15 commits) or `git merge-tree --write-tree HEAD "$BASE_REF"` reports
+conflicts, add a `## Staleness` heading to the plan file with the
+commits-behind count and either "no conflicts" or the conflicting file list.
+Say this before writing the rest of the plan — a large distance with real
+conflicts means the diff may need re-deriving after a merge, not just re-run
+against a stale base. This check is not yet part of `.agents/feature-pr.md`
+itself; see `.claude/README.md` → "Proposed changes to .agents/feature-pr.md"
+for the diff proposed for the maintainer's review.
+
+## Interaction rule
+
+Ask no clarification questions during discovery — resolve ambiguity by
+reading the repo. The one exception: if the task itself is undecidable (two
+contradictory goals, or the referenced issue/PR does not exist), stop and
+ask before writing any plan.
+
+Finish by printing the plan and stating which slice `/implement-slice`
+should start with.

--- a/.claude/commands/feature-pr.md
+++ b/.claude/commands/feature-pr.md
@@ -1,0 +1,20 @@
+# /feature-pr — run the full feature-PR workflow
+
+Read `AGENTS.md`, then execute `.agents/feature-pr.md` end to end
+(Phases 1–5). That file is the single source of truth for the process;
+this command adds only orchestration:
+
+- Phase 1: run `/discover` (uses the locator/analyzer sub-agents and
+  persists the plan to `.claude/plans/<branch>.md`).
+- Phase 2: run `/implement-slice` once per slice, in plan order.
+- Phase 3: run `/validate-numerics`.
+- Phase 4: run `/review-pr`.
+- Phase 5: run `/rewrite-history` only after its preconditions hold.
+
+Argument: an issue reference, a PR number to clean
+(`gh pr checkout <n>`), or a task description. If none is given, ask for one
+— this is the only clarification question permitted before Phase 1 starts.
+
+Respect every bound in `.agents/feature-pr.md`: max 3 iterations per slice,
+max 2 review passes, and the Escalation rule. When a bound is hit, stop and
+produce the escalation report — never widen the change to keep going.

--- a/.claude/commands/implement-slice.md
+++ b/.claude/commands/implement-slice.md
@@ -1,0 +1,33 @@
+# /implement-slice — Phase 2 (Implementation loop) of .agents/feature-pr.md
+
+Execute Phase 2 of `.agents/feature-pr.md` for **one slice**. Argument: the
+slice name, or by default the first unchecked `- [ ]` slice in
+`.claude/plans/<branch-name>.md`. If no plan file exists, run `/discover`
+first — do not implement from an unwritten plan.
+
+All rules live in Phase 2 of `.agents/feature-pr.md` (smallest coherent
+change, narrowest tests via
+`pixi run -e py312-r pytest <files> -x -q --no-cov`, also run the touched
+subsystem's existing test files, the AGENTS.md rules PRs most often break).
+This command adds:
+
+- **Bound**: max 3 iterations on this slice. On the third failure of the
+  same kind, stop and produce the Escalation report from
+  `.agents/feature-pr.md` — do not try a fourth angle.
+- **Plan mismatch**: if reality contradicts the plan (the analogue doesn't
+  fit, a wiring point doesn't exist), stop and present:
+
+  ```
+  Issue in slice [name]:
+  Expected (plan): ...
+  Found: ...
+  Why it matters: ...
+  Options: ...
+  ```
+
+  and wait for the user. Do not silently re-plan.
+- **On success**: check the slice's box in the plan file, note any dropped
+  churn or follow-up items there, and report which slice is next.
+
+Interaction rule: within a slice, work autonomously; the only mid-slice
+questions are the plan-mismatch template above and escalation.

--- a/.claude/commands/review-pr.md
+++ b/.claude/commands/review-pr.md
@@ -1,0 +1,48 @@
+# /review-pr — Phase 4 (Review loop) of .agents/feature-pr.md
+
+Execute Phase 4 of `.agents/feature-pr.md`: restore `BASE_REF`/`MERGE_BASE`
+from `.claude/plans/<branch-name>.md`, review everything that would ship
+(`git status --short`, `git diff "$MERGE_BASE"`, `git diff --cached
+"$MERGE_BASE"`), apply the five review points, and run the check sequence
+(targeted tests → the three lint hooks one at a time → `pixi run test-py` if
+shared internals were touched). Max 2 passes.
+
+This command adds a **plan-vs-implementation audit** — distinct from code
+review — answering "did we build what Phase 1 said," reported as:
+
+```
+## Review report — pass [1|2]
+
+### Plan audit
+- [slice]: implemented as planned | deviated: [what + why] — per plan checkbox
+
+### Diff hygiene
+formatting churn / generated artifacts / lockfiles / unrelated refactors:
+none remaining | removed: [...] | follow-up issue noted: [...]
+
+### Placement & surface
+logic in model classes that belongs in post_estimation/ or internals/: [...]
+public surface vs feols/fepois/feglm/quantreg conventions: [...]
+
+### Exports & docs
+__init__.py (__all__, _lazy_imports) / per-function Parameters docstrings /
+docs/_quarto.yml / how-to vignette: each done or justified-not-needed
+
+### Checks
+[command] → pass/fail (paste the failing tail, not a paraphrase)
+
+### Remaining before handoff
+- [ ] ...
+```
+
+Deviations from the plan are findings to report, not errors to hide —
+some are improvements; say which. If pass 2 still leaves failures, apply
+the Escalation rule instead of starting a third pass.
+
+This command additionally confirms Phase 3 actually completed — the plan
+file has a `## Numerical validation` section with no open items — and reports
+it under **Checks** as `Phase 3: completed` or `Phase 3: not completed —
+[open items]` (a Checks failure, not a footnote left across passes). This
+check is not yet part of `.agents/feature-pr.md` itself; see
+`.claude/README.md` → "Proposed changes to .agents/feature-pr.md" for the
+diff proposed for the maintainer's review.

--- a/.claude/commands/rewrite-history.md
+++ b/.claude/commands/rewrite-history.md
@@ -1,0 +1,22 @@
+# /rewrite-history — Phase 5 (Commit history rewrite) of .agents/feature-pr.md
+
+Execute Phase 5 of `.agents/feature-pr.md`. Everything is defined there:
+the four preconditions (feature branch, clean `git status --short`, branch
+is yours to rewrite or force-push approved, `MERGE_BASE` set with the
+`TIP` escape hatch recorded), the soft-reset recipe, and the target shape
+(two to five commits mirroring the Phase 2 slices, short imperative
+subjects, each commit passing its own targeted tests).
+
+This command adds:
+
+- Restore `MERGE_BASE` from `.claude/plans/<branch-name>.md`; record
+  `TIP=$(git rev-parse HEAD)` in that file too, so recovery survives a lost
+  shell session.
+- **Confirmation gate**: before running `git reset --soft`, print the
+  precondition checklist with each item's actual observed value and the
+  planned commit slicing, and wait for the user's go-ahead. History rewrite
+  is the one destructive step in the workflow; it never runs unprompted.
+- If any precondition fails, stop and say which one and what would resolve
+  it (commit, stash, or user decision). Never proceed with a dirty tree.
+- If the branch belongs to an outside contributor, flag it here and again in
+  the handoff summary, per Phase 5.

--- a/.claude/commands/validate-numerics.md
+++ b/.claude/commands/validate-numerics.md
@@ -1,0 +1,30 @@
+# /validate-numerics — Phase 3 (Numerical validation) of .agents/feature-pr.md
+
+Execute Phase 3 of `.agents/feature-pr.md`: validate against the strongest
+available reference, in that file's stated order of preference (R via rpy2 →
+stored verified output in `tests/data/` → brute-force reimplementation →
+closed-form collapse → seeded Monte Carlo). The dependency rule for reference
+packages and the test-shape guidance (heavily parametrized public-API
+integration tests, `tests/test_vs_fixest.py` shape) are defined there and in
+`AGENTS.md` → "Testing".
+
+This command adds a required output: append a **validation report** to
+`.claude/plans/<branch-name>.md`:
+
+```
+## Numerical validation — [date]
+Reference used: [which rung of the ladder, and why not a higher one]
+Paths covered: [no-FE / FE, unweighted / weighted, clustered, IV, multi-estimation
+               — mark each covered or justified-out-of-scope]
+Invariants asserted: [vcov symmetry + positive diagonal, row-order invariance, ...]
+Tolerances: [each rtol/atol with its one-line justification]
+Marks: [against_r_core / against_r_extended; conftest _rpy2_test_files updated? y/n]
+Open doubts: [anything not established — be explicit]
+```
+
+Hard rules:
+- Shapes matching is not validation. If no reference on the ladder can be
+  established, that is the third Escalation trigger in
+  `.agents/feature-pr.md` — stop and report; do not declare success.
+- Never loosen a tolerance to make a test pass without writing the
+  justification for why the looser bound is expected.

--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ readme.ipynb
 benchmarks/data/
 
 # Local dev files
-.claude/
+.claude/settings.local.json
+.claude/plans/
 .serena/
 SKILL.md


### PR DESCRIPTION
## Summary

A thin layer of Claude Code slash-commands + sub-agents over the existing
`.agents/feature-pr.md` workflow — one command per phase (`/discover`,
`/implement-slice`, `/validate-numerics`, `/review-pr`, `/rewrite-history`),
a locator/analyzer sub-agent split for parallel discovery, and plans
persisted as checkbox files in `.claude/plans/` (gitignored).

**`.agents/feature-pr.md` itself is untouched** — it's the reference file,
and this PR doesn't presume to edit it. Six small behaviors the commands
rely on that go beyond what `feature-pr.md` currently documents (plan
persistence, interaction rules, a plan-mismatch stop, a staleness check, a
Phase 3 completion check, and a named escalation-to-replan tier) are
implemented at the command level for now, and written up as proposed diffs
with rationale in `.claude/README.md` → "Proposed changes to
.agents/feature-pr.md" — happy to fold any/none of these into the reference
file, whatever you'd prefer.

## Test plan

- [x] Dry run (`/discover` + `/review-pr`, no changes) on PR #1275
- [x] Full run (`/discover` → `/implement-slice` × 4 → `/review-pr` × 2) on
      PR #1275, including a mid-flight rebase onto a large upstream GLM
      refactor — the staleness-check and Phase-3-check proposals came
      directly out of gaps that run exposed

🤖 Generated with [Claude Code](https://claude.com/claude-code)