### PR TITLE
add inference_type arg to confint, tidy, deprecate joint arg to confint

### DIFF
--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -17,6 +17,17 @@ fit3 = pf.feols("Y ~ X1 + X2 | f1", data = df)
 
 ## PyFixest 0.70.0 (In Development)
 
+### Inference Types
+
+- `tidy()` and `confint()` gain an `inference_type` argument. For `confint()` it
+  takes `"regular"` (pointwise, the default) or `"simult"` (simultaneous / joint
+  intervals). The `confint(joint=True)` argument is deprecated: it still works
+  but now emits a `FutureWarning` and maps to `inference_type="simult"`.
+
+  ```python
+  fit.confint(inference_type="simult")   # replaces fit.confint(joint=True)
+  ```
+
 ### GLM API and Behavior
 
 - `feglm()` now accepts `weights`, `weights_type`, and `offset`, and supports

--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -19,10 +19,11 @@ fit3 = pf.feols("Y ~ X1 + X2 | f1", data = df)
 
 ### Inference Types
 
-- `tidy()` and `confint()` gain an `inference_type` argument. For `confint()` it
-  takes `"regular"` (pointwise, the default) or `"simult"` (simultaneous / joint
-  intervals). The `confint(joint=True)` argument is deprecated: it still works
-  but now emits a `FutureWarning` and maps to `inference_type="simult"`.
+- `tidy()`, `confint()`, and `summary()` gain an `inference_type` argument. For
+  `confint()` it takes `"regular"` (pointwise, the default) or `"simult"`
+  (simultaneous / joint intervals). The `confint(joint=True)` argument is
+  deprecated: it still works but now emits a `FutureWarning` and maps to
+  `inference_type="simult"`.
 
   ```python
   fit.confint(inference_type="simult")   # replaces fit.confint(joint=True)

--- a/docs/quickstart.qmd
+++ b/docs/quickstart.qmd
@@ -306,7 +306,7 @@ Simultaneous confidence bands for a vector of parameters can be computed via the
 
 ```{python}
 fit_ci = pf.feols("Y ~ X1+ C(f1)", data=data)
-fit_ci.confint(joint=True).head()
+fit_ci.confint(inference_type="simult").head()
 ```
 
 # Panel Data Example: Causal Inference for the Brave and True

--- a/pyfixest/estimation/internals/literals.py
+++ b/pyfixest/estimation/internals/literals.py
@@ -14,6 +14,7 @@ SolverOptions = Literal[
 PredictionErrorOptions = Literal["prediction"]
 QuantregMethodOptions = Literal["fn", "pfn"]
 QuantregMultiOptions = Literal["cfm1", "cfm2"]
+InferenceType = Literal["regular", "simult", "savi"]
 
 
 def _validate_literal_argument(arg: Any, literal: Any) -> None:

--- a/pyfixest/estimation/models/_result_accessor_mixin.py
+++ b/pyfixest/estimation/models/_result_accessor_mixin.py
@@ -10,6 +10,10 @@ from pyfixest.errors import EmptyVcovError
 
 if TYPE_CHECKING:
     from pyfixest.estimation.internals.families import InferenceDist
+from pyfixest.estimation.internals.literals import (
+    InferenceType,
+    _validate_literal_argument,
+)
 from pyfixest.utils.dev_utils import _select_coefnames_and_indices
 from pyfixest.utils.utils import simultaneous_crit_val
 
@@ -165,6 +169,7 @@ class ResultAccessorMixin(TidyColumnAccessors):
     def tidy(
         self,
         alpha: float = 0.05,
+        inference_type: InferenceType = "regular",
     ) -> pd.DataFrame:
         """
         Tidy model outputs.
@@ -177,6 +182,9 @@ class ResultAccessorMixin(TidyColumnAccessors):
         alpha: Optional[float]
             The significance level for the confidence intervals. If None,
             computes a 95% confidence interval (`alpha = 0.05`).
+        inference_type : {"regular"}, optional
+            Type of coefficient-wise inference to report. Only `"regular"` is
+            currently available. Defaults to `"regular"`.
 
         Returns
         -------
@@ -184,6 +192,17 @@ class ResultAccessorMixin(TidyColumnAccessors):
             A tidy pd.DataFrame containing the regression results, including point
             estimates, standard errors, t-statistics, and p-values.
         """
+        inference_type = self._normalize_inference_type(inference_type)
+        if inference_type == "simult":
+            raise ValueError(
+                "tidy() does not support inference_type='simult'. Use "
+                "confint(inference_type='simult') for simultaneous intervals."
+            )
+        if inference_type == "savi":
+            raise NotImplementedError(
+                "inference_type='savi' is not available in tidy() yet."
+            )
+
         ub, lb = 1 - alpha / 2, alpha / 2
         try:
             self.get_inference(alpha=alpha)
@@ -210,6 +229,27 @@ class ResultAccessorMixin(TidyColumnAccessors):
             data["Sample"] = sample
         return pd.DataFrame(data).set_index("Coefficient")
 
+    def _normalize_inference_type(
+        self, inference_type: InferenceType, joint: bool = False
+    ) -> InferenceType:
+        """Validate `inference_type` and fold the deprecated `joint` flag into it."""
+        _validate_literal_argument(inference_type, InferenceType)
+
+        if joint:
+            warnings.warn(
+                "joint=True is deprecated. Use inference_type='simult' instead.",
+                FutureWarning,
+                stacklevel=3,
+            )
+            if inference_type not in ("regular", "simult"):
+                raise ValueError(
+                    "joint=True cannot be combined with "
+                    f"inference_type={inference_type!r}."
+                )
+            inference_type = "simult"
+
+        return inference_type
+
     def confint(
         self,
         alpha: float = 0.05,
@@ -219,6 +259,8 @@ class ResultAccessorMixin(TidyColumnAccessors):
         joint: bool = False,
         seed: int | None = None,
         reps: int = 10_000,
+        *,
+        inference_type: InferenceType = "regular",
     ) -> pd.DataFrame:
         r"""
         Fitted model confidence intervals.
@@ -229,8 +271,9 @@ class ResultAccessorMixin(TidyColumnAccessors):
             The significance level for confidence intervals. Defaults to 0.05.
             keep: str or list of str, optional
         joint : bool, optional
-            Whether to compute simultaneous confidence interval for joint null
-            of parameters selected by `keep` and `drop`. Defaults to False. See
+            Deprecated. Use `inference_type="simult"` instead. Whether to
+            compute simultaneous confidence intervals for the joint null of the
+            parameters selected by `keep` and `drop`. Defaults to False. See
             https://www.causalml-book.org/assets/chapters/CausalML_chap_4.pdf,
             Remark 4.4.1 for details.
         keep: str or list of str, optional
@@ -254,8 +297,13 @@ class ResultAccessorMixin(TidyColumnAccessors):
             The number of bootstrap iterations to run for joint confidence intervals.
             Defaults to 10_000. Only used if `joint` is True.
         seed : int, optional
-            The seed for the random number generator. Defaults to None. Only used if
-            `joint` is True.
+            The seed for the random number generator. Defaults to None. Only used
+            when `inference_type="simult"`.
+        inference_type : {"regular", "simult"}, optional
+            Type of confidence interval to compute. "regular" returns pointwise
+            intervals; "simult" returns simultaneous (joint) intervals for the
+            coefficients selected by `keep` and `drop`. Defaults to "regular".
+            Supersedes the deprecated `joint` argument. Keyword-only.
 
         Returns
         -------
@@ -276,14 +324,20 @@ class ResultAccessorMixin(TidyColumnAccessors):
         data = get_data()
         fit = feols("Y ~ C(f1)", data=data)
         fit.confint(alpha=0.10).head()
-        fit.confint(alpha=0.10, joint=True, reps=9999).head()
+        fit.confint(alpha=0.10, inference_type="simult", reps=9999).head()
         ```
         """
+        inference_type = self._normalize_inference_type(inference_type, joint=joint)
+        if inference_type == "savi":
+            raise NotImplementedError(
+                "inference_type='savi' is not available in confint() yet."
+            )
+
         coefnames, coef_indices = _select_coefnames_and_indices(
             self._coefnames, keep, drop, exact_match
         )
 
-        if not joint:
+        if inference_type == "regular":
             crit_val = self._inference_dist.crit_val(alpha, self._df_t)
         else:
             joint_indices = sorted(coef_indices)

--- a/pyfixest/report/summarize.py
+++ b/pyfixest/report/summarize.py
@@ -5,6 +5,7 @@ import numpy as np
 import pandas as pd
 
 from pyfixest.estimation.FixestMulti_ import FixestMulti
+from pyfixest.estimation.internals.literals import InferenceType
 from pyfixest.estimation.models.feiv_ import Feiv
 from pyfixest.estimation.models.feols_ import Feols
 from pyfixest.estimation.models.fepois_ import Fepois
@@ -278,7 +279,11 @@ def etable(
     return None
 
 
-def summary(models: ModelInputType, digits: int = 3) -> None:
+def summary(
+    models: ModelInputType,
+    digits: int = 3,
+    inference_type: InferenceType = "regular",
+) -> None:
     """
     Print a summary of estimation results for each estimated model.
 
@@ -292,6 +297,9 @@ def summary(models: ModelInputType, digits: int = 3) -> None:
             Feols, Fepois & Feiv models.
     digits : int, optional
         The number of decimal places to round the summary statistics to. Default is 3.
+    inference_type : {"regular"}, optional
+        Type of coefficient-wise inference to report, handled the same way as in
+        `tidy()`. Only `"regular"` is currently available. Defaults to `"regular"`.
 
     Returns
     -------
@@ -316,7 +324,7 @@ def summary(models: ModelInputType, digits: int = 3) -> None:
     for fxst in list(models):
         depvar = fxst._depvar
 
-        df = fxst.tidy().round(digits)
+        df = fxst.tidy(inference_type=inference_type).round(digits)
 
         estimation_method = _get_estimation_method_name(fxst)
         print("###")

--- a/pyfixest/report/visualize.py
+++ b/pyfixest/report/visualize.py
@@ -867,7 +867,7 @@ def _get_model_df(
 
     if joint in ["both", True]:
         lb, ub = f"{alpha / 2 * 100:.1f}%", f"{(1 - alpha / 2) * 100:.1f}%"
-        df_joint = fxst.confint(joint=True, alpha=alpha, seed=seed)
+        df_joint = fxst.confint(inference_type="simult", alpha=alpha, seed=seed)
         df_joint.reset_index(inplace=True)
         df_joint = df_joint.rename(columns={"index": "Coefficient"})
         df_joint_full = (

--- a/tests/test_confint.py
+++ b/tests/test_confint.py
@@ -1,4 +1,5 @@
 import sys
+import warnings
 
 import numpy as np
 import pandas as pd
@@ -29,21 +30,39 @@ def test_confint():
 
     # simultaneous CIs: simultaneous CIs always wider
     for _ in range(5):
-        assert np.all(
-            confint.loc[:, "2.5%"] > fit.confint(alpha=0.05, joint=True).loc[:, "2.5%"]
-        )
-        assert np.all(
-            confint.loc[:, "97.5%"]
-            < fit.confint(alpha=0.05, joint=True).loc[:, "97.5%"]
-        )
+        simult = fit.confint(alpha=0.05, inference_type="simult")
+        assert np.all(confint.loc[:, "2.5%"] > simult.loc[:, "2.5%"])
+        assert np.all(confint.loc[:, "97.5%"] < simult.loc[:, "97.5%"])
 
     # test seeds
-    confint1 = fit.confint(joint=True, seed=1)
-    confint2 = fit.confint(joint=True, seed=1)
-    confint3 = fit.confint(joint=True, seed=2)
+    confint1 = fit.confint(inference_type="simult", seed=1)
+    confint2 = fit.confint(inference_type="simult", seed=1)
+    confint3 = fit.confint(inference_type="simult", seed=2)
 
     assert np.all(confint1 == confint2)
     assert np.all(confint1 != confint3)
+
+
+def test_confint_joint_maps_to_simult():
+    """The deprecated `joint=True` path matches `inference_type="simult"`."""
+    fit = feols("Y ~ X1 + X2 + C(f1)", data=get_data())
+
+    with pytest.warns(FutureWarning, match="joint.*deprecated"):
+        deprecated = fit.confint(joint=True, seed=1)
+    simult = fit.confint(inference_type="simult", seed=1)
+    pd.testing.assert_frame_equal(deprecated, simult)
+
+    # The new spellings emit no FutureWarning.
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", FutureWarning)
+        fit.confint(inference_type="simult", seed=1)
+        fit.confint(inference_type="regular")
+
+
+def test_tidy_inference_type_regular():
+    """`tidy(inference_type="regular")` matches the default `tidy()` output."""
+    fit = feols("Y ~ X1 + X2 + C(f1)", data=get_data())
+    pd.testing.assert_frame_equal(fit.tidy(), fit.tidy(inference_type="regular"))
 
 
 @pytest.mark.skipif(sys.version_info >= (3, 12), reason="requires python3.11 or lower.")
@@ -75,7 +94,7 @@ def test_against_doubleml():
         df,
         vcov="hetero",
     )
-    pyfixest_res = m.confint(keep="X_.$", reps=10_000, joint=True)
+    pyfixest_res = m.confint(keep="X_.$", reps=10_000, inference_type="simult")
 
     assert np.all(np.abs(dml_res.values - pyfixest_res.values) < 1e-2)
 
@@ -90,9 +109,9 @@ def test_confint_preserves_keep_order():
     pd.testing.assert_frame_equal(pointwise, expected)
 
     joint_model_order = fit.confint(
-        keep=model_order, exact_match=True, joint=True, reps=1000, seed=42
+        keep=model_order, exact_match=True, inference_type="simult", reps=1000, seed=42
     )
     joint_keep_order = fit.confint(
-        keep=keep_order, exact_match=True, joint=True, reps=1000, seed=42
+        keep=keep_order, exact_match=True, inference_type="simult", reps=1000, seed=42
     )
     pd.testing.assert_frame_equal(joint_keep_order, joint_model_order.loc[keep_order])

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1118,3 +1118,32 @@ def test_did2s_unestimated_first_stage_fixef():
             treatment="treat",
             cluster="unit",
         )
+
+
+def test_inference_type_errors():
+    """Validate `inference_type` handling in `confint()` and `tidy()`."""
+    fit = feols("Y ~ X1 + X2 + C(f1)", data=get_data())
+
+    # Invalid values are rejected in both methods.
+    with pytest.raises(ValueError):
+        fit.confint(inference_type="bogus")
+    with pytest.raises(ValueError):
+        fit.tidy(inference_type="bogus")
+
+    # SAVI is reserved but not wired into confint()/tidy() yet.
+    with pytest.raises(NotImplementedError):
+        fit.confint(inference_type="savi")
+    with pytest.raises(NotImplementedError):
+        fit.tidy(inference_type="savi")
+
+    # Simultaneous inference is a confint()-only concept.
+    with pytest.raises(ValueError):
+        fit.tidy(inference_type="simult")
+
+    # joint=True is deprecated and warns...
+    with pytest.warns(FutureWarning, match="joint.*deprecated"):
+        fit.confint(joint=True)
+
+    # ...and cannot be combined with a conflicting inference_type.
+    with pytest.raises(ValueError):
+        fit.confint(joint=True, inference_type="savi")

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1121,24 +1121,30 @@ def test_did2s_unestimated_first_stage_fixef():
 
 
 def test_inference_type_errors():
-    """Validate `inference_type` handling in `confint()` and `tidy()`."""
+    """Validate `inference_type` handling in `confint()`, `tidy()`, and `summary()`."""
     fit = feols("Y ~ X1 + X2 + C(f1)", data=get_data())
 
-    # Invalid values are rejected in both methods.
+    # Invalid values are rejected everywhere.
     with pytest.raises(ValueError):
         fit.confint(inference_type="bogus")
     with pytest.raises(ValueError):
         fit.tidy(inference_type="bogus")
+    with pytest.raises(ValueError):
+        summary(fit, inference_type="bogus")
 
-    # SAVI is reserved but not wired into confint()/tidy() yet.
+    # SAVI is reserved but not wired up yet. summary() mirrors tidy().
     with pytest.raises(NotImplementedError):
         fit.confint(inference_type="savi")
     with pytest.raises(NotImplementedError):
         fit.tidy(inference_type="savi")
+    with pytest.raises(NotImplementedError):
+        summary(fit, inference_type="savi")
 
     # Simultaneous inference is a confint()-only concept.
     with pytest.raises(ValueError):
         fit.tidy(inference_type="simult")
+    with pytest.raises(ValueError):
+        summary(fit, inference_type="simult")
 
     # joint=True is deprecated and warns...
     with pytest.warns(FutureWarning, match="joint.*deprecated"):

--- a/tests/test_summarise.py
+++ b/tests/test_summarise.py
@@ -164,3 +164,16 @@ def test_etable_correct_output_type():
 
     typst_table = pf.etable(fit, type="typst")
     assert isinstance(typst_table, str)
+
+
+def test_summary_inference_type_regular(capsys):
+    """summary(inference_type='regular') matches the default summary output."""
+    fit = feols("Y ~ X1 + X2 | f1", data=get_data())
+
+    summary(fit)
+    default_out = capsys.readouterr().out
+    summary(fit, inference_type="regular")
+    regular_out = capsys.readouterr().out
+
+    assert regular_out
+    assert regular_out == default_out


### PR DESCRIPTION
Add an `inference_type` argument to `tidy`, `confint`, `summary`, deprecate the `joint` arg to `confint`. 