### PR TITLE
chore: remove dead code from Feols

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -324,14 +324,15 @@ once.
   automatically only if `prek install` set up the git hook, which agents and fresh
   clones usually haven't done, so run them explicitly rather than relying on it.
   mypy is scoped to `pyfixest/`, not `tests/`.
-- Commit messages: one short, precise, imperative subject line that says what
-  changed — e.g. "Add transform building blocks", "Rewrite predict() and fixef()
-  to reuse stored ModelSpec", "Make `FixestMulti` a pure container". Target
-  ~50–60 chars, no trailing period, backtick code identifiers. Conventional
-  prefixes (`feat:`, `fix(scope):`, `docs:`, `refactor:`) are welcome but
-  optional — a plain imperative subject is equally house-style. Add a body only
-  when the *why* isn't obvious from the subject, and keep it to a line or two.
-  Don't hand-append `(#PR)`; GitHub adds it on squash-merge.
+- Commit messages: a conventional prefix plus one short, precise, imperative
+  subject line that says what changed — e.g. `feat: add transform building
+  blocks`, `refactor: make FixestMulti a pure container`, `chore: remove dead
+  code from Feols`. Use `feat`, `fix`, `refactor`, `perf`, `test`, `docs`,
+  `chore`, `build`, `ci`; add a scope when it narrows usefully
+  (`fix(vcov): ...`). Target ~50–60 chars including the prefix, no trailing
+  period, backtick code identifiers. Add a body only when the *why* isn't
+  obvious from the subject, and keep it to a line or two. Don't hand-append
+  `(#PR)`; GitHub adds it on squash-merge.
 - Before handing off a PR, rewrite the branch into a few logically ordered,
   individually test-passing commits (helpers + tests → wiring + tests → API
   exposure + docs). The maintainer reviews commit by commit; see

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -324,15 +324,24 @@ once.
   automatically only if `prek install` set up the git hook, which agents and fresh
   clones usually haven't done, so run them explicitly rather than relying on it.
   mypy is scoped to `pyfixest/`, not `tests/`.
-- Commit messages: a conventional prefix plus one short, precise, imperative
-  subject line that says what changed — e.g. `feat: add transform building
-  blocks`, `refactor: make FixestMulti a pure container`, `chore: remove dead
-  code from Feols`. Use `feat`, `fix`, `refactor`, `perf`, `test`, `docs`,
-  `chore`, `build`, `ci`; add a scope when it narrows usefully
-  (`fix(vcov): ...`). Target ~50–60 chars including the prefix, no trailing
-  period, backtick code identifiers. Add a body only when the *why* isn't
-  obvious from the subject, and keep it to a line or two. Don't hand-append
-  `(#PR)`; GitHub adds it on squash-merge.
+- Commit subjects: a conventional prefix plus one short, precise, imperative
+  line that says what changed — e.g. `feat: add transform building blocks`,
+  `refactor: make FixestMulti a pure container`, `chore: remove dead code from
+  Feols`. Use `feat`, `fix`, `refactor`, `perf`, `test`, `docs`, `chore`,
+  `build`, `ci`; add a scope when it narrows usefully (`fix(vcov): ...`).
+  Target ~50–60 chars including the prefix, no trailing period, backtick code
+  identifiers. Don't hand-append `(#PR)`; GitHub adds it on squash-merge.
+- Commit bodies: add one only when the *why* isn't obvious from the subject,
+  and keep it to a line or two. Write plain English that a contributor reading
+  `git log` in a year can follow without opening the diff. Name the thing, then
+  say what is true of it, in the present tense and in ordinary words:
+  - "`_feols_input_checks` is never called" — not "has no callers".
+  - "`na_index` is only assigned, never read" — not "was only ever written".
+  - "the second `_supports_wildboottest = True` overwrites the first, so the
+    weights check above it never takes effect" — not "the guard was a no-op".
+
+  Prefer a longer plain sentence over a short cryptic one. If a phrase would
+  need a follow-up question to explain it, it is the wrong phrase.
 - Before handing off a PR, rewrite the branch into a few logically ordered,
   individually test-passing commits (helpers + tests → wiring + tests → API
   exposure + docs). The maintainer reviews commit by commit; see

--- a/pyfixest/estimation/models/feglm_.py
+++ b/pyfixest/estimation/models/feglm_.py
@@ -158,7 +158,6 @@ class Feglm(Feols):
             # Re-set weights after dropping rows (handles both weighted and unweighted)
             self._weights = self._set_weights()
 
-            self.na_index = np.concatenate([self.na_index, np.array(na_separation)])
             self.n_separation_na = len(na_separation)
             # possible to have dropped fixed effects level due to separation
             self._k_fe = self._fe.nunique(axis=0) if self._has_fixef else None

--- a/pyfixest/estimation/models/feols_.py
+++ b/pyfixest/estimation/models/feols_.py
@@ -318,8 +318,6 @@ class Feols(ResultAccessorMixin):
 
         self._support_crv3_inference = True
         self._support_hac_inference = True
-        if self._weights_name is not None:
-            self._supports_wildboottest = False
         self._supports_wildboottest = True
         self._supports_cluster_causal_variance = True
         if self._has_weights or self._is_iv:
@@ -356,7 +354,6 @@ class Feols(ResultAccessorMixin):
         self._G: list[int] = []
         self._ssc = np.array([], dtype=np.float64)
         self._vcov = np.array([])
-        self.na_index = np.array([])  # initiated outside of the class
         self.n_separation_na = 0
 
         # set in get_inference()
@@ -867,62 +864,6 @@ class Feols(ResultAccessorMixin):
 
         return vcov_mat
 
-    def add_fixest_multi_context(
-        self,
-        depvar: str,
-        Y: pd.Series,
-        _data: pd.DataFrame,
-        _ssc_dict: dict[str, str | bool],
-        _k_fe: int,
-        fval: str,
-        store_data: bool,
-    ) -> None:
-        """
-        Enrich Feols object.
-
-        Enrich an instance of `Feols` Class with additional
-        attributes set in the `FixestMulti` class.
-
-        Parameters
-        ----------
-        FixestFormula : FixestFormula
-            The formula(s) used for estimation encoded in a `FixestFormula` object.
-        depvar : str
-            The dependent variable of the regression model.
-        Y : pd.Series
-            The dependent variable of the regression model.
-        _data : pd.DataFrame
-            The data used for estimation.
-        _ssc_dict : dict
-            A dictionary with the sum of squares and cross products matrices.
-        _k_fe : int
-            The number of fixed effects.
-        fval : str
-            The fixed effects formula.
-        store_data : bool
-            Indicates whether to save the data used for estimation in the object
-
-        Returns
-        -------
-        None
-        """
-        # some bookkeeping
-        self._fml = self.FixestFormula.formula
-        self._depvar = depvar
-        self._Y_untransformed = Y
-        self._data = pd.DataFrame()
-
-        if store_data:
-            self._data = _data
-
-        self._ssc_dict = _ssc_dict
-        self._k_fe = _k_fe  # type: ignore[assignment]
-        if fval != "0":
-            self._has_fixef = True
-            self._fixef = fval
-        else:
-            self._has_fixef = False
-
     def _clear_attributes(self):
         attributes = []
 
@@ -1381,12 +1322,7 @@ class Feols(ResultAccessorMixin):
             seed = np.random.randint(1, 100_000_000)
         rng = np.random.default_rng(seed)
 
-        depvar = self._depvar
         fml = self._fml
-        xfml_list = fml.split("~")[1].split("+")
-        xfml_list = [x for x in xfml_list if x != treatment]
-        xfml = "" if not xfml_list else "+".join(xfml_list)
-
         data = self._data
         Y = self._Y.flatten()
         W = data[treatment].to_numpy()
@@ -1454,21 +1390,6 @@ class Feols(ResultAccessorMixin):
         res_crv1.name = "CRV1"
 
         return pd.concat([res_ccv, res_crv1], axis=1).T
-
-        ccv_module = import_module("pyfixest.estimation.post_estimation.ccv")
-        _ccv = ccv_module._ccv
-
-        return _ccv(
-            data=data,
-            depvar=depvar,
-            treatment=treatment,
-            cluster=cluster,
-            xfml=xfml,
-            seed=seed,
-            pk=pk,
-            qk=qk,
-            n_splits=n_splits,
-        )
 
     def _model_matrix_one_hot(
         self, output="numpy"
@@ -2282,38 +2203,6 @@ class Feols(ResultAccessorMixin):
             self._N += X_new.shape[0]
 
         return beta_n_plus_1
-
-
-def _feols_input_checks(Y: np.ndarray, X: np.ndarray, weights: np.ndarray):
-    """
-    Perform basic checks on the input matrices Y and X for the FEOLS.
-
-    Parameters
-    ----------
-    Y : np.ndarray
-        FEOLS input matrix Y.
-    X : np.ndarray
-        FEOLS input matrix X.
-    weights : np.ndarray
-        FEOLS weights.
-
-    Returns
-    -------
-    None
-    """
-    if not isinstance(Y, (np.ndarray)):
-        raise TypeError("Y must be a numpy array.")
-    if not isinstance(X, (np.ndarray)):
-        raise TypeError("X must be a numpy array.")
-    if not isinstance(weights, (np.ndarray)):
-        raise TypeError("weights must be a numpy array.")
-
-    if Y.ndim != 2:
-        raise ValueError("Y must be a 2D array")
-    if X.ndim != 2:
-        raise ValueError("X must be a 2D array")
-    if weights.ndim != 2:
-        raise ValueError("weights must be a 2D array")
 
 
 def _check_vcov_input(


### PR DESCRIPTION
Removes code in `Feols` with no callers or no effect:

- `add_fixest_multi_context` — unused since `FixestMulti` became a pure container (#1360)
- `_feols_input_checks` — no callers
- the block after `ccv`'s `return`, plus the `depvar`/`xfml` locals only it used
- `self.na_index` — only ever written, never read (`_na_index` is the one in use)
- an overwritten `_supports_wildboottest = False` guard that was a no-op

No behaviour change. `AGENTS.md` now requires a conventional prefix on commit
subjects instead of listing it as optional.

`pixi run test-py`: 732 passed. `test-r-core` left to CI — rpy2 segfaults on
package load locally, on unmodified master too.