### PR TITLE
Scope the fixest `^` interaction to the fixed effects segment

### DIFF
--- a/pyfixest/estimation/formula/parse.py
+++ b/pyfixest/estimation/formula/parse.py
@@ -22,9 +22,6 @@ from pyfixest.estimation.formula.formulaic_compat import (
     get_first_multistage_rhs,
     is_structured_formula,
 )
-from pyfixest.estimation.formula.transforms.fixed_effects_encoding import (
-    _FixedEffectsOperatorResolver,
-)
 from pyfixest.estimation.formula.utils import (
     _MULTIPLE_ESTIMATION_PATTERN,
     _get_position_of_first_parenthesis_pair,
@@ -35,7 +32,6 @@ from pyfixest.estimation.formula.utils import (
 
 _PARSER: Final[FormulaParser] = DefaultFormulaParser(
     feature_flags=FORMULAIC_FEATURE_FLAG,
-    operator_resolver=_FixedEffectsOperatorResolver(),
     include_intercept=True,
 )
 

--- a/pyfixest/estimation/formula/transforms/fixed_effects_encoding.py
+++ b/pyfixest/estimation/formula/transforms/fixed_effects_encoding.py
@@ -1,10 +1,6 @@
-import functools
-import itertools
 from typing import Final
 
 import pandas as pd
-from formulaic.parser import DefaultOperatorResolver
-from formulaic.parser.types import Operator, OrderedSet
 from formulaic.utils.stateful_transforms import stateful_transform
 
 FIXED_EFFECT_ENCODING: Final[str] = "__fixed_effect_encoding__"
@@ -23,28 +19,3 @@ def encode_fixed_effects(*args, _state=None, _metadata=None, _spec=None):
     return data.merge(
         _state[FIXED_EFFECT_ENCODING], on=data.columns.tolist(), how="left"
     )[FIXED_EFFECT_ENCODING]
-
-
-class _FixedEffectsOperatorResolver(DefaultOperatorResolver):
-    def __init__(self):
-        super().__init__()
-
-    @property
-    def operators(self) -> list[Operator]:
-        operators = [
-            operator for operator in super().operators if operator.symbol != "^"
-        ]
-
-        operators.append(
-            Operator(
-                symbol="^",
-                arity=2,
-                precedence=500,
-                associativity="left",
-                to_terms=lambda *term_sets: OrderedSet(
-                    functools.reduce(lambda x, y: x * y, term)
-                    for term in itertools.product(*term_sets)
-                ),
-            )
-        )
-        return operators

--- a/pyfixest/estimation/formula/utils.py
+++ b/pyfixest/estimation/formula/utils.py
@@ -10,16 +10,17 @@ from pyfixest.errors import FormulaSyntaxError
 def _str_split_by_sep(string: str, separator: str = "+") -> list[str]:
     """
     Split on top-level *separator*, skipping any occurrences nested inside
-    parentheses.  The main use-case is splitting formula terms on ``+``
-    without breaking apart multi-estimation operators like ``sw(a, b + c)``.
+    parentheses or brackets.  The main use-case is splitting formula terms on
+    ``+`` without breaking apart multi-estimation operators like
+    ``sw(a, b + c)`` or instrumental variable blocks like ``[X2 ~ Z1 + Z2]``.
     """
     args: list[str] = []
     depth = 0
     current: list[str] = []
     for c in string:
-        if c == "(":
+        if c in "([":
             depth += 1
-        elif c == ")":
+        elif c in ")]":
             depth -= 1
         elif c == separator and depth == 0:
             args.append("".join(current).strip())
@@ -83,7 +84,30 @@ _MULTIPLE_ESTIMATION_PATTERN = re.compile(
 def _preprocess(formula: str) -> str:
     formula = _preprocess_fixest_instrumental_variable(formula)
     formula = _preprocess_fixest_multiple_dependents(formula)
+    formula = _preprocess_fixest_fixed_effect_interactions(formula)
     return formula
+
+
+def _preprocess_fixest_fixed_effect_interactions(formula: str) -> str:
+    """Convert fixest-style fixed effect interactions to formulaic.
+    Y ~ X1 | f1^f2 will be converted to Y ~ X1 | f1:f2.
+
+    fixest reads `^` as "interact these fixed effects", while formulaic reads it
+    as exponentiation -- `(X1 + X2)^2` expands to `X1 + X2 + X1:X2`. The two
+    meanings only ever collide inside the fixed effects segment, so the rewrite
+    is restricted to it and `^` keeps its formulaic meaning everywhere else.
+    """
+    main, *fixed_effects = _str_split_by_sep(formula, separator="|")
+    if not fixed_effects:
+        return formula
+    return " | ".join(
+        [main, *(_replace_top_level(fe, "^", ":") for fe in fixed_effects)]
+    )
+
+
+def _replace_top_level(string: str, separator: str, replacement: str) -> str:
+    """Replace *separator* with *replacement* outside of parentheses and brackets."""
+    return replacement.join(_str_split_by_sep(string, separator=separator))
 
 
 def _preprocess_fixest_instrumental_variable(formula: str) -> str:

--- a/tests/test_formula_parse.py
+++ b/tests/test_formula_parse.py
@@ -18,10 +18,6 @@ from pyfixest.estimation.formula.utils import _get_position_of_first_parenthesis
 
 # Known-broken behaviour, fixed by the follow-up PRs in this series. `strict`
 # means the marker has to be removed together with the fix.
-XFAIL_CARET = (
-    "`^` is replaced globally by a fixed-effect interaction operator, so "
-    "`(X1 + X2)^2` no longer expands to an interaction"
-)
 XFAIL_DEPENDENT_PLUS = (
     "any `+` on the left hand side is read as multiple dependent variables, "
     "including one nested inside a transform"
@@ -507,7 +503,6 @@ class TestCaretOperator:
             ("Y ~ (X1 + X2)^2 | f1^f2", "Y ~ X1 + X2 + X1:X2"),
         ],
     )
-    @pytest.mark.xfail(strict=True, reason=XFAIL_CARET)
     def test_caret_expands_like_power_outside_fixed_effects(
         self, formula, expected_second_stage
     ):
@@ -523,7 +518,6 @@ class TestCaretOperator:
             "Y ~ (X1 + X2 + f1)^3",
         ],
     )
-    @pytest.mark.xfail(strict=True, reason=XFAIL_CARET)
     def test_caret_matches_double_star(self, formula):
         """`^` is documented by formulaic as an alias for `**`."""
         assert (
@@ -562,7 +556,6 @@ class TestCaretOperator:
         )
         np.testing.assert_allclose(interacted.se().to_numpy(), manual.se().to_numpy())
 
-    @pytest.mark.xfail(strict=True, reason=XFAIL_CARET)
     def test_caret_power_estimates_interaction(self, test_data):
         """`(X1 + X2)^2` must estimate the interaction, not a `:2` term."""
         fit = pf.feols("Y ~ (X1 + X2)^2", test_data)

--- a/tests/test_release_snapshot.py
+++ b/tests/test_release_snapshot.py
@@ -56,10 +56,6 @@ RESID_REDEFINED_AFTER_RELEASE = {"glm-logit", "glm-probit-fe"}
 # in this series. `strict` means the marker has to be removed together with the
 # fix, so none of these can quietly stay broken.
 KNOWN_FAILURES = {
-    "ols-caret-power": (
-        "`^` is replaced globally by a fixed-effect interaction operator, so "
-        "`(X1 + X2)^2` no longer expands to an interaction"
-    ),
     "ols-identity-sum": (
         "any `+` on the left hand side is read as multiple dependent variables, "
         "including one nested inside a transform"


### PR DESCRIPTION
Stacked on #1421 — merge that first.

### Problem

`_FixedEffectsOperatorResolver` replaces formulaic's `^` operator for the
**whole** formula, but the fixest meaning of `^` (interact these fixed effects)
is only wanted inside the `|` segment. Formulaic documents `^` as an alias for
`**`, so everywhere else it should expand a power:

```python
pf.feols("Y ~ (X1 + X2)^2", data)
# expected: Intercept, X1, X2, X1:X2
# on this branch: Intercept, X1:2, X2:2   <- interaction silently lost
```

### Fix

Rewrite `^` to `:` during preprocessing, in the fixed effects segment only
(`_preprocess_fixest_fixed_effect_interactions`), and drop the custom operator
resolver so formulaic's own `^` survives everywhere else. `_str_split_by_sep`
now tracks brackets as well as parentheses so the split is safe around IV
blocks.

A `^` nested inside parentheses in the FE segment (`| I(x^2)`) is left alone.

### Verification

- `| f1^f2` still demeans on the interacted group — checked numerically against
  a manually built `f1_f2` column (coefficients and standard errors).
- `^` and `**` now produce identical expansions.
- Removes the `XFAIL_CARET` markers and the `ols-caret-power` snapshot marker
  added in #1421.
