### PR TITLE
perf(feols): stop copying the untransformed design matrix

### DIFF
--- a/pyfixest/estimation/models/feols_.py
+++ b/pyfixest/estimation/models/feols_.py
@@ -527,7 +527,6 @@ class Feols(ResultAccessorMixin):
 
     def wls_transform(self):
         "Transform model matrices for WLS Estimation."
-        self._X_untransformed = self._X.copy()
         if self._has_weights:
             w = np.sqrt(self._weights)
             self._Y = self._Y * w


### PR DESCRIPTION
Drop unused variable `X_untransformed`. It is never used anywhere. 