### PR TITLE
Fix/cluster caret rename

### DIFF
--- a/pyfixest/estimation/models/feols_.py
+++ b/pyfixest/estimation/models/feols_.py
@@ -2442,8 +2442,9 @@ def _deparse_vcov_input(vcov: str | dict[str, str], has_fixef: bool, is_iv: bool
 
     clustervar = deparse_vcov if is_clustered else None
 
-    # loop over clustervar to change "^" to "_"
-    if clustervar and "^" in clustervar:
+    # Interacted fixed effects are materialized as `f1_f2` columns, so a
+    # cluster variable written `f1^f2` has to be renamed to match.
+    if clustervar and any("^" in x for x in clustervar):
         clustervar = [x.replace("^", "_") for x in clustervar]
         warnings.warn(
             f"""

--- a/tests/test_ses.py
+++ b/tests/test_ses.py
@@ -224,9 +224,7 @@ def test_cluster_on_interacted_fixed_effect():
     """`{"CRV1": "f1^f2"}` must find the materialized `f1_f2` column.
 
     Interacted fixed effects are written into the data as `f1_f2`, so the
-    cluster name needs the same rename. The membership test used to check the
-    list for an element equal to "^", so it never fired and the lookup raised
-    a bare KeyError.
+    cluster variables also need to be renamed / to match to find the column.
     """
     data = get_data().dropna().reset_index(drop=True)
     fit = feols("Y ~ X1 | f1^f2", data=data)

--- a/tests/test_ses.py
+++ b/tests/test_ses.py
@@ -218,3 +218,24 @@ def run_crv3_poisson():
         vcov={"CRV3": "f1"},
         ssc=ssc(k_adj=False, G_adj=False),
     )
+
+
+def test_cluster_on_interacted_fixed_effect():
+    """`{"CRV1": "f1^f2"}` must find the materialized `f1_f2` column.
+
+    Interacted fixed effects are written into the data as `f1_f2`, so the
+    cluster name needs the same rename. The membership test used to check the
+    list for an element equal to "^", so it never fired and the lookup raised
+    a bare KeyError.
+    """
+    data = get_data().dropna().reset_index(drop=True)
+    fit = feols("Y ~ X1 | f1^f2", data=data)
+
+    with pytest.warns(UserWarning, match="replaced by"):
+        fit.vcov({"CRV1": "f1^f2"})
+
+    assert fit._clustervar == ["f1_f2"]
+
+    # identical to clustering on the materialized column directly
+    direct = feols("Y ~ X1 | f1^f2", data=data, vcov={"CRV1": "f1_f2"})
+    np.testing.assert_allclose(fit._vcov, direct._vcov)


### PR DESCRIPTION
Fix a bug with interacted cluster variables. 

This used to throw an error: 

```python 
pf.feols("Y ~ X1 | f1^f2", data, vcov={"CRV1": "f1^f2"})
fit = pf.feols("Y ~ X1 | f1^f2", data)
fit.vcov({"CRV1": "f1^f2"})
```
because the `vcov` method could not find the interacted variable column named `f1_f2`. 