### PR TITLE
Consolidate agent instructions and add house-style checks

### DIFF
--- a/.agents/align-pr.md
+++ b/.agents/align-pr.md
@@ -1,0 +1,157 @@
+# Workflow: align a contributor PR with house style
+
+Audit an existing PR against `AGENTS.md` and produce either a paste-ready
+review or a fixed-up local branch, so the maintainer does as little as
+possible. `.agents/feature-pr.md` is for *building* a change; this workflow is
+for *auditing and repairing* one that already exists. Read `AGENTS.md` first —
+it is the rulebook; this file is only the loop that applies it.
+
+Input: a PR number (given several, run the whole workflow per PR
+independently; never mix branches). Two modes, chosen per invocation:
+
+- **report** (default) — findings only: one markdown review the maintainer can
+  paste into GitHub. Post nothing yourself unless explicitly asked.
+- **fix** — apply the mechanical and structural fixes on a local branch
+  `align/pr-<n>` cut from the PR head; leave judgment calls as findings.
+
+Hard rules in both modes: never push anywhere, never force-push or rewrite the
+contributor's branch, never post comments or reviews, unless the maintainer
+explicitly asks for that step. `align/pr-<n>` is a local copy and is yours to
+rewrite.
+
+## Phase 0 — Intake (run once)
+
+1. `gh pr checkout <n>`; in fix mode branch off to `align/pr-<n>`. Record
+   `BASE_REF` and `MERGE_BASE` exactly as in `.agents/feature-pr.md` Phase 1.
+2. Staleness check: list files the PR touches that no longer exist on the base
+   (`git diff --name-only "$MERGE_BASE"` vs `git ls-tree -r --name-only
+   "$BASE_REF"`). A PR written against a pre-refactor tree (moved docs pages,
+   relocated modules) gets a finding naming the moved targets; in fix mode
+   attempt one rebase onto `BASE_REF` — conflicts beyond the trivial become a
+   finding, not a fight.
+3. Classify the change surface into the Phase 1 buckets of `feature-pr.md`
+   (feature logic / tests / docs / formatting churn / generated artifacts /
+   unrelated refactor) and identify the change type — post-estimation feature,
+   vcov type, API function, Rust kernel, estimation-time option. The type
+   selects the wiring checklist from AGENTS.md "Where new code goes".
+4. Check for overlapping open PRs (`gh pr list --search "<topic>"`). Duplicate
+   or complementary efforts (e.g. a NumPy implementation of a kernel another
+   PR is porting to Rust) are a maintainer question — suggest how they could
+   be joined (one PR's code often becomes the other's test reference), do not
+   resolve it yourself.
+
+## Phase 1 — Mechanical audit
+
+Run the linters on the changed files first (`ruff-format`, `ruff-check`,
+`mypy`; commands in AGENTS.md → "Commands") — do not hand-report what they
+already catch. Then run each detector below over the **added lines** of the
+diff (`git diff "$MERGE_BASE" -- <paths> | grep '^+'`). Every hit is a
+finding; in fix mode, apply the stated fix. These detectors exist because real
+PRs broke each rule — keep the table in sync with AGENTS.md when rules change.
+
+| AGENTS.md rule | Detect (added lines) | Fix |
+|---|---|---|
+| RNG via `default_rng` | `np\.random\.(seed\|randn\|normal\|uniform\|binomial\|choice)\(` | rewrite with `rng = np.random.default_rng(seed)`; one rng per test/DGP |
+| no test classes | `class Test` or `def setup_method` under `tests/` | flatten to module-level `test_*` functions + fixtures/`parametrize` |
+| no banner or narration comments | `# ?[-=~]{3,}` or comments restating the next line | delete; keep only constraint comments |
+| `{python}` examples, not doctests | `>>> ` inside `pyfixest/` docstrings | convert the Examples section to an executable ```{python} chunk |
+| no new numba paths | `import numba` outside `estimation/numba/` and `ritest.py` | structural finding → Phase 2 item 4 |
+| `DataFrameType` at the API boundary | `data: pd.DataFrame` in `estimation/api/` | `DataFrameType` + one `_narwhals_to_pandas` call at entry |
+| snake_case everywhere | camelCase identifiers or string defaults (`"mainVar"`) | rename |
+| package imports in tests | `spec_from_file_location` / `importlib.util` under `tests/` | import through the package; environment problems are fixed with `pixi run` |
+| rpy2 registration | new test file imports `rpy2` but is absent from `_rpy2_test_files` (`tests/conftest.py`) | add it, plus the right `against_r_*` marker |
+| no generated-file churn | diff touches `pixi.lock`, `Cargo.lock`, `docs/_freeze/**`, `coverage.xml`, `docs/reference/**` | drop from the branch |
+| `tests/data/` provenance | new file under `tests/data/` with no generator script in the diff | finding: request or write the `.do`/`.R`/`.py` generator |
+| public/private twin | public `f()` whose body is only `return _f(...)` with the same signature | merge into one function |
+
+## Phase 2 — Structural audit (placement and wiring)
+
+Walk the AGENTS.md "Where new code goes" checklist for the change type from
+Phase 0, item by item, and record every missing wiring point. The recurring
+gaps, in the order they bite:
+
+1. **Logic mass in a model class.** Count added lines in `models/*.py`.
+   Anything beyond validate-and-delegate (plus the docstring) moves to
+   `post_estimation/` or `internals/`; the method keeps only input checks and
+   the call.
+2. **vcov wiring.** A new vcov type needs all of: the `literals.py` entry,
+   `_check_vcov_input` / `_deparse_vcov_input`, a small `_vcov_<name>`
+   dispatch method, meat/bread math in `internals/vcov_utils.py` (or Rust),
+   ssc through `_make_ssc_kwargs`, and threading through `FixestMulti.vcov()`
+   (and quantreg where applicable). Ad-hoc `self._<name>_*` state scraped out
+   of `vcov_kwargs.get(...)` inside `Feols.vcov` is the tell that this
+   checklist was skipped.
+3. **API surface.** New function: export chain (`api/__init__.py`,
+   `estimation/__init__.py`, `pyfixest/__init__.py` — `__all__`,
+   `_lazy_imports`, `_direct_module_imports`), quartodoc `contents` in
+   `docs/_quarto.yml`, a changelog entry in `docs/changelog.qmd`, and a
+   signature whose order matches the siblings (`fml, data, vcov, …`).
+4. **Hot loops.** A per-observation or per-pair double loop in Python or
+   numba becomes a Rust kernel per the `src/nw.rs` template; the contributed
+   Python implementation is kept as the test reference, not the shipped path.
+   In fix mode this is usually the one structural rewrite worth doing; if it
+   exceeds the iteration budget, hand back a finding with the exact template
+   files instead.
+5. **Unsupported paths.** For each of: IV (`Feiv`), GLM/Poisson, quantreg,
+   weights (`aweights`/`fweights`), fixed effects, multiple estimation
+   (`FixestMulti`), `lean=True` / `store_data=False` — the feature either
+   supports it *and tests it*, or raises informatively
+   (`NotImplementedError`, `VcovTypeNotSupportedError`). Silent wrong numbers
+   on these paths are the number-one review concern; flag any path that is
+   neither tested nor blocked.
+
+## Phase 3 — Econometrics audit
+
+The correctness bar from AGENTS.md → "Testing", strongest gap first:
+
+1. **External reference.** At least one of: R via rpy2 (marked
+   `against_r_core`/`against_r_extended`), stored Stata/R output under
+   `tests/data/` with its generator, a brute-force reimplementation in the
+   test, a closed-form collapse onto an existing estimator, or a seeded Monte
+   Carlo size/coverage property. Shape checks and "SE is in a plausible
+   range" do not count. If R `fixest` itself supports the feature, a
+   comparison against it is the expected reference — its absence is always a
+   finding.
+2. **Tolerances.** Any `rtol`/`atol` at or looser than `1e-2`, or one loosened
+   relative to sibling tests, needs a written justification; absent one, flag
+   it — do not tighten blindly in fix mode, since the looseness may be hiding
+   a real discrepancy.
+3. **Cheap invariants.** vcov symmetric with positive diagonal, row-order
+   invariance, weights collapsing to unweighted at equal weights — present
+   where the feature makes them cheap.
+4. **Spot-check the math** against the paper cited in the docstring: kernel
+   weights, small-sample corrections, the IV projection
+   (`tXZ @ tZZinv @ meat @ tZZinv @ tZX`). If you cannot establish
+   correctness, say so explicitly in the report — never bless numbers you
+   could not verify, and never "fix" econometrics you are unsure about.
+
+## Phase 4 — Output
+
+**Report mode.** One markdown review per PR, findings ordered by severity:
+(1) wrong or unverifiable econometrics, (2) silently-wrong-number paths,
+(3) missing reference tests, (4) wiring/placement gaps, (5) mechanical style.
+Each finding: `file:line`, the AGENTS.md rule (quote its phrase), and the
+concrete fix. Close with **Questions for the maintainer** — naming choices,
+scope, duplicate PRs, default parameter values: decisions this workflow must
+not make alone. Contributors are volunteers: open with what the PR does well,
+and phrase findings against the written guide, not against the person.
+
+Ratchet (both modes): a finding you could not anchor to an AGENTS.md phrase is
+a gap in the guide — propose the AGENTS.md edit (and, if mechanically
+checkable, the Phase 1 table row or lint rule) alongside the review.
+
+**Fix mode.** On `align/pr-<n>`: apply Phase 1 fixes, then Phase 2, in
+batches; after each batch run the narrowest relevant tests plus the three lint
+hooks (max 3 red-green iterations per batch, then stop and downgrade the rest
+to findings). Finish with the commit-history rewrite from `feature-pr.md`
+Phase 5. Hand off: what was fixed, what remains as findings (including
+everything from Phase 3 you did not touch), the diff stat, and the ready
+branch name — pushing it or opening a PR is the maintainer's call.
+
+## Escalation
+
+Same triggers as `feature-pr.md`: the same failure three times, generated
+files in the way, or correctness that cannot be established → stop and
+report. In addition, always escalate rather than decide: user-facing naming,
+API shape changes, default values with econometric content (cutoffs,
+kernels, ssc), and whether overlapping PRs should be merged.

--- a/.agents/align-pr.md
+++ b/.agents/align-pr.md
@@ -42,27 +42,26 @@ rewrite.
 
 ## Phase 1 — Mechanical audit
 
-Run the linters on the changed files first (`ruff-format`, `ruff-check`,
-`mypy`; commands in AGENTS.md → "Commands") — do not hand-report what they
-already catch. Then run each detector below over the **added lines** of the
-diff (`git diff "$MERGE_BASE" -- <paths> | grep '^+'`). Every hit is a
-finding; in fix mode, apply the stated fix. These detectors exist because real
-PRs broke each rule — keep the table in sync with AGENTS.md when rules change.
+This phase is automated. Run, in order:
 
-| AGENTS.md rule | Detect (added lines) | Fix |
-|---|---|---|
-| RNG via `default_rng` | `np\.random\.(seed\|randn\|normal\|uniform\|binomial\|choice)\(` | rewrite with `rng = np.random.default_rng(seed)`; one rng per test/DGP |
-| no test classes | `class Test` or `def setup_method` under `tests/` | flatten to module-level `test_*` functions + fixtures/`parametrize` |
-| no banner or narration comments | `# ?[-=~]{3,}` or comments restating the next line | delete; keep only constraint comments |
-| `{python}` examples, not doctests | `>>> ` inside `pyfixest/` docstrings | convert the Examples section to an executable ```{python} chunk |
-| no new numba paths | `import numba` outside `estimation/numba/` and `ritest.py` | structural finding → Phase 2 item 4 |
-| `DataFrameType` at the API boundary | `data: pd.DataFrame` in `estimation/api/` | `DataFrameType` + one `_narwhals_to_pandas` call at entry |
-| snake_case everywhere | camelCase identifiers or string defaults (`"mainVar"`) | rename |
-| package imports in tests | `spec_from_file_location` / `importlib.util` under `tests/` | import through the package; environment problems are fixed with `pixi run` |
-| rpy2 registration | new test file imports `rpy2` but is absent from `_rpy2_test_files` (`tests/conftest.py`) | add it, plus the right `against_r_*` marker |
-| no generated-file churn | diff touches `pixi.lock`, `Cargo.lock`, `docs/_freeze/**`, `coverage.xml`, `docs/reference/**` | drop from the branch |
-| `tests/data/` provenance | new file under `tests/data/` with no generator script in the diff | finding: request or write the `.do`/`.R`/`.py` generator |
-| public/private twin | public `f()` whose body is only `return _f(...)` with the same signature | merge into one function |
+```bash
+pixi run -e lint prek run ruff-check --files <changed>   # RNG, style, typing
+pixi run python scripts/check_house_style.py <changed>   # tree checks
+pixi run python scripts/check_house_style.py --diff "$MERGE_BASE"
+```
+
+Every hit is a finding; in fix mode, apply it. Do not hand-report what these
+already catch, and do not re-derive their rules here — `check_house_style.py`
+is the detector list, and its module docstring says how to extend it. When a
+review finding turns out to be mechanically detectable, add a check there
+rather than a row here.
+
+Two mechanical rules have no detector yet — check them by eye:
+
+- **Narration comments.** Comments restating the next line; keep only the ones
+  stating a constraint the code cannot.
+- **Public/private twin.** A public `f()` whose body is only `return _f(...)`
+  with the same signature is one function too many.
 
 ## Phase 2 — Structural audit (placement and wiring)
 

--- a/.agents/align-pr.md
+++ b/.agents/align-pr.md
@@ -85,12 +85,9 @@ gaps, in the order they bite:
    `_lazy_imports`, `_direct_module_imports`), quartodoc `contents` in
    `docs/_quarto.yml`, a changelog entry in `docs/changelog.qmd`, and a
    signature whose order matches the siblings (`fml, data, vcov, …`).
-4. **Hot loops.** A per-observation or per-pair double loop in Python or
-   numba becomes a Rust kernel per the `src/nw.rs` template; the contributed
+4. **Hot loops.** A per-observation or per-pair double loop in Python or numba
+   becomes a Rust kernel in `src/`, alongside the existing ones; the contributed
    Python implementation is kept as the test reference, not the shipped path.
-   In fix mode this is usually the one structural rewrite worth doing; if it
-   exceeds the iteration budget, hand back a finding with the exact template
-   files instead.
 5. **Unsupported paths.** For each of: IV (`Feiv`), GLM/Poisson, quantreg,
    weights (`aweights`/`fweights`), fixed effects, multiple estimation
    (`FixestMulti`), `lean=True` / `store_data=False` — the feature either

--- a/.agents/feature-pr.md
+++ b/.agents/feature-pr.md
@@ -10,8 +10,10 @@ checklists, house style, and commands this workflow assumes. This file defines t
 process. Stay inside its bounded loops — no unbounded retrying.
 
 Inputs: a feature issue, or an existing PR to clean (`gh pr checkout <n>`,
-`gh pr diff <n>`). Always work on a feature branch; a pre-commit hook blocks
-commits to `master`.
+`gh pr diff <n>`). To *audit* a contributor PR against the guide — review
+findings or targeted repairs rather than building the feature out — use
+`.agents/align-pr.md` instead. Always work on a feature branch; a pre-commit
+hook blocks commits to `master`.
 
 ## Phase 1 — Discovery (run once)
 
@@ -158,8 +160,10 @@ for those. Review the full change against AGENTS.md:
    AGENTS.md → "Docs"): `pyfixest/__init__.py` (`__all__`, `_lazy_imports`); the
    Parameters docstring in each of `feols`/`fepois`/`feglm`/`quantreg` that gained
    an option (they do not share docstrings); quartodoc `contents` in
-   `docs/_quarto.yml` for a new class or function; and a `docs/how-to/*.qmd`
-   vignette (navbar entry in `_quarto.yml`) when the feature warrants a guide.
+   `docs/_quarto.yml` for a new class or function; a changelog entry in
+   `docs/changelog.qmd` under the "(In Development)" heading; and a
+   `docs/how-to/*.qmd` vignette (navbar entry in `_quarto.yml`) when the
+   feature warrants a guide.
 5. Run in order: targeted tests → the three lint hooks on changed files, one at
    a time — `pixi run -e lint prek run ruff-format --files <changed>`, then the
    same command with `ruff-check`, then with `mypy` → `pixi run test-py` if

--- a/.agents/feature-pr.md
+++ b/.agents/feature-pr.md
@@ -32,6 +32,14 @@ hook blocks commits to `master`.
    MERGE_BASE=$(git merge-base HEAD "$BASE_REF")
    ```
 
+   Then check staleness before planning: if `git rev-list --count
+   HEAD..$BASE_REF` is large (rule of thumb: more than ~15 commits) or
+   `git merge-tree --write-tree HEAD "$BASE_REF"` reports conflicts, record both
+   under a `## Staleness` heading in the plan first. A large distance with real
+   conflicts means the diff may need re-deriving after a merge, not just
+   re-running against a stale base — say so up front rather than discovering it
+   at Phase 4.
+
 2. Collect the change surface. PR cleanup: `gh pr diff <n> --name-only` and the
    PR description. New feature: the issue plus the subsystems you expect to
    touch.
@@ -81,7 +89,9 @@ the touched subsystem (e.g. changes to `vcov_utils.py` implicate
 `tests/test_predict_resid_fixef.py`). `--no-cov` skips the coverage report that
 pytest addopts otherwise force on every run; coverage comes with the broader
 runs in Phase 4. Fix what the traceback says. Three failed iterations on the
-same slice → Escalation.
+same slice → Escalation. Stop too when reality contradicts the plan — the
+analogue does not fit, a wiring point does not exist: present expected vs.
+found vs. options rather than silently re-planning.
 
 While implementing, enforce the AGENTS.md rules that PRs most often break:
 - Bulky logic never lands in model classes; the class method validates,
@@ -115,11 +125,8 @@ strongest reference available, in this order of preference:
 5. Seeded Monte Carlo properties (`np.random.default_rng(seed)`): empirical
    size near nominal under the null, power against a fixed alternative.
 
-Dependency rule for reference packages (full version: AGENTS.md → "Testing"):
-on conda-forge → add as a dependency and mark `against_r_core` (runs in CI);
-not on conda-forge → CRAN via `r_test_requirements.R` (repo root) with the test
-marked `against_r_extended` (runs locally only), or commit a generator script
-and hard-code its values into the test. Both are acceptable.
+For where a reference package goes and how to mark its test, see AGENTS.md →
+"Testing".
 
 Prefer a few heavily parametrized integration tests through the public API — the
 `tests/test_vs_fixest.py` shape (formulas × vcov × weights × ssc vs R `fixest`) —
@@ -134,9 +141,9 @@ is expected.
 
 ## Phase 4 — Review loop (at most 2 passes)
 
-Recompute or restore `BASE_REF` and `MERGE_BASE` from the Phase 1 plan if the
-shell session changed. Self-review everything that would ship, not only committed
-changes:
+Restore `BASE_REF` and `MERGE_BASE` from the Phase 1 plan if the shell session
+changed — later phases assume them. Self-review everything that would ship, not
+only committed changes:
 
 ```bash
 git status --short
@@ -172,8 +179,7 @@ for those. Review the full change against AGENTS.md:
 
 ## Phase 5 — Commit history rewrite (before handing off)
 
-Recompute or restore `MERGE_BASE` from the Phase 1 plan if the shell session
-changed. Inspect `git log --oneline "$MERGE_BASE"..HEAD`. If it is not a short
+Inspect `git log --oneline "$MERGE_BASE"..HEAD`. If it is not a short
 sequence of coherent commits, rewrite it. Interactive `git rebase -i` is
 unavailable in some agent sandboxes; the soft-reset recipe below works — but it
 collapses all committed work onto the index, so verify every precondition first:
@@ -213,12 +219,12 @@ Stop and report instead of widening the change when:
 The report names the exact files, the exact commands run, the observed output,
 and your best hypothesis — nothing vaguer.
 
-## Command reference
+One case is not a failure and is not reported this way: **the codebase changed
+shape under you** — a large upstream merge, a landed refactor touching the same
+files (see the Phase 1 staleness check). Re-enter Phase 1 with the new state,
+write a fresh plan, and confirm it before resuming Phase 2. This is a bigger
+jolt than the Phase 2 plan-mismatch stop, which is one slice's analogue not
+fitting; distinguish the two.
 
-All commands are defined once, in AGENTS.md → "Commands" — look them up there
-rather than copying them here. The only workflow-specific form is the Phase 2
-inner loop:
-
-```bash
-pixi run -e py312-r pytest <test files> -x -q --no-cov
-```
+Commands live in AGENTS.md → "Commands"; look them up there rather than copying
+them here.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,6 +43,14 @@ repos:
       - id: ruff-format
         types_or: [jupyter, pyi, python]
 
+  - repo: local
+    hooks:
+      - id: house-style
+        name: house style (AGENTS.md)
+        entry: python scripts/check_house_style.py
+        language: python
+        types: [python]
+
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v2.1.0
     hooks:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,10 +24,12 @@ not, point its rules/config file here instead of duplicating content.
 Edit workflows only in `.agents/`.
 
 This guide is maintained by ratchet: when maintainer feedback states a
-preference this file does not encode (or contradicts), update AGENTS.md — and
-the Phase 1 table in `.agents/align-pr.md` if the rule is mechanically
-checkable — as part of the same change. Prefer a lint rule over prose where
-one exists.
+preference this file does not encode (or contradicts), encode it as part of the
+same change. **Prefer a check over prose.** If the rule is mechanically
+detectable it belongs in a ruff rule or in `scripts/check_house_style.py`, and
+then it does *not* also belong here — a rule stated in two places drifts. This
+file stays under ~350 lines; when it grows past that, something in it has
+become checkable and should move.
 
 ## Repo map
 
@@ -328,6 +330,7 @@ pixi run -e lint prek run ruff-format --files <changed files>
 pixi run -e lint prek run ruff-check  --files <changed files>
 pixi run -e lint prek run mypy       --files <changed files>
 pixi run lint                                      # all hooks, all files
+pixi run check-style                               # house-style checks over the branch diff
 
 pixi run docs-render                               # full docs (runs quartodoc docs-build first)
 pixi task list                                     # everything else

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,13 +11,23 @@ Two rules beat everything else:
 2. **Mirror the nearest existing implementation.** Almost every kind of change has
    an in-repo precedent. Find it and copy its structure before writing new code.
 
-For the end-to-end workflow (implement a feature, clean up a contributor PR),
-follow **`.agents/feature-pr.md`**. This file is the tool-neutral entry point:
-Claude Code (via `CLAUDE.md`), Codex, and OpenCode read `AGENTS.md` natively;
-if a tool in your setup does not, point its rules/config file here instead of
-duplicating content. `CLAUDE.md` is a thin redirect (`@AGENTS.md`) and is
-committed to the repo.
-Edit the workflow only in `.agents/feature-pr.md`.
+Two workflows live in `.agents/`; pick by task:
+
+- **`.agents/feature-pr.md`** — implement a feature or build a PR end to end.
+- **`.agents/align-pr.md`** — audit an existing contributor PR against this
+  guide and either report the misalignments or fix them on a local branch.
+
+This file is the tool-neutral entry point: Claude Code (via `CLAUDE.md`),
+Codex, and OpenCode read `AGENTS.md` natively; if a tool in your setup does
+not, point its rules/config file here instead of duplicating content.
+`CLAUDE.md` is a thin redirect (`@AGENTS.md`) and is committed to the repo.
+Edit workflows only in `.agents/`.
+
+This guide is maintained by ratchet: when maintainer feedback states a
+preference this file does not encode (or contradicts), update AGENTS.md — and
+the Phase 1 table in `.agents/align-pr.md` if the rule is mechanically
+checkable — as part of the same change. Prefer a lint rule over prose where
+one exists.
 
 ## Repo map
 
@@ -94,6 +104,8 @@ the paper should recognize it in the code:
   has one. Matrix products use the `t` prefix for transpose: `tZX` is Z'X,
   `tZZinv` is (Z'Z)^-1. Cite the paper (with a link) in the docstring of the
   function that implements it, as `Feols.decompose` does for Gelbach (2016).
+  User-facing names spell out what they do even at the cost of length
+  (`dfm_heterogeneity_test`, not `dfm_test`).
 - Methods orchestrate; numbers happen in functions. A model method validates
   inputs, unpacks `self._` state into locals, calls a standalone module-level
   function that operates on arrays, and assigns the results back to `self._`
@@ -111,13 +123,18 @@ the paper should recognize it in the code:
   drop_multicol_vars → wls_transform`, each step a small named unit. Sanctioned
   exceptions to "short": a single solver iteration loop (IRLS, LSMR,
   Frisch–Newton — splitting it hurts readability and `torch.compile`) and
-  validation-heavy user-facing methods. Split logic, not loops.
+  validation-heavy user-facing methods. Split logic, not loops. The inverse
+  also holds: a public function that only forwards to a same-signature private
+  `_twin` is one function too many.
 - Performance-critical code — per-observation or per-cluster hot loops that
   NumPy cannot vectorize — is written and optimized in Rust under `src/` (the
   demean, CRV1-meat, and HAC-meat kernels are the pattern), not micro-optimized
   in Python. Everything else stays plain, readable NumPy: do not trade clarity
   for speed outside a measured hot loop, and keep a NumPy reference
-  implementation around for testing the kernel.
+  implementation around for testing the kernel. numba appears only in the
+  optional demean backend (`estimation/numba/`) and `ritest`; new features do
+  not add numba paths — a contributed numba kernel becomes a Rust kernel, with
+  the plain-NumPy version kept as the test reference.
 
 Naming and layout:
 - One public function per `api/` module; model-class modules end in `_`
@@ -135,12 +152,16 @@ Signatures and typing:
 - In docstring Parameters sections, spell types as in the signature
   (`str | None`, not `Optional[str]`). Older docstrings mix spellings — don't
   copy them.
+- Public estimation API: `fml` first, `data` second, typed `DataFrameType`
+  (accepts pandas/polars/duckdb) and converted once at the boundary via
+  `_narwhals_to_pandas` — never `pd.DataFrame` in an `api/` signature.
 - mypy runs on `pyfixest/` only; `NDArray[np.float64]` in the `.pyi` stubs.
 
 Docstrings (ruff enforces the NumPy convention):
 - Required on public functions/methods/classes; not required in `tests/`.
 - User-facing API docstrings carry full Parameters/Returns and an Examples
   section with executable ```{python} chunks — quartodoc renders and runs them.
+  Never doctest-style `>>>` examples.
 - Cross-link classes as `[Feols](/reference/estimation.models.feols_.Feols.qmd)`
   and vignettes as `[guide](/tutorials/standard-errors.qmd)` — always
   root-relative with a `.qmd` extension. A few older docstrings use relative
@@ -159,7 +180,11 @@ Errors, warnings, optional dependencies:
   (see `post_estimation/ritest.py`).
 
 Numerics and data:
-- RNG is always `np.random.default_rng(seed)`; never global seeding.
+- RNG is always `np.random.default_rng(seed)`; never `np.random.seed` or the
+  legacy global `np.random.*` samplers — in library code, tests, and docs
+  alike. ruff `NPY002` enforces this; the files grandfathered in
+  `pyproject.toml` per-file-ignores keep their legacy streams because stored
+  references depend on the exact draws — do not extend that list.
 - Never mutate user input data. `copy_data=False` is the only sanctioned
   exception, and its side effects are spelled out in the docstring.
 - `store_data=False` and `lean=True` strip attributes
@@ -196,16 +221,23 @@ note in `tests/conftest.py`, the lazy-numba note in `ritest.py`) — no narratio
   to the module-level list or a case to the matrix — rather than writing a new
   test function. `test_errors.py`'s one-function-per-error style predates this
   rule; don't copy it.
-- Style: module-level formula lists fed to `pytest.mark.parametrize`; seeded
-  DGP fixtures (module-scoped when expensive); explicit `rtol`/`atol` constants
-  at the top of the file with a comment justifying them.
+- Style: module-level `test_*` functions — no test classes, no `setup_method`,
+  no `# === section ===` banner comments; shared setup is a seeded DGP fixture
+  (module-scoped when expensive). Module-level formula lists fed to
+  `pytest.mark.parametrize`; explicit `rtol`/`atol` constants at the top of the
+  file with a comment justifying them. Import through the package
+  (`import pyfixest as pf`), never via `importlib` file loading — if the Rust
+  extension won't import, fix the environment (`pixi run`), not the import.
 - The bar for new econometrics is higher than "runs and has the right shape":
   exact known-value or brute-force cross-checks, edge cases (singleton
   clusters, collinearity, tiny samples), invalid-input tests, and at least one
   external reference — R `fixest`/`sandwich` via rpy2, stored Stata output
-  committed under `tests/data/` (with the `.do` script), or a simulation
-  property (empirical size/coverage). Code adapted from elsewhere gets a
-  provenance and license note in its docstring (see `tests/test_ccv.py`).
+  committed under `tests/data/`, or a simulation property (empirical
+  size/coverage). Every file under `tests/data/` ships with the script that
+  generated it (`.do`, `.R`, or `.py`) in the same directory; hard-coded
+  reference numbers in a test cite their generator the same way. Code adapted
+  from elsewhere gets a provenance and license note in its docstring (see
+  `tests/test_ccv.py`).
 - Reference packages and dependencies: if the reference implementation is on
   conda-forge, add it as a dependency (R packages → `[tool.pixi.feature.r.dependencies]`
   in `pyproject.toml`, test marked `against_r_core`) so CI runs the comparison
@@ -237,6 +269,9 @@ incomplete change. What to touch depends on the surface:
   feature only widens one (a new vcov type → the standard-errors guide,
   `docs/tutorials/standard-errors.qmd`). The Conley and decomposition features
   are the model.
+- Every user-facing change adds an entry to `docs/changelog.qmd` under the
+  current "(In Development)" release heading, in the style of the entries
+  already there.
 - Never hand-edit `docs/reference/**` — it is generated by quartodoc and
   gitignored. Reference display names are shortened by a custom renderer
   (`docs/_renderer.py`); the `docs-build` task runs quartodoc from `docs/` so it

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,17 @@ Two rules beat everything else:
 2. **Mirror the nearest existing implementation.** Almost every kind of change has
    an in-repo precedent. Find it and copy its structure before writing new code.
 
+**Known-stale precedents — do not mirror these.** Some rules below are newer
+than parts of the codebase. Where they disagree, the rule wins and the old code
+is a cleanup target, not a template:
+
+| Do not copy | Do this instead |
+|---|---|
+| `Literal` aliases in `models/feols_.py`, `internals/vcov_.py`, `demeaners.py`, `core/demean.py` (`prediction_type` duplicates `PredictionType`) | new aliases go in `internals/literals.py`, validated with `_validate_literal_argument` |
+| `assert` for input validation in `_check_vcov_input` | raise `ValueError` listing the allowed values |
+| `_support_*` flags | spell new ones `_supports_*` |
+| `test_errors.py`'s one-function-per-error style | extend an existing parametrized matrix |
+
 Two workflows live in `.agents/`; pick by task:
 
 - **`.agents/feature-pr.md`** — implement a feature or build a PR end to end.
@@ -28,8 +39,9 @@ preference this file does not encode (or contradicts), encode it as part of the
 same change. **Prefer a check over prose.** If the rule is mechanically
 detectable it belongs in a ruff rule or in `scripts/check_house_style.py`, and
 then it does *not* also belong here — a rule stated in two places drifts. This
-file stays under ~350 lines; when it grows past that, something in it has
-become checkable and should move.
+file stays at roughly its current length: adding a rule means deleting one,
+compressing one, or moving one to a check. It is read in full at the start of
+every session, so length is a running cost.
 
 ## Repo map
 
@@ -113,11 +125,20 @@ the paper should recognize it in the code:
   function that operates on arrays, and assigns the results back to `self._`
   attributes. The numerical function never touches `self` — that seam is what
   makes it testable against a reference. `Feols.get_fit` →
-  `internals/fit_.fit_ols` is the template.
+  `internals/fit_.fit_ols` is the template. As a rule of thumb, more than ~30
+  added lines in `estimation/models/` means the code is in the wrong file.
+- A feature never adds an overridable hook method to the model classes.
+  Per-model behavior is selected by a `_supports_*` flag, or by passing the
+  variant to the function as an argument — defining `_do_x()` on `Feols` and
+  overriding it in `Feiv` and `Feglm` spreads one feature's numerics across
+  three files and puts them out of reach of a reference test.
 - Numerical functions return a small result dataclass (`OlsFit`, `IvFit`,
   `ClusterPrep`; frozen and slotted where possible) whose Attributes docstring
   states each array's shape — not a tuple, not a dict. Internal calls pass
   arguments by keyword: `fit_ols(X=self._X, Y=self._Y, solver=self._solver)`.
+  Every attribute a dataclass sets is declared as a field — `field(init=False)`
+  for ones computed later; assigning `self._foo` in a method without declaring
+  it hides state from readers and from mypy.
 - One function, one named task, kept short — most functions in the codebase are
   under ~30 code lines. If a function's name or docstring summary needs an
   "and", split it. The fit pipeline is the model: `prepare_model_matrix →
@@ -133,10 +154,9 @@ the paper should recognize it in the code:
   demean, CRV1-meat, and HAC-meat kernels are the pattern), not micro-optimized
   in Python. Everything else stays plain, readable NumPy: do not trade clarity
   for speed outside a measured hot loop, and keep a NumPy reference
-  implementation around for testing the kernel. numba appears only in the
-  optional demean backend (`estimation/numba/`) and `ritest`; new features do
-  not add numba paths — a contributed numba kernel becomes a Rust kernel, with
-  the plain-NumPy version kept as the test reference.
+  implementation around for testing the kernel. A contributed numba kernel
+  becomes a Rust kernel, with the plain-NumPy version kept as the test
+  reference.
 
 Naming and layout:
 - One public function per `api/` module; model-class modules end in `_`
@@ -156,14 +176,13 @@ Signatures and typing:
   copy them.
 - Public estimation API: `fml` first, `data` second, typed `DataFrameType`
   (accepts pandas/polars/duckdb) and converted once at the boundary via
-  `_narwhals_to_pandas` — never `pd.DataFrame` in an `api/` signature.
+  `_narwhals_to_pandas`.
 - mypy runs on `pyfixest/` only; `NDArray[np.float64]` in the `.pyi` stubs.
 
 Docstrings (ruff enforces the NumPy convention):
 - Required on public functions/methods/classes; not required in `tests/`.
 - User-facing API docstrings carry full Parameters/Returns and an Examples
   section with executable ```{python} chunks — quartodoc renders and runs them.
-  Never doctest-style `>>>` examples.
 - Cross-link classes as `[Feols](/reference/estimation.models.feols_.Feols.qmd)`
   and vignettes as `[guide](/tutorials/standard-errors.qmd)` — always
   root-relative with a `.qmd` extension. A few older docstrings use relative
@@ -182,11 +201,9 @@ Errors, warnings, optional dependencies:
   (see `post_estimation/ritest.py`).
 
 Numerics and data:
-- RNG is always `np.random.default_rng(seed)`; never `np.random.seed` or the
-  legacy global `np.random.*` samplers — in library code, tests, and docs
-  alike. ruff `NPY002` enforces this; the files grandfathered in
-  `pyproject.toml` per-file-ignores keep their legacy streams because stored
-  references depend on the exact draws — do not extend that list.
+- RNG is always `np.random.default_rng(seed)` — one generator per test or DGP.
+  ruff `NPY002` enforces this; do not extend its grandfather list in
+  `pyproject.toml`.
 - Never mutate user input data. `copy_data=False` is the only sanctioned
   exception, and its side effects are spelled out in the docstring.
 - `store_data=False` and `lean=True` strip attributes
@@ -221,15 +238,15 @@ note in `tests/conftest.py`, the lazy-numba note in `ritest.py`) — no narratio
   getters.
 - When a change fits an existing parametrized matrix, extend it — add a formula
   to the module-level list or a case to the matrix — rather than writing a new
-  test function. `test_errors.py`'s one-function-per-error style predates this
-  rule; don't copy it.
-- Style: module-level `test_*` functions — no test classes, no `setup_method`,
-  no `# === section ===` banner comments; shared setup is a seeded DGP fixture
-  (module-scoped when expensive). Module-level formula lists fed to
-  `pytest.mark.parametrize`; explicit `rtol`/`atol` constants at the top of the
-  file with a comment justifying them. Import through the package
-  (`import pyfixest as pf`), never via `importlib` file loading — if the Rust
-  extension won't import, fix the environment (`pixi run`), not the import.
+  test function.
+- At least one test per feature calls `feols`/`fepois`/`feglm`/`quantreg` and
+  drives the feature through it. The wiring *is* the feature: a module tested
+  only in isolation can ship with a public entry point that raises. Where the PR
+  description shows a usage example, that exact call is a test.
+- Style: module-level `test_*` functions, no banner comments; shared setup is a
+  seeded DGP fixture (module-scoped when expensive). Module-level formula lists
+  fed to `pytest.mark.parametrize`; explicit `rtol`/`atol` constants at the top
+  of the file with a comment justifying them.
 - The bar for new econometrics is higher than "runs and has the right shape":
   exact known-value or brute-force cross-checks, edge cases (singleton
   clusters, collinearity, tiny samples), invalid-input tests, and at least one
@@ -240,15 +257,12 @@ note in `tests/conftest.py`, the lazy-numba note in `ritest.py`) — no narratio
   reference numbers in a test cite their generator the same way. Code adapted
   from elsewhere gets a provenance and license note in its docstring (see
   `tests/test_ccv.py`).
-- Reference packages and dependencies: if the reference implementation is on
-  conda-forge, add it as a dependency (R packages → `[tool.pixi.feature.r.dependencies]`
-  in `pyproject.toml`, test marked `against_r_core`) so CI runs the comparison
-  live. If it is *not* on conda-forge, either install it from CRAN via
-  `r_test_requirements.R` (repo root) and mark the test `against_r_extended` (that
-  suite runs locally only, not in CI), or ship a small script that produces the
-  reference values and hard-code those values into the test (commit the
-  generator under `tests/data/`, as the Stata `.do` files do). Both are fine;
-  reach for hard-coded values over a heavy or flaky live dependency.
+- Reference packages: on conda-forge → add as a dependency (R packages →
+  `[tool.pixi.feature.r.dependencies]`) and mark the test `against_r_core`, so
+  CI runs the comparison live. Not on conda-forge → either CRAN via
+  `r_test_requirements.R` with the test marked `against_r_extended` (local only),
+  or commit a generator under `tests/data/` and hard-code its values. Both are
+  fine; reach for hard-coded values over a heavy or flaky live dependency.
 
 ## Docs
 
@@ -285,10 +299,9 @@ the same bar, whether it is a function, a method or a class:
 - Description: say what the object does and when to use it, not just what it
   returns. A one-line summary is not enough for a user-facing entry.
 - At least one executable example: an `Examples` section with a `{python}` chunk,
-  which quartodoc runs into the page. This includes getters and accessors
-  (`coef()`, `se()`, a `get_*` data generator), where two lines that fit a model
-  and print the result are enough. Keep examples fast (small `pf.get_data()`
-  samples, few bootstrap `reps`). Skip the example only when runtime is
+  which quartodoc runs into the page. Getters and accessors (`coef()`, `se()`, a
+  `get_*` generator) included — two lines are enough. Keep examples fast (small
+  `pf.get_data()` samples, few `reps`); skip one only when runtime is
   prohibitive, and say so.
 - Vignette link when a relevant guide exists, as
   `[guide](/how-to/<feature>.qmd)`. Inference methods point at the
@@ -299,20 +312,14 @@ the same bar, whether it is a function, a method or a class:
   `quantreg` cites Portnoy and Koenker (1997). Mirror the paper's notation in
   the code (see "House style").
 
-Result classes (`Feols`, `Fepois`, `Feiv`, ...) are obtained through the
-estimation functions, so their example fits a model and calls a method instead
-of constructing the class.
-
-Examples go straight to the `{python}` chunk and keep any explanation in short
-comments inside the code. Do not narrate the example in prose — the long
-narrated Examples in `feols` and `fepois` predate this rule; don't copy their
-style for new entries.
-
-Check that an example actually runs before handing off: the minimum is
-executing its body in `pixi run python`; the full check is
-`pixi run docs-build` followed by
+Result-class examples (`Feols`, `Fepois`, `Feiv`, …) fit a model and call a
+method rather than constructing the class. Examples go straight to the
+`{python}` chunk with any explanation in short comments inside the code — do not
+narrate in prose (the long narrated Examples in `feols`/`fepois` predate this
+rule). Verify an example runs before handing off: at minimum execute its body in
+`pixi run python`; the full check is `pixi run docs-build` then
 `QUARTO_PYTHON=.pixi/envs/docs/bin/python3 quarto render docs/reference/<page>.qmd`
-(quarto ignores the `python:` key in `_quarto.yml` for single-file renders).
+(quarto ignores the `python:` key for single-file renders).
 
 ## Commands
 

--- a/pixi.lock
+++ b/pixi.lock
@@ -27845,7 +27845,7 @@ packages:
 - pypi: ./
   name: pyfixest
   version: 0.60.0
-  sha256: b6f43a9d2103d1e17c1ab03d54839e9df416a757d784282322858b7bb0c071bc
+  sha256: 1d0b54139547fce44bb1f4bb404aff48bcf0756cb9d337371092850e1160d757
   requires_dist:
   - formulaic>=1.1.0
   - joblib>=1.4.2

--- a/pyfixest/estimation/models/feols_.py
+++ b/pyfixest/estimation/models/feols_.py
@@ -1377,8 +1377,6 @@ class Feols(ResultAccessorMixin):
             )
             self.vcov({"CRV1": cluster})
 
-        if seed is None:
-            seed = np.random.randint(1, 100_000_000)
         rng = np.random.default_rng(seed)
 
         depvar = self._depvar

--- a/pyfixest/utils/dev_utils.py
+++ b/pyfixest/utils/dev_utils.py
@@ -26,8 +26,6 @@ def _create_rng(seed: int | None = None) -> np.random.Generator:
     numpy.random.Generator
         A random number generator.
     """
-    if seed is None:
-        seed = np.random.randint(100_000_000)
     return np.random.default_rng(seed)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -230,6 +230,7 @@ test-py = { cmd = 'pytest tests -n auto -m "not (extended or against_r_core or a
 test-py-extended = { cmd = 'pytest tests -n auto -m "extended" --cov=pyfixest --cov-report=xml', depends-on = ["_setup"], description = "Extended Python tests" }
 test-py-nojit = { cmd = 'pytest tests/test_ses.py tests/test_demean.py tests/test_collinearity.py tests/test_count_fixef_fully_nested.py -n auto --cov=pyfixest --cov-report=xml:coverage-nojit.xml', env = { NUMBA_DISABLE_JIT = "1" }, depends-on = ["_setup"], description = "Run numba-heavy tests with NUMBA_DISABLE_JIT=1 so codecov sees numba code paths (weekly extended suite)" }
 render-notebooks = { cmd = "python scripts/run_notebooks.py", description = "Run all notebooks" }
+check-style = { cmd = "python scripts/check_house_style.py --diff origin/master", description = "House-style checks over the branch diff (deleted tests, docs wiring, churn)" }
 
 [tool.pixi.tasks._setup]
 cmd = "python scripts/setup_maturin_hook.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,9 @@ select = [
     "SIM", # flake8-simplify
     "RUF", # ruff,
     "TRY", # tryceratops
+    "NPY", # numpy: NPY002 bans the legacy np.random.* API in favor of default_rng
+    # "N" (pep8-naming) is deliberately NOT enabled: econometric paper notation
+    # (X, tZX, IV_Diag, test_HC1_vs_CRV1) is house style, see AGENTS.md.
 ]
 
 ignore = [
@@ -150,6 +153,18 @@ ignore = [
 "pyfixest/visualize.py" = ["D103"]
 "scripts/*.py" = ["D103"]
 "benchmarks/modular/*.py" = ["D101", "D102", "D103"]
+# NPY002 grandfathering: these files predate the rule and their exact legacy
+# RNG streams are load-bearing (stored reference values, frozen doc output).
+# Do not extend this list — new code uses np.random.default_rng.
+"pyfixest/utils/dgps.py" = ["NPY002"]
+"tests/test_i.py" = ["NPY002"]
+"tests/test_wald_test.py" = ["NPY002"]
+"tests/test_iv.py" = ["NPY002"]
+"tests/test_demean.py" = ["NPY002"]
+"tests/test_errors.py" = ["NPY002"]
+"tests/test_poisson.py" = ["NPY002"]
+# Benchmarks time kernels; the RNG stream carries no correctness weight.
+"benchmarks/**" = ["NPY002"]
 
 [tool.ruff.lint.pycodestyle]
 max-doc-length = 88

--- a/scripts/check_house_style.py
+++ b/scripts/check_house_style.py
@@ -1,0 +1,246 @@
+"""
+Mechanical house-style checks that back the prose rules in `AGENTS.md`.
+
+Every check here exists because a real PR broke the rule. Rules that can live
+in this file do not also live in `AGENTS.md` — the guide states intent, this
+script enforces it. Add a check whenever a review finding turns out to be
+mechanically detectable, and delete the corresponding prose.
+
+Two modes:
+
+    python scripts/check_house_style.py [FILE ...]   # tree checks (pre-commit)
+    python scripts/check_house_style.py --diff BASE  # diff checks (CI)
+
+Exits non-zero if anything is found.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+Finding = tuple[str, int, str]
+
+# --- tree checks -----------------------------------------------------------
+
+NUMBA_ALLOWED = (
+    "pyfixest/estimation/numba/",
+    "pyfixest/estimation/post_estimation/ritest.py",
+)
+GENERATED = (
+    "pixi.lock",
+    "Cargo.lock",
+    "docs/_freeze/",
+    "coverage.xml",
+    "docs/reference/",
+)
+
+CAMEL_DEFAULT = re.compile(r'=\s*"([a-z]+[A-Z][a-zA-Z]*)"')
+
+# Files that predate a rule. Do not extend this list — new code follows the
+# rule, and an entry leaves only when the file is cleaned up.
+GRANDFATHERED = {
+    "tests/test_check_version.py": {"test class"},
+    "tests/test_formula_parse.py": {"test class"},
+    "tests/test_hac_meat.py": {"test class"},
+    "pyfixest/estimation/deprecated/FormulaParser.py": {"doctest example"},
+}
+
+
+def check_file(path: str, text: str) -> list[Finding]:
+    """Run every tree check that applies to one file."""
+    out: list[Finding] = []
+    lines = text.splitlines()
+    in_tests = path.startswith("tests/")
+    in_pkg = path.startswith("pyfixest/")
+
+    for i, line in enumerate(lines, start=1):
+        if in_tests and re.match(r"\s*class Test", line):
+            out.append((path, i, "test class — use module-level test_* functions"))
+        if in_tests and "def setup_method" in line:
+            out.append((path, i, "setup_method — use a seeded fixture instead"))
+        if in_tests and ("spec_from_file_location" in line or "importlib.util" in line):
+            out.append((path, i, "importlib file loading — import through the package"))
+        if in_pkg and line.lstrip().startswith(">>>"):
+            out.append((path, i, "doctest example — use an executable {python} chunk"))
+        if (
+            in_pkg
+            and re.match(r"\s*(import numba|from numba)", line)
+            and not any(path.startswith(a) for a in NUMBA_ALLOWED)
+        ):
+            out.append(
+                (path, i, "new numba path — hot loops become Rust kernels in src/")
+            )
+        if path.startswith("pyfixest/estimation/api/") and "data: pd.DataFrame" in line:
+            out.append(
+                (path, i, "pd.DataFrame in an api/ signature — use DataFrameType")
+            )
+        for m in CAMEL_DEFAULT.finditer(line):
+            out.append(
+                (path, i, f'camelCase string default "{m.group(1)}" — use snake_case')
+            )
+
+    exempt = GRANDFATHERED.get(path, set())
+    return [f for f in out if not any(f[2].startswith(e) for e in exempt)]
+
+
+def check_rpy2_registration(paths: list[str]) -> list[Finding]:
+    """Flag test files that import rpy2 without a `_rpy2_test_files` entry."""
+    conftest = ROOT / "tests" / "conftest.py"
+    if not conftest.exists():
+        return []
+    registered = conftest.read_text()
+    out: list[Finding] = []
+    for path in paths:
+        if not (path.startswith("tests/") and path.endswith(".py")):
+            continue
+        if Path(path).name == "conftest.py":
+            continue
+        full = ROOT / path
+        if not full.exists() or "rpy2" not in full.read_text():
+            continue
+        if Path(path).name not in registered:
+            out.append((path, 1, "imports rpy2 but is missing from _rpy2_test_files"))
+    return out
+
+
+# --- diff checks -----------------------------------------------------------
+
+
+def _diff(base: str, *args: str) -> str:
+    cmd = ["git", "diff", base, *args]
+    return subprocess.run(
+        cmd, capture_output=True, text=True, cwd=ROOT, check=False
+    ).stdout
+
+
+def check_deleted_tests(base: str) -> list[Finding]:
+    """Flag removed tests — tests are added, never replaced."""
+    out: list[Finding] = []
+    for line in _diff(base, "--", "tests/").splitlines():
+        m = re.match(r"^-def (test_\w+)", line)
+        if m:
+            out.append(
+                (
+                    "tests/",
+                    0,
+                    f"deleted test `{m.group(1)}` — tests are added, not replaced",
+                )
+            )
+    return out
+
+
+def check_generated_churn(base: str) -> list[Finding]:
+    """Flag generated artifacts and lockfiles left in a feature diff."""
+    out: list[Finding] = []
+    for stat in _diff(base, "--numstat").splitlines():
+        fields = stat.split("\t")
+        if len(fields) != 3:
+            continue
+        added, _removed, name = fields
+        if not any(name.startswith(g) or name == g for g in GENERATED):
+            continue
+        # A lockfile edit under ~5 lines is the local-package hash bump that any
+        # pyproject.toml change produces; a re-resolve is orders of magnitude
+        # larger and is what this check is actually looking for.
+        if name.endswith(".lock") and added.isdigit() and int(added) <= 5:
+            continue
+        out.append(
+            (
+                name,
+                0,
+                "generated/lockfile churn — drop it unless the task is about dependencies",
+            )
+        )
+    return out
+
+
+def check_data_provenance(base: str) -> list[Finding]:
+    """Every tests/data/ file ships with the script that generated it."""
+    names = [
+        n
+        for n in _diff(base, "--name-only").splitlines()
+        if n.startswith("tests/data/")
+    ]
+    added = [n for n in names if not n.endswith((".do", ".R", ".py"))]
+    has_generator = any(n.endswith((".do", ".R", ".py")) for n in names)
+    if added and not has_generator:
+        return [
+            (added[0], 0, "new tests/data/ file with no generator script in the diff")
+        ]
+    return []
+
+
+def check_quartodoc(base: str) -> list[Finding]:
+    """Flag new public model methods missing from the quartodoc reference."""
+    quarto = (ROOT / "docs" / "_quarto.yml").read_text()
+    out: list[Finding] = []
+    for line in _diff(base, "--", "pyfixest/estimation/models/").splitlines():
+        m = re.match(r"^\+    def ([a-z]\w+)\(", line)
+        if m and m.group(1) not in quarto:
+            out.append(
+                (
+                    "docs/_quarto.yml",
+                    0,
+                    f"new public method `{m.group(1)}` missing from quartodoc contents",
+                )
+            )
+    return out
+
+
+# --- entry point -----------------------------------------------------------
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "files", nargs="*", help="files to check (default: all tracked)"
+    )
+    parser.add_argument("--diff", metavar="BASE", help="run diff checks against BASE")
+    args = parser.parse_args()
+
+    findings: list[Finding] = []
+
+    if args.diff:
+        findings += check_deleted_tests(args.diff)
+        findings += check_generated_churn(args.diff)
+        findings += check_data_provenance(args.diff)
+        findings += check_quartodoc(args.diff)
+    else:
+        paths = (
+            args.files
+            or subprocess.run(
+                ["git", "ls-files", "*.py"],
+                capture_output=True,
+                text=True,
+                cwd=ROOT,
+                check=False,
+            ).stdout.split()
+        )
+        for path in paths:
+            rel = (
+                str(Path(path).resolve().relative_to(ROOT))
+                if Path(path).is_absolute()
+                else path
+            )
+            full = ROOT / rel
+            if full.exists() and full.suffix == ".py":
+                findings += check_file(rel, full.read_text())
+        findings += check_rpy2_registration([str(p) for p in paths])
+
+    for path, line, msg in findings:
+        location = f"{path}:{line}" if line else path
+        print(f"{location}: {msg}")
+
+    if findings:
+        print(f"\n{len(findings)} house-style finding(s) — see AGENTS.md")
+    return 1 if findings else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Consolidates the unmerged `agent-style-guide` commits, the two evidence-backed
proposals from #1383, and an audit of #1373 / #1370 / #1363 / #1275.

Two problems the audit found:

- `AGENTS.md`'s "mirror the nearest implementation" beat its own recipes,
  because the codebase doesn't follow them — `Literal` aliases live in five
  places, so three of four PRs skipped `literals.py`. Fixed with a
  known-stale-precedents table.
- Rules were stated but not checkable. All four PRs missed their quartodoc
  entry. `scripts/check_house_style.py` now holds the mechanical rules
  (pre-commit hook + `pixi run check-style`), and the prose it replaced is gone.

Also adds four rules the audit found uncovered (no override hooks on model
classes, a test through the public API, dataclass fields, stale precedents) and
#1383's staleness check and re-plan tier.

Net: 769 lines of prose instead of ~1232 if combined as written. `AGENTS.md`
now states the ratchet — a checkable rule belongs in a check, and adding a rule
means deleting one.

Test plan:

- [x] `pixi run lint` green, including the new `house-style` hook
- [x] `pixi run test-py` — 732 passed, 0 failed
- [x] Diff checks verified against #1370 (deleted test, missing quartodoc entry)
      and #1373 (numba, importlib, test classes)

Supersedes #1383 and `claude/pyfixest-agent-style-guide-6cd554`.

Replaces #1410, which GitHub closed when the branch was renamed.
