### PR TITLE
Fix/lean contract

### DIFF
--- a/pyfixest/errors/__init__.py
+++ b/pyfixest/errors/__init__.py
@@ -62,6 +62,10 @@ class FormulaSyntaxError(Exception):  # noqa: D101
     pass
 
 
+class ModelAttributeStrippedError(AttributeError):  # noqa: D101
+    pass
+
+
 __all__ = [
     "CovariateInteractionError",
     "DepvarIsNotNumericError",
@@ -74,6 +78,7 @@ __all__ = [
     "FormulaSyntaxError",
     "InstrumentsAsCovarsError",
     "MatrixNotFullRankError",
+    "ModelAttributeStrippedError",
     "NanInClusterVarError",
     "NonConvergenceError",
     "UnderDeterminedIVError",

--- a/pyfixest/estimation/models/_result_accessor_mixin.py
+++ b/pyfixest/estimation/models/_result_accessor_mixin.py
@@ -149,6 +149,10 @@ class ResultAccessorMixin(TidyColumnAccessors):
     _adj_r2_within: float
     _vcov_type: str
 
+    def _require(self, *attrs: str, feature: str) -> None:
+        """Raise if `lean` or `store_data` removed state. Provided by the host class."""
+        raise NotImplementedError
+
     def _bind_report_methods(self):
         """Bind summary, coefplot, iplot, and etable from pyfixest.report as instance methods."""
         _module = import_module("pyfixest.report")
@@ -303,6 +307,8 @@ class ResultAccessorMixin(TidyColumnAccessors):
         fit._r2, fit._adj_r2, fit._r2_within
         ```
         """
+        self._require("_Y", "_Y_untransformed", "_u_hat", feature="get_performance()")
+
         Y_within = self._Y
         Y = self._Y_untransformed.to_numpy()
 
@@ -584,4 +590,5 @@ class ResultAccessorMixin(TidyColumnAccessors):
         fit.resid()[:5]
         ```
         """
+        self._require("_u_hat", "_weights", feature="resid()")
         return self._u_hat.flatten() / np.sqrt(self._weights.flatten())

--- a/pyfixest/estimation/models/feols_.py
+++ b/pyfixest/estimation/models/feols_.py
@@ -966,10 +966,9 @@ class Feols(ResultAccessorMixin):
             if hasattr(self, attr):
                 delattr(self, attr)
 
-        # The demeaned-data cache belongs to the runner and is shared across
-        # every model in a cache block; keeping a reference here pins it for as
-        # long as any one model lives. The preconditioner lookup is small and
-        # `preconditioner` exposes it, so that one stays.
+        # create a novel DemeanCache object with the preconditioner (which is still
+        # needed) but drops the demeaned variables in the dict - these are no longer
+        # needed
         self._demean_cache = DemeanCache(
             lookup_preconditioner=self._demean_cache.lookup_preconditioner
         )

--- a/pyfixest/estimation/models/feols_.py
+++ b/pyfixest/estimation/models/feols_.py
@@ -977,9 +977,8 @@ class Feols(ResultAccessorMixin):
     def _require(self, *attrs: str, feature: str) -> None:
         """Raise an informative error when `lean` or `store_data` removed state.
 
-        Post-estimation methods call this before touching an attribute that
-        `_clear_attributes` may have deleted, so the user gets the flag to
-        change rather than an `AttributeError` naming a private attribute.
+        Names the model attribute the post-estimation method needs, and the
+        flag that removed it.
         """
         for attr in attrs:
             if hasattr(self, attr):

--- a/pyfixest/estimation/models/feols_.py
+++ b/pyfixest/estimation/models/feols_.py
@@ -4,7 +4,7 @@ import re
 import warnings
 from collections.abc import Mapping
 from importlib import import_module
-from typing import Any, Literal, cast
+from typing import Any, ClassVar, Literal, cast
 
 import numpy as np
 import pandas as pd
@@ -15,7 +15,7 @@ from scipy.stats import chi2, f, t
 
 from pyfixest.core.demean import Preconditioner
 from pyfixest.demeaners import AnyDemeaner, LsmrDemeaner, MapDemeaner
-from pyfixest.errors import VcovTypeNotSupportedError
+from pyfixest.errors import ModelAttributeStrippedError, VcovTypeNotSupportedError
 from pyfixest.estimation.api.utils import _ALL_SAMPLE, _AllSampleSentinel
 from pyfixest.estimation.formula import model_matrix as model_matrix_fixest
 from pyfixest.estimation.formula.parse import Formula as FixestFormula
@@ -639,6 +639,8 @@ class Feols(ResultAccessorMixin):
         """
         # Assuming `data` is the DataFrame in question
 
+        if data is None:
+            self._require("_data", feature="vcov()")
         data_to_check = data if data is not None else self._data
         try:
             data_to_check = _narwhals_to_pandas(data_to_check)
@@ -696,6 +698,8 @@ class Feols(ResultAccessorMixin):
             self._vcov = self._ssc * self._vcov_nid()
 
         elif self._vcov_type == "CRV":
+            if data is None:
+                self._require("_data", feature="vcov() with clustered errors")
             prep = prepare_cluster_state(
                 data=data if data is not None else self._data,
                 clustervar=self._clustervar,
@@ -923,37 +927,72 @@ class Feols(ResultAccessorMixin):
         else:
             self._has_fixef = False
 
+    # Attributes dropped after fitting. `_require` checks against these, so the
+    # set a method needs and the set that was removed stay comparable.
+    _DATA_CLEARED: ClassVar[frozenset[str]] = frozenset({"_data"})
+    _LEAN_CLEARED: ClassVar[frozenset[str]] = frozenset(
+        {
+            "_data",
+            "_X",
+            "_Y",
+            "_Z",
+            "_Xd",
+            "_Yd",
+            "_Zd",
+            "_cluster_df",
+            "_tXZ",
+            "_tZy",
+            "_tZX",
+            "_weights",
+            "_scores",
+            "_tZZinv",
+            "_u_hat",
+            "_Y_hat_link",
+            "_Y_hat_response",
+            "_Y_untransformed",
+        }
+    )
+
     def _clear_attributes(self):
-        attributes = []
+        attributes: set[str] = set()
 
         if not self._store_data:
-            attributes += ["_data"]
+            attributes |= self._DATA_CLEARED
 
         if self._lean:
-            attributes += [
-                "_data",
-                "_X",
-                "_Y",
-                "_Z",
-                "_Xd",
-                "_Yd",
-                "_Zd",
-                "_cluster_df",
-                "_tXZ",
-                "_tZy",
-                "_tZX",
-                "_weights",
-                "_scores",
-                "_tZZinv",
-                "_u_hat",
-                "_Y_hat_link",
-                "_Y_hat_response",
-                "_Y_untransformed",
-            ]
+            attributes |= self._LEAN_CLEARED
 
         for attr in attributes:
             if hasattr(self, attr):
                 delattr(self, attr)
+
+        # The demeaned-data cache belongs to the runner and is shared across
+        # every model in a cache block; keeping a reference here pins it for as
+        # long as any one model lives. The preconditioner lookup is small and
+        # `preconditioner` exposes it, so that one stays.
+        self._demean_cache = DemeanCache(
+            lookup_preconditioner=self._demean_cache.lookup_preconditioner
+        )
+
+    def _require(self, *attrs: str, feature: str) -> None:
+        """Raise an informative error when `lean` or `store_data` removed state.
+
+        Post-estimation methods call this before touching an attribute that
+        `_clear_attributes` may have deleted, so the user gets the flag to
+        change rather than an `AttributeError` naming a private attribute.
+        """
+        for attr in attrs:
+            if hasattr(self, attr):
+                continue
+            flag = (
+                "lean=True"
+                if attr in self._LEAN_CLEARED and self._lean
+                else "store_data=False"
+            )
+            raise ModelAttributeStrippedError(
+                f"`{feature}` needs `{attr}`, which was dropped because the model "
+                f"was fitted with `{flag}`. Refit without it to use `{feature}`."
+            )
 
     def wald_test(self, R=None, q=None, distribution="F"):
         """
@@ -1152,6 +1191,7 @@ class Feols(ResultAccessorMixin):
 
         ```
         """
+        self._require("_data", feature="wildboottest()")
         if param is not None and param not in self._coefnames:
             raise ValueError(
                 f"Parameter {param} not found in the model's coefficients."
@@ -1333,6 +1373,7 @@ class Feols(ResultAccessorMixin):
         fit.ccv(treatment="D", pk=0.05, qk=0.5, n_splits=8, seed=123).head()
         ```
         """
+        self._require("_data", "_X", "_Y", feature="ccv()")
         assert self._supports_cluster_causal_variance, (
             "The model does not support the causal cluster variance estimator."
         )
@@ -1747,8 +1788,9 @@ class Feols(ResultAccessorMixin):
         list(fe["C(f1)"].items())[:5]
         ```
         """
-        weights_sqrt = np.sqrt(self._weights).flatten()
+        self._require("_data", "_weights", "_beta_hat", feature="fixef()")
 
+        weights_sqrt = np.sqrt(self._weights).flatten()
         blocked_transforms = ["i(", "^", "poly("]
         for bt in blocked_transforms:
             if bt in self._fml:
@@ -1892,6 +1934,7 @@ class Feols(ResultAccessorMixin):
         fit.predict(newdata=data.head())
         ```
         """
+        self._require("_X", "_Y_hat_link", feature="predict()")
         if self._is_iv:
             raise NotImplementedError(
                 "The predict() method is currently not supported for IV models."
@@ -2045,6 +2088,7 @@ class Feols(ResultAccessorMixin):
         fit.ritest("X1", reps=1000, store_ritest_statistics=True)
         ```
         """
+        self._require("_data", "_weights", feature="ritest()")
         resampvar = resampvar.replace(" ", "")
         resampvar_, h0_value, hypothesis, test_type = _decode_resampvar(resampvar)
 

--- a/tests/test_model_lifecycle.py
+++ b/tests/test_model_lifecycle.py
@@ -88,13 +88,41 @@ def test_clear_sets_cover_what_is_deleted(data):
     assert leftover == [], f"store_data=False left {leftover} in place"
 
 
-def test_demean_cache_is_released_but_preconditioner_survives(data):
+def test_demean_cache_is_released(data):
     """The shared demeaned-data cache must not be pinned by a fitted model."""
     fit = pf.feols(FML, data)
     assert fit._demean_cache.lookup_demeaned_data == {}
-    # the preconditioner lookup backs the public `preconditioner` property
-    assert isinstance(fit._demean_cache.lookup_preconditioner, dict)
-    assert fit.preconditioner is None or fit.preconditioner is not None
+
+
+def test_preconditioner_survives_the_cache_release(data):
+    """Releasing the demeaned data must not take the preconditioner with it.
+
+    The LSMR `within` backend builds a preconditioner on the first solve and
+    `Feols.preconditioner` hands it back so a later fit over the same design
+    can skip the setup phase. It is stored in the same cache object as the
+    demeaned data that `_clear_attributes` drops, so it needs its own check --
+    and it only exists for two or more fixed effects, where `within` does not
+    fall back to MAP.
+    """
+    demeaner = pf.LsmrDemeaner(backend="within")
+    fit = pf.feols("Y ~ X1 | f1 + f2", data, demeaner=demeaner)
+
+    assert fit._demean_cache.lookup_demeaned_data == {}
+    assert fit.preconditioner is not None
+
+    # the point of keeping it: it can be fed back into a later fit
+    reused = pf.feols(
+        "Y ~ X1 | f1 + f2",
+        data,
+        demeaner=pf.LsmrDemeaner(backend="within", preconditioner=fit.preconditioner),
+    )
+    np.testing.assert_allclose(fit.coef().to_numpy(), reused.coef().to_numpy())
+
+
+def test_single_fixed_effect_has_no_preconditioner(data):
+    """`within` runs MAP for one fixed effect, so there is nothing to preserve."""
+    fit = pf.feols("Y ~ X1 | f1", data, demeaner=pf.LsmrDemeaner(backend="within"))
+    assert fit.preconditioner is None
 
 
 def test_multiple_estimation_does_not_pin_the_cache(data):

--- a/tests/test_model_lifecycle.py
+++ b/tests/test_model_lifecycle.py
@@ -1,0 +1,105 @@
+"""Behaviour of fitted models under `lean=True` and `store_data=False`.
+
+`_clear_attributes` drops attributes by name; these tests pin which methods
+survive that and check the ones that do not fail with an informative error
+rather than an `AttributeError` naming a private attribute.
+"""
+
+import numpy as np
+import pytest
+
+import pyfixest as pf
+from pyfixest.errors import ModelAttributeStrippedError
+
+FML = "Y ~ X1 + X2 | f1"
+
+
+@pytest.fixture(scope="module")
+def data():
+    return pf.get_data().dropna().reset_index(drop=True)
+
+
+def _call(name, fit):
+    return {
+        "predict": lambda f: f.predict(),
+        "fixef": lambda f: f.fixef(),
+        "resid": lambda f: f.resid(),
+        "vcov": lambda f: f.vcov({"CRV1": "f1"}),
+        "ritest": lambda f: f.ritest("X1", reps=5),
+        "get_performance": lambda f: f.get_performance(),
+        "wildboottest": lambda f: f.wildboottest(param="X1", reps=99),
+        "tidy": lambda f: f.tidy(),
+        "confint": lambda f: f.confint(),
+        "coef": lambda f: f.coef(),
+    }[name](fit)
+
+
+# methods that keep working once the attribute set has been stripped
+SURVIVES = {
+    "lean": ["tidy", "confint", "coef"],
+    "store_data": ["tidy", "confint", "coef", "predict", "resid", "get_performance"],
+}
+# methods that need stripped state and must say so
+RAISES = {
+    "lean": [
+        "predict",
+        "fixef",
+        "resid",
+        "vcov",
+        "ritest",
+        "get_performance",
+        "wildboottest",
+    ],
+    "store_data": ["fixef", "vcov", "ritest", "wildboottest"],
+}
+FLAGS = {"lean": {"lean": True}, "store_data": {"store_data": False}}
+
+
+@pytest.mark.parametrize("mode", sorted(FLAGS))
+@pytest.mark.parametrize("method", sorted({m for v in SURVIVES.values() for m in v}))
+def test_surviving_methods_still_work(data, mode, method):
+    if method not in SURVIVES[mode]:
+        pytest.skip(f"{method} is not expected to survive {mode}")
+    _call(method, pf.feols(FML, data, **FLAGS[mode]))
+
+
+@pytest.mark.parametrize("mode", sorted(FLAGS))
+@pytest.mark.parametrize("method", sorted({m for v in RAISES.values() for m in v}))
+def test_stripped_methods_raise_informatively(data, mode, method):
+    """The error names the method, the attribute and the flag that removed it."""
+    if method not in RAISES[mode]:
+        pytest.skip(f"{method} does not need state stripped by {mode}")
+    fit = pf.feols(FML, data, **FLAGS[mode])
+    with pytest.raises(ModelAttributeStrippedError) as exc:
+        _call(method, fit)
+    msg = str(exc.value)
+    assert method in msg
+    assert ("lean=True" in msg) or ("store_data=False" in msg)
+
+
+def test_clear_sets_cover_what_is_deleted(data):
+    """Every name in the clear sets is actually gone from a stripped model."""
+    fit = pf.feols(FML, data, lean=True)
+    leftover = [a for a in type(fit)._LEAN_CLEARED if hasattr(fit, a)]
+    assert leftover == [], f"lean=True left {leftover} in place"
+
+    fit = pf.feols(FML, data, store_data=False)
+    leftover = [a for a in type(fit)._DATA_CLEARED if hasattr(fit, a)]
+    assert leftover == [], f"store_data=False left {leftover} in place"
+
+
+def test_demean_cache_is_released_but_preconditioner_survives(data):
+    """The shared demeaned-data cache must not be pinned by a fitted model."""
+    fit = pf.feols(FML, data)
+    assert fit._demean_cache.lookup_demeaned_data == {}
+    # the preconditioner lookup backs the public `preconditioner` property
+    assert isinstance(fit._demean_cache.lookup_preconditioner, dict)
+    assert fit.preconditioner is None or fit.preconditioner is not None
+
+
+def test_multiple_estimation_does_not_pin_the_cache(data):
+    """Each model in a cache block releases the block's demeaned data."""
+    fits = pf.feols("Y ~ X1 | csw0(f1, f2)", data)
+    for m in fits.to_list():
+        assert m._demean_cache.lookup_demeaned_data == {}
+    assert np.isfinite(fits.to_list()[0].coef().to_numpy()).all()


### PR DESCRIPTION
1) Check if attributes required for post estimation methods are available - these could have been dropped via `lean` and related args. Throws informative error if true. 
2) Drop the demaned data in DemeanCache, only keeps the preconditioner. 