### PR TITLE
Security: Hardcoded local file system paths in R library configuration

### DIFF
--- a/pyfixest/utils/set_rpy2_path.py
+++ b/pyfixest/utils/set_rpy2_path.py
@@ -6,18 +6,15 @@ def update_r_paths():
     "Get current R library paths."
     current_r_paths = robjects.r(".libPaths()")
 
-    # Define your custom paths
-    custom_paths = robjects.StrVector(
+    # Combine current R paths with default system paths (avoiding duplicates)
+    default_paths = robjects.StrVector(
         [
-            "/home/runner/work/pyfixest/pyfixest/.pixi/envs/dev/lib/R/library",
             "/usr/local/lib/R/site-library",
             "/usr/lib/R/site-library",
             "/usr/lib/R/library",
         ]
     )
-
-    # Combine current R paths with custom paths (avoiding duplicates)
-    new_lib_paths = robjects.StrVector(list(set(custom_paths).union(current_r_paths)))
+    new_lib_paths = robjects.StrVector(list(set(default_paths).union(current_r_paths)))
 
     # Set the combined library paths in the R environment
     robjects.r[".libPaths"](new_lib_paths)


### PR DESCRIPTION
## Summary

Security: Hardcoded local file system paths in R library configuration

## Problem

**Severity**: `Low` | **File**: `pyfixest/utils/set_rpy2_path.py:L9`

The `pyfixest/utils/set_rpy2_path.py` file contains hardcoded paths to R libraries specific to a GitHub Actions runner environment (e.g., `/home/runner/work/pyfixest/pyfixest/.pixi/envs/dev/lib/R/library`). If this script is run in a different environment, it may fail or inadvertently alter the R library paths, potentially causing unexpected behavior or loading malicious R packages if those directories are writable.

## Solution

Remove hardcoded CI/CD specific paths from utility scripts or dynamically construct them based on environment variables. Ensure that R library paths are only modified in controlled testing environments.

## Changes

- `pyfixest/utils/set_rpy2_path.py` (modified)