### PR TITLE
Refactor wald_test to use shared _wald_statistic utility

### DIFF
--- a/pyfixest/estimation/models/feols_.py
+++ b/pyfixest/estimation/models/feols_.py
@@ -59,7 +59,7 @@ from pyfixest.estimation.post_estimation.ritest import (
     _get_ritest_stats_slow,
     _plot_ritest_pvalue,
 )
-from pyfixest.estimation.post_estimation.wald import _wald_statistic
+from pyfixest.estimation.post_estimation.wald import _normalize_q, _wald_statistic
 from pyfixest.utils.dev_utils import (
     DataFrameType,
     _extract_variable_level,
@@ -1001,12 +1001,13 @@ class Feols(ResultAccessorMixin):
 
         # If R is None, default to the identity matrix
         R = np.eye(self._k) if R is None else np.atleast_2d(np.asarray(R, dtype=float))
+        q_array = _normalize_q(q, R.shape[0])
 
         W, self._dfn = _wald_statistic(
             beta_hat=self._beta_hat,
             vcov=self._vcov,
             R=R,
-            q=q,
+            q=q_array,
         )
 
         if self._is_clustered:
@@ -1016,10 +1017,10 @@ class Feols(ResultAccessorMixin):
 
         self._wald_statistic = W
 
-        # Check if distribution is "F" and R is not identity matrix
-        # or q is not zero vector
+        # The F distribution is only used for the joint test that all
+        # coefficients are zero (R identity, q zero).
         if distribution == "F" and (
-            not np.array_equal(R, np.eye(self._k)) or not np.all(q == 0)
+            not np.array_equal(R, np.eye(self._k)) or np.any(q_array)
         ):
             warnings.warn(
                 "Distribution changed to chi2, as R is not an identity matrix and q is not a zero vector."

--- a/pyfixest/estimation/models/feols_.py
+++ b/pyfixest/estimation/models/feols_.py
@@ -59,7 +59,7 @@ from pyfixest.estimation.post_estimation.ritest import (
     _get_ritest_stats_slow,
     _plot_ritest_pvalue,
 )
-from pyfixest.estimation.post_estimation.wald import _normalize_q, _wald_statistic
+from pyfixest.estimation.post_estimation.wald import _wald_statistic
 from pyfixest.utils.dev_utils import (
     DataFrameType,
     _extract_variable_level,
@@ -1001,13 +1001,12 @@ class Feols(ResultAccessorMixin):
 
         # If R is None, default to the identity matrix
         R = np.eye(self._k) if R is None else np.atleast_2d(np.asarray(R, dtype=float))
-        q_array = _normalize_q(q, R.shape[0])
 
         W, self._dfn = _wald_statistic(
             beta_hat=self._beta_hat,
             vcov=self._vcov,
             R=R,
-            q=q_array,
+            q=q,
         )
 
         if self._is_clustered:
@@ -1020,7 +1019,7 @@ class Feols(ResultAccessorMixin):
         # The F distribution is only used for the joint test that all
         # coefficients are zero (R identity, q zero).
         if distribution == "F" and (
-            not np.array_equal(R, np.eye(self._k)) or np.any(q_array)
+            not np.array_equal(R, np.eye(self._k)) or (q is not None and np.any(q))
         ):
             warnings.warn(
                 "Distribution changed to chi2, as R is not an identity matrix and q is not a zero vector."

--- a/pyfixest/estimation/models/feols_.py
+++ b/pyfixest/estimation/models/feols_.py
@@ -59,6 +59,7 @@ from pyfixest.estimation.post_estimation.ritest import (
     _get_ritest_stats_slow,
     _plot_ritest_pvalue,
 )
+from pyfixest.estimation.post_estimation.wald import _wald_statistic
 from pyfixest.utils.dev_utils import (
     DataFrameType,
     _extract_variable_level,
@@ -999,48 +1000,28 @@ class Feols(ResultAccessorMixin):
         k_fe = np.sum(self._k_fe.values) if self._has_fixef else 0
 
         # If R is None, default to the identity matrix
-        if R is None:
-            R = np.eye(self._k)
+        R = np.eye(self._k) if R is None else np.atleast_2d(np.asarray(R, dtype=float))
 
-        # Ensure R is two-dimensional
-        if R.ndim == 1:
-            R = R.reshape((1, len(R)))
-
-        if R.shape[1] != self._k:
-            raise ValueError(
-                "The number of columns of R must be equal to the number of coefficients."
-            )
-
-        # If q is None, default to a vector of zeros
-        if q is None:
-            q = np.zeros(R.shape[0])
-        else:
-            if not isinstance(q, (int, float, np.ndarray)):
-                raise ValueError("q must be a numeric scalar or array.")
-            if isinstance(q, np.ndarray):
-                if q.ndim != 1:
-                    raise ValueError("q must be a one-dimensional array or a scalar.")
-                if q.shape[0] != R.shape[0]:
-                    raise ValueError("q must have the same number of rows as R.")
-
-        n_restriction = R.shape[0]
-        self._dfn = n_restriction
+        W, self._dfn = _wald_statistic(
+            beta_hat=self._beta_hat,
+            vcov=self._vcov,
+            R=R,
+            q=q,
+        )
 
         if self._is_clustered:
             self._dfd = np.min(np.array(self._G)) - 1
         else:
             self._dfd = self._N - self._k - k_fe
 
-        bread = R @ self._beta_hat - q
-        meat = np.linalg.pinv(R @ self._vcov @ R.T)
-        W = bread.T @ meat @ bread
         self._wald_statistic = W
 
-        # Check if distribution is "F" and R is not identity matrix
-        # or q is not zero vector
-        if distribution == "F" and (
-            not np.array_equal(R, np.eye(self._k)) or not np.all(q == 0)
-        ):
+        # The F distribution is only used for the joint test that all
+        # coefficients are zero (R identity, q zero).
+        tests_all_coefs_zero = np.array_equal(R, np.eye(self._k)) and (
+            q is None or not np.any(q)
+        )
+        if distribution == "F" and not tests_all_coefs_zero:
             warnings.warn(
                 "Distribution changed to chi2, as R is not an identity matrix and q is not a zero vector."
             )

--- a/pyfixest/estimation/models/feols_.py
+++ b/pyfixest/estimation/models/feols_.py
@@ -1016,12 +1016,11 @@ class Feols(ResultAccessorMixin):
 
         self._wald_statistic = W
 
-        # The F distribution is only used for the joint test that all
-        # coefficients are zero (R identity, q zero).
-        tests_all_coefs_zero = np.array_equal(R, np.eye(self._k)) and (
-            q is None or not np.any(q)
-        )
-        if distribution == "F" and not tests_all_coefs_zero:
+        # Check if distribution is "F" and R is not identity matrix
+        # or q is not zero vector
+        if distribution == "F" and (
+            not np.array_equal(R, np.eye(self._k)) or not np.all(q == 0)
+        ):
             warnings.warn(
                 "Distribution changed to chi2, as R is not an identity matrix and q is not a zero vector."
             )

--- a/pyfixest/estimation/post_estimation/wald.py
+++ b/pyfixest/estimation/post_estimation/wald.py
@@ -1,0 +1,51 @@
+"""Shared utilities for Wald tests."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def _wald_statistic(
+    beta_hat: np.ndarray,
+    vcov: np.ndarray,
+    R: np.ndarray,
+    q: float | np.ndarray | None = None,
+) -> tuple[float, int]:
+    """Compute a Wald quadratic form and its numerator degrees of freedom."""
+    beta_hat = np.asarray(beta_hat, dtype=float)
+    vcov = np.asarray(vcov, dtype=float)
+    R = np.asarray(R, dtype=float)
+
+    if R.ndim == 1:
+        R = R.reshape((1, len(R)))
+
+    if R.ndim != 2:
+        raise ValueError("R must be a one- or two-dimensional array.")
+
+    if R.shape[1] != beta_hat.shape[0]:
+        raise ValueError(
+            "The number of columns of R must be equal to the number of coefficients."
+        )
+
+    if R.shape[0] == 0 or np.linalg.matrix_rank(R) != R.shape[0]:
+        raise ValueError("R must have full row rank.")
+
+    if q is None:
+        q_array = np.zeros(R.shape[0])
+    else:
+        try:
+            q_array = np.asarray(q, dtype=float)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("q must be a numeric scalar or array.") from exc
+
+        if q_array.ndim == 0:
+            q_array = np.full(R.shape[0], float(q_array))
+        elif q_array.ndim != 1:
+            raise ValueError("q must be a one-dimensional array or a scalar.")
+        elif q_array.shape[0] != R.shape[0]:
+            raise ValueError("q must have the same number of rows as R.")
+
+    bread = R @ beta_hat - q_array
+    meat = np.linalg.pinv(R @ vcov @ R.T)
+    wald_statistic = float(bread.T @ meat @ bread)
+    return wald_statistic, R.shape[0]

--- a/pyfixest/estimation/post_estimation/wald.py
+++ b/pyfixest/estimation/post_estimation/wald.py
@@ -5,6 +5,25 @@ from __future__ import annotations
 import numpy as np
 
 
+def _normalize_q(q: float | np.ndarray | None, n_restrictions: int) -> np.ndarray:
+    """Normalize the right-hand side of a Wald restriction."""
+    if q is None:
+        return np.zeros(n_restrictions)
+
+    q_array = np.asarray(q)
+    if q_array.dtype.kind not in {"i", "u", "f"}:
+        raise ValueError("q must be a numeric scalar or array.")
+    q_array = q_array.astype(float, copy=False)
+
+    if q_array.ndim == 0:
+        return np.full(n_restrictions, float(q_array))
+    if q_array.ndim != 1:
+        raise ValueError("q must be a one-dimensional array or a scalar.")
+    if q_array.shape[0] != n_restrictions:
+        raise ValueError("q must have the same number of rows as R.")
+    return q_array
+
+
 def _wald_statistic(
     beta_hat: np.ndarray,
     vcov: np.ndarray,
@@ -30,20 +49,7 @@ def _wald_statistic(
     if R.shape[0] == 0 or np.linalg.matrix_rank(R) != R.shape[0]:
         raise ValueError("R must have full row rank.")
 
-    if q is None:
-        q_array = np.zeros(R.shape[0])
-    else:
-        try:
-            q_array = np.asarray(q, dtype=float)
-        except (TypeError, ValueError) as exc:
-            raise ValueError("q must be a numeric scalar or array.") from exc
-
-        if q_array.ndim == 0:
-            q_array = np.full(R.shape[0], float(q_array))
-        elif q_array.ndim != 1:
-            raise ValueError("q must be a one-dimensional array or a scalar.")
-        elif q_array.shape[0] != R.shape[0]:
-            raise ValueError("q must have the same number of rows as R.")
+    q_array = _normalize_q(q, R.shape[0])
 
     bread = R @ beta_hat - q_array
     meat = np.linalg.pinv(R @ vcov @ R.T)

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -508,6 +508,14 @@ def test_wald_test_R_q_column_consistency():
         )
 
 
+def test_wald_test_rejects_rank_deficient_restrictions():
+    data = pf.get_data()
+    fit = feols("Y ~ X1 + X2", data)
+
+    with pytest.raises(ValueError, match="full row rank"):
+        fit.wald_test(R=np.array([[0, 1, 0], [0, 2, 0]]))
+
+
 def setup_feiv_instance():
     # Setup necessary data for Feiv
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -497,6 +497,9 @@ def test_wald_test_R_q_column_consistency():
     with pytest.raises(ValueError):
         fit.wald_test(R=np.array([[1, 0]]), q="invalid type q")
 
+    with pytest.raises(ValueError, match="q must be a numeric scalar or array"):
+        fit.wald_test(R=np.eye(2), q="0")
+
     # Test with q being a one-dimensional array or a scalar.
     with pytest.raises(ValueError):
         fit.wald_test(R=np.array([[1, 0], [0, 1]]), q=np.array([[0, 1]]))


### PR DESCRIPTION
- Delegate Wald test computation to the shared _wald_statistic function which centralizes R/q validation and the bread/meat/W calculation.
- Replace manual R reshaping with np.atleast_2d.
- Simplify F-vs-chi2 distribution check: only warn when R is not identity or q is nonzero, not for the all-coefficients-zero test.
- Add test for rank-deficient restriction rejection.

Relates to #1386.