### PR TITLE
Fix confidence interval coefficient ordering

### DIFF
--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -41,6 +41,10 @@ As previously announced, we removed:
 
 ### Bug Fixes
 
+- Fixes `confint()` when `keep` or `drop` requests coefficients in an order
+  different from the model order. Previously, intervals could be associated
+  with the wrong coefficient labels, including for simultaneous confidence
+  intervals.
 - `did2s()` now raises an informative error when some fixed effect levels cannot be
   estimated in the first stage regression (e.g. for always-treated units, which have
   no not-yet-treated observations), instead of failing later with an opaque

--- a/pyfixest/estimation/models/_result_accessor_mixin.py
+++ b/pyfixest/estimation/models/_result_accessor_mixin.py
@@ -286,8 +286,9 @@ class ResultAccessorMixin(TidyColumnAccessors):
         if not joint:
             crit_val = self._inference_dist.crit_val(alpha, self._df_t)
         else:
-            D_inv = 1 / self._se[coef_indices]
-            V = self._vcov[np.ix_(coef_indices, coef_indices)]
+            joint_indices = sorted(coef_indices)
+            D_inv = 1 / self._se[joint_indices]
+            V = self._vcov[np.ix_(joint_indices, joint_indices)]
             C_coefs = (D_inv * V).T * D_inv
             crit_val = simultaneous_crit_val(C_coefs, reps, alpha=alpha, seed=seed)
 

--- a/pyfixest/estimation/models/_result_accessor_mixin.py
+++ b/pyfixest/estimation/models/_result_accessor_mixin.py
@@ -10,7 +10,7 @@ from pyfixest.errors import EmptyVcovError
 
 if TYPE_CHECKING:
     from pyfixest.estimation.internals.families import InferenceDist
-from pyfixest.utils.dev_utils import _select_order_coefs
+from pyfixest.utils.dev_utils import _get_coef_indices
 from pyfixest.utils.utils import simultaneous_crit_val
 
 
@@ -279,40 +279,20 @@ class ResultAccessorMixin(TidyColumnAccessors):
         fit.confint(alpha=0.10, joint=True, reps=9999).head()
         ```
         """
-        if keep is None:
-            keep = []
-        if drop is None:
-            drop = []
-
-        tidy_df = self.tidy()
-        if keep or drop:
-            if isinstance(keep, str):
-                keep = [keep]
-            if isinstance(drop, str):
-                drop = [drop]
-            idxs = _select_order_coefs(tidy_df.index.tolist(), keep, drop, exact_match)
-            coefnames = tidy_df.loc[idxs, :].index.tolist()
-        else:
-            coefnames = self._coefnames
-
-        joint_indices = [i for i, x in enumerate(self._coefnames) if x in coefnames]
-        if not joint_indices:
-            raise ValueError("No coefficients match the keep/drop patterns.")
+        coefnames, coef_indices = _get_coef_indices(
+            self._coefnames, keep, drop, exact_match
+        )
 
         if not joint:
             crit_val = self._inference_dist.crit_val(alpha, self._df_t)
         else:
-            D_inv = 1 / self._se[joint_indices]
-            V = self._vcov[np.ix_(joint_indices, joint_indices)]
+            D_inv = 1 / self._se[coef_indices]
+            V = self._vcov[np.ix_(coef_indices, coef_indices)]
             C_coefs = (D_inv * V).T * D_inv
             crit_val = simultaneous_crit_val(C_coefs, reps, alpha=alpha, seed=seed)
 
-        ub = pd.Series(
-            self._beta_hat[joint_indices] + crit_val * self._se[joint_indices]
-        )
-        lb = pd.Series(
-            self._beta_hat[joint_indices] - crit_val * self._se[joint_indices]
-        )
+        ub = pd.Series(self._beta_hat[coef_indices] + crit_val * self._se[coef_indices])
+        lb = pd.Series(self._beta_hat[coef_indices] - crit_val * self._se[coef_indices])
 
         df = pd.DataFrame(
             {

--- a/pyfixest/estimation/models/_result_accessor_mixin.py
+++ b/pyfixest/estimation/models/_result_accessor_mixin.py
@@ -10,7 +10,7 @@ from pyfixest.errors import EmptyVcovError
 
 if TYPE_CHECKING:
     from pyfixest.estimation.internals.families import InferenceDist
-from pyfixest.utils.dev_utils import _get_coef_indices
+from pyfixest.utils.dev_utils import _select_coefnames_and_indices
 from pyfixest.utils.utils import simultaneous_crit_val
 
 
@@ -279,7 +279,7 @@ class ResultAccessorMixin(TidyColumnAccessors):
         fit.confint(alpha=0.10, joint=True, reps=9999).head()
         ```
         """
-        coefnames, coef_indices = _get_coef_indices(
+        coefnames, coef_indices = _select_coefnames_and_indices(
             self._coefnames, keep, drop, exact_match
         )
 

--- a/pyfixest/utils/dev_utils.py
+++ b/pyfixest/utils/dev_utils.py
@@ -104,6 +104,32 @@ def _select_order_coefs(
     return res
 
 
+def _get_coef_indices(
+    coefnames_all: list,
+    keep: list | str | None = None,
+    drop: list | str | None = None,
+    exact_match: bool | None = False,
+) -> tuple[list[str], list[int]]:
+    if keep is None:
+        keep = []
+    if drop is None:
+        drop = []
+
+    if keep or drop:
+        if isinstance(keep, str):
+            keep = [keep]
+        if isinstance(drop, str):
+            drop = [drop]
+        selected = _select_order_coefs(coefnames_all, keep, drop, bool(exact_match))
+    else:
+        selected = coefnames_all
+
+    indices = [coefnames_all.index(name) for name in selected]
+    if not indices:
+        raise ValueError("No coefficients match the keep/drop patterns.")
+    return selected, indices
+
+
 def docstring_from(func, custom_doc=""):
     """Copy the docstring of another function."""
 

--- a/pyfixest/utils/dev_utils.py
+++ b/pyfixest/utils/dev_utils.py
@@ -104,7 +104,7 @@ def _select_order_coefs(
     return res
 
 
-def _get_coef_indices(
+def _select_coefnames_and_indices(
     coefnames_all: list,
     keep: list | str | None = None,
     drop: list | str | None = None,

--- a/tests/test_confint.py
+++ b/tests/test_confint.py
@@ -78,3 +78,12 @@ def test_against_doubleml():
     pyfixest_res = m.confint(keep="X_.$", reps=10_000, joint=True)
 
     assert np.all(np.abs(dml_res.values - pyfixest_res.values) < 1e-2)
+
+
+def test_confint_preserves_keep_order():
+    fit = feols("Y ~ X1 + X2", get_data())
+    ci = fit.confint(keep=["X2", "X1"], joint=True, reps=1000, seed=42)
+    assert list(ci.index) == ["X2", "X1"]
+
+    ci2 = fit.confint(keep=["X2", "X1"])
+    assert list(ci2.index) == ["X2", "X1"]

--- a/tests/test_confint.py
+++ b/tests/test_confint.py
@@ -81,9 +81,18 @@ def test_against_doubleml():
 
 
 def test_confint_preserves_keep_order():
-    fit = feols("Y ~ X1 + X2", get_data())
-    ci = fit.confint(keep=["X2", "X1"], joint=True, reps=1000, seed=42)
-    assert list(ci.index) == ["X2", "X1"]
+    fit = feols("Y ~ X1 + X2 + C(f1)", get_data())
+    model_order = fit.coef().index[:5].tolist()
+    keep_order = model_order[::-1]
 
-    ci2 = fit.confint(keep=["X2", "X1"])
-    assert list(ci2.index) == ["X2", "X1"]
+    pointwise = fit.confint(keep=keep_order, exact_match=True)
+    expected = fit.confint().loc[keep_order]
+    pd.testing.assert_frame_equal(pointwise, expected)
+
+    joint_model_order = fit.confint(
+        keep=model_order, exact_match=True, joint=True, reps=1000, seed=42
+    )
+    joint_keep_order = fit.confint(
+        keep=keep_order, exact_match=True, joint=True, reps=1000, seed=42
+    )
+    pd.testing.assert_frame_equal(joint_keep_order, joint_model_order.loc[keep_order])


### PR DESCRIPTION
Summary:
- preserve requested coefficient order without relabeling confidence intervals
- keep seeded joint confidence intervals invariant to presentation order
- add value-level regression coverage and a changelog entry

Validation:
- targeted confidence-interval and error tests: 47 passed, 2 skipped
- ruff format, ruff check, and mypy passed
- full quick suite could not start locally because Pixi panicked in macOS system configuration