### PR TITLE
Make coefficient update tests deterministic

### DIFF
--- a/tests/test_others.py
+++ b/tests/test_others.py
@@ -62,11 +62,12 @@ def test_integer_XY():
 
 
 def test_coef_update():
-    data = get_data()
-    data_subsample = data.sample(frac=0.5)
+    rng = np.random.default_rng(1234)
+    data = get_data().dropna(subset=["Y", "X1", "X2"])
+    data_subsample = data.sample(frac=0.5, random_state=1234)
     m = feols("Y ~ X1 + X2", data=data_subsample)
-    new_points_id = np.random.choice(
-        list(set(data.index) - set(data_subsample.index)), 5
+    new_points_id = rng.choice(
+        data.index.difference(data_subsample.index), 5, replace=False
     )
     X_new, y_new = (
         np.c_[
@@ -88,11 +89,12 @@ def test_coef_update():
 
 
 def test_coef_update_inplace():
-    data = get_data()
-    data_subsample = data.sample(frac=0.3)
+    rng = np.random.default_rng(1234)
+    data = get_data().dropna(subset=["Y", "X1", "X2"])
+    data_subsample = data.sample(frac=0.3, random_state=1234)
     m = feols("Y ~ X1 + X2", data=data_subsample)
-    new_points_id = np.random.choice(
-        list(set(data.index) - set(data_subsample.index)), 5
+    new_points_id = rng.choice(
+        data.index.difference(data_subsample.index), 5, replace=False
     )
     X_new, y_new = (
         np.c_[


### PR DESCRIPTION
## Summary

- restrict coefficient update tests to complete cases for `Y`, `X1`, and `X2`
- seed both subsample and update-row selection
- sample update rows without replacement

The previous tests could randomly pass a row containing NaN to `Feols.update()`, while the comparison `feols()` fit silently dropped that row. This made the two paths use different effective datasets and intermittently produced all-NaN updated coefficients.

Fixes #1387.

## Validation

```text
pixi run -e py312-r pytest tests/test_others.py::test_coef_update tests/test_others.py::test_coef_update_inplace -q --no-cov
2 passed

pixi run -e lint prek run ruff-format --files tests/test_others.py
Passed

pixi run -e lint prek run ruff-check --files tests/test_others.py
Passed
```