### PR TITLE
refactor(vcov): drive vcov validation and dispatch from a registry

### DIFF
--- a/pyfixest/estimation/internals/literals.py
+++ b/pyfixest/estimation/internals/literals.py
@@ -1,7 +1,9 @@
 from typing import Any, Literal, get_args
 
 PredictionType = Literal["response", "link"]
-VcovTypeOptions = Literal["iid", "hetero", "HC1", "HC2", "HC3", "nid"]
+# Must stay in sync with the non-clustered entries of
+# `internals.vcov_utils.VCOV_REGISTRY`; `test_ses.py` asserts they match.
+VcovTypeOptions = Literal["iid", "hetero", "HC1", "HC2", "HC3", "NW", "DK", "nid"]
 WeightsTypeOptions = Literal["aweights", "fweights"]
 FixedRmOptions = Literal["singleton", "none"]
 FamilyOptions = Literal["logit", "probit", "gaussian", "poisson"]

--- a/pyfixest/estimation/internals/vcov_utils.py
+++ b/pyfixest/estimation/internals/vcov_utils.py
@@ -1,5 +1,6 @@
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import Any
 
 import numpy as np
 import pandas as pd
@@ -14,9 +15,143 @@ from pyfixest.core.nw import (
 from pyfixest.core.nw import (
     nw_meat_time as _nw_meat_time_rs,
 )
-from pyfixest.errors import NanInClusterVarError
+from pyfixest.errors import NanInClusterVarError, VcovTypeNotSupportedError
 from pyfixest.utils.dev_utils import DataFrameType, _narwhals_to_pandas
 from pyfixest.utils.utils import get_ssc
+
+
+@dataclass(frozen=True)
+class VcovSpec:
+    """One user-facing `vcov` option and what the dispatcher needs for it.
+
+    Attributes
+    ----------
+    detail : str
+        The user-facing name, stored on the model as `_vcov_type_detail`.
+    family : str
+        The coarse estimator family, stored as `_vcov_type`. Several details
+        share a family: `HC1`, `HC2` and `HC3` are all `"hetero"`.
+    takes_cluster : bool
+        Whether the option is written as `{detail: clustervar}` rather than as
+        a bare string, and therefore clusters.
+    method_name : str | None
+        Name of the `Feols` method returning the unscaled vcov. `None` for
+        clustered specs, whose per-cluster loop runs in `run_crv_loop`.
+    ssc_family : str | None
+        The `vcov_type` handed to `get_ssc`. Defaults to `family`; only `nid`
+        differs, borrowing the `"hetero"` correction.
+    ssc_G : Callable[[Any], int] | None
+        Returns the `G` that `get_ssc` needs, given the fitted model.
+    prepare : Callable[[Any, dict | None], None] | None
+        Runs before the ssc and vcov computation to unpack `vcov_kwargs` onto
+        the model. Only the HAC estimators need it.
+    check_kwargs : Callable[[dict | None], None] | None
+        Validates `vcov_kwargs` at the API boundary, without a fitted model.
+    check_model : Callable[[bool, bool], None] | None
+        Validates the option against `(has_fixef, is_iv)` once the model is known.
+    """
+
+    detail: str
+    family: str
+    takes_cluster: bool = False
+    method_name: str | None = None
+    ssc_family: str | None = None
+    ssc_G: Callable[[Any], int] | None = None
+    prepare: Callable[[Any, dict | None], None] | None = None
+    check_kwargs: Callable[[dict | None], None] | None = None
+    check_model: Callable[[bool, bool], None] | None = None
+
+    @property
+    def ssc_vcov_type(self) -> str:
+        "The `vcov_type` to hand to `get_ssc`."
+        return self.ssc_family if self.ssc_family is not None else self.family
+
+
+def _G_one(model: Any) -> int:
+    return 1
+
+
+def _G_nobs(model: Any) -> int:
+    # fixest:::vcov_hetero_internal: adj = ifelse(ssc$cluster.adj, n/(n - 1), 1)
+    return model._N
+
+
+def _G_time_periods(model: Any) -> int:
+    "Count the distinct time periods T used by the HAC estimator."
+    return int(np.unique(model._data[model._time_id]).shape[0])
+
+
+def _prepare_hac(model: Any, vcov_kwargs: dict | None) -> None:
+    "Unpack the HAC keyword arguments onto the model."
+    kw = vcov_kwargs or {}
+    model._lag = kw.get("lag")
+    model._time_id = kw.get("time_id")
+    model._panel_id = kw.get("panel_id")
+
+
+def _require_time_id(vcov_kwargs: dict | None) -> None:
+    if not vcov_kwargs or "time_id" not in vcov_kwargs:
+        raise ValueError("Missing required 'time_id' for NW/DK vcov")
+
+
+def _reject_fixef_and_iv(has_fixef: bool, is_iv: bool) -> None:
+    if has_fixef:
+        raise VcovTypeNotSupportedError(
+            "HC2 and HC3 inference types are not supported for regressions with fixed effects."
+        )
+    if is_iv:
+        raise VcovTypeNotSupportedError(
+            "HC2 and HC3 inference types are not supported for IV regressions."
+        )
+
+
+VCOV_REGISTRY: dict[str, VcovSpec] = {
+    "iid": VcovSpec("iid", "iid", method_name="_vcov_iid", ssc_G=_G_one),
+    "hetero": VcovSpec("hetero", "hetero", method_name="_vcov_hetero", ssc_G=_G_nobs),
+    "HC1": VcovSpec("HC1", "hetero", method_name="_vcov_hetero", ssc_G=_G_nobs),
+    "HC2": VcovSpec(
+        "HC2",
+        "hetero",
+        method_name="_vcov_hetero",
+        ssc_G=_G_nobs,
+        check_model=_reject_fixef_and_iv,
+    ),
+    "HC3": VcovSpec(
+        "HC3",
+        "hetero",
+        method_name="_vcov_hetero",
+        ssc_G=_G_nobs,
+        check_model=_reject_fixef_and_iv,
+    ),
+    "NW": VcovSpec(
+        "NW",
+        "HAC",
+        method_name="_vcov_hac",
+        ssc_G=_G_time_periods,
+        prepare=_prepare_hac,
+        check_kwargs=_require_time_id,
+    ),
+    "DK": VcovSpec(
+        "DK",
+        "HAC",
+        method_name="_vcov_hac",
+        ssc_G=_G_time_periods,
+        prepare=_prepare_hac,
+        check_kwargs=_require_time_id,
+    ),
+    "nid": VcovSpec(
+        "nid", "nid", method_name="_vcov_nid", ssc_family="hetero", ssc_G=_G_nobs
+    ),
+    "CRV1": VcovSpec("CRV1", "CRV", takes_cluster=True),
+    "CRV3": VcovSpec("CRV3", "CRV", takes_cluster=True),
+}
+
+VCOV_STRING_OPTIONS: tuple[str, ...] = tuple(
+    k for k, spec in VCOV_REGISTRY.items() if not spec.takes_cluster
+)
+VCOV_CLUSTER_OPTIONS: tuple[str, ...] = tuple(
+    k for k, spec in VCOV_REGISTRY.items() if spec.takes_cluster
+)
 
 
 @dataclass

--- a/pyfixest/estimation/models/feols_.py
+++ b/pyfixest/estimation/models/feols_.py
@@ -37,6 +37,9 @@ from pyfixest.estimation.internals.vcov_ import (
     vcov_iid_ols,
 )
 from pyfixest.estimation.internals.vcov_utils import (
+    VCOV_CLUSTER_OPTIONS,
+    VCOV_REGISTRY,
+    VCOV_STRING_OPTIONS,
     _compute_bread,
     prepare_cluster_state,
     run_crv_loop,
@@ -637,20 +640,15 @@ class Feols(ResultAccessorMixin):
         See [On Small Sample Corrections](/explanation/ssc.qmd) for how the
         `ssc` adjustments interact with each estimator.
         """
-        # Assuming `data` is the DataFrame in question
+        if data is not None:
+            try:
+                data = _narwhals_to_pandas(data)
+            except TypeError as e:
+                raise TypeError(
+                    f"The data set must be a DataFrame type. Received: {type(data)}"
+                ) from e
 
-        data_to_check = data if data is not None else self._data
-        try:
-            data_to_check = _narwhals_to_pandas(data_to_check)
-        except TypeError as e:
-            raise TypeError(
-                f"The data set must be a DataFrame type. Received: {type(data)}"
-            ) from e
-
-        # assign estimated fixed effects, and fixed effects nested within cluster.
-
-        # deparse vcov input
-        _check_vcov_input(vcov=vcov, vcov_kwargs=vcov_kwargs, data=self._data)
+        _check_vcov_input(vcov=vcov, vcov_kwargs=vcov_kwargs)
 
         (
             self._vcov_type,
@@ -663,39 +661,9 @@ class Feols(ResultAccessorMixin):
             self._is_iv, self._tXZ, self._tZZinv, self._tZX, self._hessian
         )
 
-        if self._vcov_type == "iid":
-            self._ssc, self._df_k, self._df_t = get_ssc(
-                **self._make_ssc_kwargs(vcov_type="iid", G=1)
-            )
-            self._vcov = self._ssc * self._vcov_iid()
+        spec = VCOV_REGISTRY[self._vcov_type_detail]
 
-        elif self._vcov_type == "hetero":
-            # fixest:::vcov_hetero_internal: adj = ifelse(ssc$cluster.adj, n/(n - 1), 1)
-            self._ssc, self._df_k, self._df_t = get_ssc(
-                **self._make_ssc_kwargs(vcov_type="hetero", G=self._N)
-            )
-            self._vcov = self._ssc * self._vcov_hetero()
-
-        elif self._vcov_type == "HAC":
-            kw = vcov_kwargs or {}
-            self._lag = kw.get("lag")
-            self._time_id = kw.get("time_id")
-            self._panel_id = kw.get("panel_id")
-            self._ssc, self._df_k, self._df_t = get_ssc(
-                **self._make_ssc_kwargs(
-                    vcov_type="HAC",
-                    G=np.unique(self._data[self._time_id]).shape[0],
-                )  # number of unique time periods T used
-            )
-            self._vcov = self._ssc * self._vcov_hac()
-
-        elif self._vcov_type == "nid":
-            self._ssc, self._df_k, self._df_t = get_ssc(
-                **self._make_ssc_kwargs(vcov_type="hetero", G=self._N)
-            )
-            self._vcov = self._ssc * self._vcov_nid()
-
-        elif self._vcov_type == "CRV":
+        if spec.takes_cluster:
             prep = prepare_cluster_state(
                 data=data if data is not None else self._data,
                 clustervar=self._clustervar,
@@ -712,6 +680,17 @@ class Feols(ResultAccessorMixin):
                 make_ssc_kwargs=self._make_ssc_kwargs,
                 cluster_vcov=self._vcov_crv_cluster,
             )
+        else:
+            if spec.prepare is not None:
+                spec.prepare(self, vcov_kwargs)
+            assert spec.ssc_G is not None and spec.method_name is not None
+            self._ssc, self._df_k, self._df_t = get_ssc(
+                **self._make_ssc_kwargs(
+                    vcov_type=spec.ssc_vcov_type, G=spec.ssc_G(self)
+                )
+            )
+            self._vcov = self._ssc * getattr(self, spec.method_name)()
+
         # update p-value, t-stat, standard error, confint
         self.get_inference()
 
@@ -2319,62 +2298,56 @@ def _feols_input_checks(Y: np.ndarray, X: np.ndarray, weights: np.ndarray):
 def _check_vcov_input(
     vcov: str | dict[str, str],
     vcov_kwargs: dict[str, Any] | None,
-    data: pd.DataFrame,
+    data: pd.DataFrame | None = None,
 ):
     """
-    Check the input for the vcov argument in the Feols class.
+    Check the shape and option name of the vcov argument.
+
+    Validates everything that can be checked without a fitted model: the
+    argument's type, that the requested estimator exists in `VCOV_REGISTRY`,
+    and any estimator-specific `vcov_kwargs` requirements. Model-dependent
+    checks live in `_deparse_vcov_input`.
 
     Parameters
     ----------
-    vcov : Union[str, dict[str, str]]
+    vcov : str | dict[str, str]
         The vcov argument passed to the Feols class.
-    vcov_kwargs : Optional[dict[str, Any]]
+    vcov_kwargs : dict[str, Any] | None
         The vcov_kwargs argument passed to the Feols class.
-    data : pd.DataFrame
-        The data passed to the Feols class.
+    data : pd.DataFrame | None
+        Unused. Retained for backwards compatibility of the call signature.
 
     Returns
     -------
     None
     """
-    assert isinstance(vcov, (dict, str, list)), "vcov must be a dict, string or list"
     if isinstance(vcov, dict):
-        assert next(iter(vcov.keys())) in [
-            "CRV1",
-            "CRV3",
-        ], "vcov dict key must be CRV1 or CRV3"
-        assert isinstance(next(iter(vcov.values())), str), (
-            "vcov dict value must be a string"
+        if len(vcov) != 1:
+            raise ValueError(
+                f"The vcov dict must have exactly one key, but has {len(vcov)}."
+            )
+        detail, clustervar = next(iter(vcov.items()))
+        if detail not in VCOV_CLUSTER_OPTIONS:
+            raise ValueError(
+                f"The vcov dict key must be one of {VCOV_CLUSTER_OPTIONS}, but is '{detail}'."
+            )
+        if not isinstance(clustervar, str):
+            raise TypeError("The vcov dict value must be a string.")
+        if len(clustervar.split("+")) > 2:
+            raise ValueError("Not more than twoway clustering is supported.")
+    elif isinstance(vcov, str):
+        if vcov not in VCOV_STRING_OPTIONS:
+            raise ValueError(
+                f"vcov must be one of {VCOV_STRING_OPTIONS}, or a dict such as "
+                f"{{'CRV1': 'clustervar'}}, but is '{vcov}'."
+            )
+        spec = VCOV_REGISTRY[vcov]
+        if spec.check_kwargs is not None:
+            spec.check_kwargs(vcov_kwargs)
+    else:
+        raise TypeError(
+            f"vcov must be a string or a dict, but is of type {type(vcov)}."
         )
-        deparse_vcov = next(iter(vcov.values())).split("+")
-        assert len(deparse_vcov) <= 2, "not more than twoway clustering is supported"
-
-    if isinstance(vcov, list):
-        assert all(isinstance(v, str) for v in vcov), "vcov list must contain strings"
-        assert all(v in data.columns for v in vcov), (
-            "vcov list must contain columns in the data"
-        )
-    if isinstance(vcov, str):
-        assert vcov in [
-            "iid",
-            "hetero",
-            "HC1",
-            "HC2",
-            "HC3",
-            "NW",
-            "DK",
-            "nid",
-        ], (
-            "vcov string must be iid, hetero, HC1, HC2, HC3, NW, or DK, or for quantile regression, 'nid'."
-        )
-
-        # check that time_id is provided if vcov is NW or DK
-        if (
-            vcov in {"NW", "DK"}
-            and vcov_kwargs is not None
-            and "time_id" not in vcov_kwargs
-        ):
-            raise ValueError("Missing required 'time_id' for NW/DK vcov")
 
 
 def _deparse_vcov_input(vcov: str | dict[str, str], has_fixef: bool, is_iv: bool):
@@ -2404,43 +2377,23 @@ def _deparse_vcov_input(vcov: str | dict[str, str], has_fixef: bool, is_iv: bool
     """
     if isinstance(vcov, dict):
         vcov_type_detail = next(iter(vcov.keys()))
-        deparse_vcov = next(iter(vcov.values())).split("+")
-        if isinstance(deparse_vcov, str):
-            deparse_vcov = [deparse_vcov]
-        deparse_vcov = [x.replace(" ", "") for x in deparse_vcov]
-    elif isinstance(vcov, (list, str)):
+        clustervar = [x.replace(" ", "") for x in next(iter(vcov.values())).split("+")]
+    elif isinstance(vcov, str):
         vcov_type_detail = vcov
+        clustervar = None
     else:
-        raise TypeError("arg vcov needs to be a dict, string or list")
+        raise TypeError("arg vcov needs to be a dict or a string")
 
-    if vcov_type_detail == "iid":
-        vcov_type = "iid"
-        is_clustered = False
-    elif vcov_type_detail in ["hetero", "HC1", "HC2", "HC3"]:
-        vcov_type = "hetero"
-        is_clustered = False
-        if vcov_type_detail in ["HC2", "HC3"]:
-            if has_fixef:
-                raise VcovTypeNotSupportedError(
-                    "HC2 and HC3 inference types are not supported for regressions with fixed effects."
-                )
-            if is_iv:
-                raise VcovTypeNotSupportedError(
-                    "HC2 and HC3 inference types are not supported for IV regressions."
-                )
-    elif vcov_type_detail in ["NW", "DK"]:
-        vcov_type = "HAC"
-        is_clustered = False
+    spec = VCOV_REGISTRY.get(vcov_type_detail)
+    if spec is None:
+        raise ValueError(
+            f"vcov must be one of {tuple(VCOV_REGISTRY)}, but is '{vcov_type_detail}'."
+        )
+    if spec.check_model is not None:
+        spec.check_model(has_fixef, is_iv)
 
-    elif vcov_type_detail in ["CRV1", "CRV3"]:
-        vcov_type = "CRV"
-        is_clustered = True
-
-    elif vcov_type_detail == "nid":
-        vcov_type = "nid"
-        is_clustered = False
-
-    clustervar = deparse_vcov if is_clustered else None
+    if not spec.takes_cluster:
+        clustervar = None
 
     # loop over clustervar to change "^" to "_"
     if clustervar and "^" in clustervar:
@@ -2452,4 +2405,4 @@ def _deparse_vcov_input(vcov: str | dict[str, str], has_fixef: bool, is_iv: bool
             """
         )
 
-    return vcov_type, vcov_type_detail, is_clustered, clustervar
+    return spec.family, spec.detail, spec.takes_cluster, clustervar

--- a/tests/test_ses.py
+++ b/tests/test_ses.py
@@ -236,6 +236,28 @@ def test_vcov_options_match_registry():
     assert set(get_args(VcovTypeOptions)) == set(VCOV_STRING_OPTIONS)
 
 
+@pytest.mark.parametrize(
+    ("vcov", "vcov_kwargs", "error"),
+    [
+        (["f1", "f2"], None, TypeError),  # a list is not a supported vcov shape
+        (42, None, TypeError),
+        ("bogus", None, ValueError),
+        ({"BOGUS": "f1"}, None, ValueError),
+        ({"CRV1": 1}, None, TypeError),
+        ({"CRV1": "f1+f2+f3"}, None, ValueError),  # at most twoway clustering
+        ({"CRV1": "f1", "CRV3": "f2"}, None, ValueError),
+        ("NW", None, ValueError),  # time_id is required, also when kwargs are absent
+        ("NW", {"lag": 2}, ValueError),
+        ("DK", None, ValueError),
+    ],
+)
+def test_vcov_input_validation(vcov, vcov_kwargs, error):
+    "Malformed vcov input raises at the boundary, not deeper in the dispatch."
+    fit = feols("Y ~ X1", data=get_data().dropna())
+    with pytest.raises(error):
+        fit.vcov(vcov, vcov_kwargs=vcov_kwargs)
+
+
 @pytest.mark.parametrize("detail", sorted(VCOV_REGISTRY))
 def test_vcov_registry_specs_are_dispatchable(detail):
     "Every spec resolves to either the cluster loop or an existing Feols method."

--- a/tests/test_ses.py
+++ b/tests/test_ses.py
@@ -1,7 +1,14 @@
+from typing import get_args
+
 import numpy as np
 import pytest
 
 from pyfixest.estimation import feols, fepois
+from pyfixest.estimation.internals.literals import VcovTypeOptions
+from pyfixest.estimation.internals.vcov_utils import (
+    VCOV_REGISTRY,
+    VCOV_STRING_OPTIONS,
+)
 from pyfixest.utils.utils import get_data, ssc
 
 
@@ -218,3 +225,25 @@ def run_crv3_poisson():
         vcov={"CRV3": "f1"},
         ssc=ssc(k_adj=False, G_adj=False),
     )
+
+
+def test_vcov_options_match_registry():
+    """`VcovTypeOptions` must list exactly the non-clustered registry entries.
+
+    The Literal is the type annotation on every public API's `vcov` argument;
+    this is what stops it drifting from the estimators actually implemented.
+    """
+    assert set(get_args(VcovTypeOptions)) == set(VCOV_STRING_OPTIONS)
+
+
+@pytest.mark.parametrize("detail", sorted(VCOV_REGISTRY))
+def test_vcov_registry_specs_are_dispatchable(detail):
+    "Every spec resolves to either the cluster loop or an existing Feols method."
+    spec = VCOV_REGISTRY[detail]
+    if spec.takes_cluster:
+        assert spec.method_name is None and spec.ssc_G is None
+    else:
+        assert spec.ssc_G is not None
+        assert callable(
+            getattr(feols("Y ~ X1", data=get_data().dropna()), spec.method_name)
+        )


### PR DESCRIPTION
Follow-up to #1412. The set of legal `vcov` values was written down in four
places: `VcovTypeOptions`, the assert list in `_check_vcov_input`, the `if/elif`
chain in `_deparse_vcov_input`, and the dispatch chain in `Feols.vcov`. They had
already drifted — `VcovTypeOptions` was missing `NW` and `DK` — and the
validators disagreed with the dispatcher, so documented inputs crashed:

| input | before | after |
| --- | --- | --- |
| `fit.vcov(["f1","f2"])` | `UnboundLocalError` | `TypeError` |
| `fit.vcov("NW")` | `KeyError: None` | `ValueError: Missing required 'time_id'` |
| `fit.vcov({"BOGUS": "f1"})` under `-O` | `UnboundLocalError` | `ValueError` |

Now one `VcovSpec` per option in `internals/vcov_utils.py` owns the family, the
ssc rule, the `_vcov_*` method and the validators; the two validation functions
and `Feols.vcov` all read from it. Validation raises `ValueError`/`TypeError`
instead of asserts that vanish under `-O`, and a test pins `VcovTypeOptions` to
the registry so it cannot drift again.

Incidental: non-clustered `vcov()` no longer touches `_data` (a computed-then-
discarded `data_to_check` did), so `vcov("hetero")` now works under
`store_data=False`. Clustered vcov still needs the data, as before.

No numerical change. 74 vcov matrices across OLS/WLS/IV/Poisson/logit/quantreg ×
iid/hetero/HC1-3/CRV1/CRV3/twoway/NW/DK/nid × 4 ssc variants match master; the
only cases not bit-identical are two-way-FE ones, which differ from master by
exactly as much as two runs of the same commit differ from each other (~3e-8,
pre-existing demeaner non-determinism).

The `"^" in clustervar` list-membership check in `_deparse_vcov_input` is
preserved verbatim. It never fires — `{"CRV1": "f1^f2"}` yields `['f1^f2']` with
no warning — but fixing it changes behaviour, so it belongs in its own PR.

`pixi run test-py`: 753 passed. R suites left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
