### PR TITLE
Derive formulaic `_hat` names from endogenous terms

### DIFF
--- a/pyfixest/estimation/formula/formulaic_compat.py
+++ b/pyfixest/estimation/formula/formulaic_compat.py
@@ -69,12 +69,13 @@ def _get_single_multistage_block(rhs: formulaic.formula.Formula) -> Any:
 
 def filter_multistage_endogenous_terms(
     exogenous: formulaic.formula.Formula,
-    endogenous_variables: Iterable[Any],
+    endogenous_terms: Iterable[Any],
 ) -> formulaic.formula.SimpleFormula:
-    """Drop formulaic's generated ``<endogenous>_hat`` second-stage terms."""
-    # formulaic internal: MULTISTAGE renames endogenous vars to "<name>_hat" in
-    # the second-stage RHS. If formulaic changes the suffix, compat tests catch it.
-    generated_endogenous = {f"{variable}_hat" for variable in endogenous_variables}
+    """Drop formulaic's generated ``<endogenous term>_hat`` second-stage terms."""
+    # formulaic internal: MULTISTAGE renames each endogenous *term* to
+    # "<term>_hat" in the second-stage RHS -- `log(X2)` becomes `log(X2)_hat`,
+    # not `X2_hat`. If formulaic changes the suffix, compat tests catch it.
+    generated_endogenous = {f"{term}_hat" for term in endogenous_terms}
     terms = list(exogenous.root)
     missing = generated_endogenous - {str(term) for term in terms}
     if missing:

--- a/pyfixest/estimation/formula/parse.py
+++ b/pyfixest/estimation/formula/parse.py
@@ -181,9 +181,7 @@ class Formula:
         """Exogenous aka covariates aka independent variables."""
         exogenous = self._right_hand_side
         if self.is_instrumental_variable:
-            exogenous = filter_multistage_endogenous_terms(
-                exogenous, self.endogenous.required_variables
-            )
+            exogenous = filter_multistage_endogenous_terms(exogenous, self.endogenous)
 
         if self.is_fixed_effects and exogenous.required_variables:
             # drop intercept for fixed effects regressions

--- a/tests/test_formula_parse.py
+++ b/tests/test_formula_parse.py
@@ -695,6 +695,12 @@ class TestEdgeCases:
         assert "Z1" in f.second_stage
         # assert f.first_stage == "Z1 ~ W1"
 
+    def test_iv_transformed_endogenous_in_second_stage(self):
+        """A transformed endogenous variable survives the _hat term filtering."""
+        f = Formula.parse("Y ~ X1 | log(Z1) ~ W1")[0]
+        assert f.second_stage == "Y ~ 1 + X1 + log(Z1)"
+        assert f.first_stage.startswith("log(Z1) ~")
+
     def test_iv_with_fe_endogenous_in_second_stage(self):
         """Endogenous variable should be in second_stage even with FE."""
         result = Formula.parse("Y ~ X1 | f1 | Z1 ~ W1")

--- a/tests/test_formulaic_compat.py
+++ b/tests/test_formulaic_compat.py
@@ -57,6 +57,29 @@ def test_hat_suffix_filtering(data: pd.DataFrame) -> None:
     assert "X2_hat" not in exog_vars
 
 
+def test_hat_suffix_filtering_with_transformed_endogenous(data: pd.DataFrame) -> None:
+    """Formulaic names generated terms after the endogenous term, not its variables."""
+    fit = pf.feols("Y ~ X1 + [np.exp(X2) ~ Z1]", data=data)
+
+    exog_terms = {str(term) for term in fit.FixestFormula.exogenous}
+
+    # `np.exp(X2)` generates `np.exp(X2)_hat`, never `X2_hat`.
+    assert exog_terms == {"1", "X1"}
+    assert fit.FixestFormula.second_stage == "Y ~ 1 + X1 + np.exp(X2)"
+    assert "np.exp(X2)" in fit.coef().index
+
+
+def test_transformed_endogenous_matches_precomputed_column(data: pd.DataFrame) -> None:
+    """Transforming the endogenous variable inline equals transforming it in the data."""
+    precomputed = data.assign(exp_X2=np.exp(data["X2"]))
+
+    inline = pf.feols("Y ~ X1 + [np.exp(X2) ~ Z1]", data=data)
+    column = pf.feols("Y ~ X1 + [exp_X2 ~ Z1]", data=precomputed)
+
+    np.testing.assert_allclose(inline.coef().to_numpy(), column.coef().to_numpy())
+    np.testing.assert_allclose(inline.se().to_numpy(), column.se().to_numpy())
+
+
 def test_multistage_access_guard_raises_loudly() -> None:
     """Malformed formulaic MULTISTAGE shape must fail before silent IV leakage."""
     malformed_rhs = formulaic.Formula("X1")


### PR DESCRIPTION
Stacked on #1422 — merge that first.

### Problem

formulaic's MULTISTAGE syntax names the generated second-stage term after the
endogenous **term**, not its source variables
([`parser.py`](https://github.com/matthewwardrop/formulaic/blob/v1.2.1/formulaic/parser/parser.py#L354-L364) builds `Factor(str(t) + "_hat")`
from the term). So `[log(X2) ~ Z1]` generates `log(X2)_hat`.

`filter_multistage_endogenous_terms` derived the name from
`required_variables` and therefore looked for `X2_hat`, which is never present:

```python
pf.feols("Y ~ X1 | log(X2) ~ Z1", data)
# FormulaicCompatibilityError: expected generated second-stage terms
# ['X2_hat'] to be present before filtering
```

Any transformed endogenous variable hit this — the guard fired on a formula
that used to work.

### Fix

Pass the endogenous *terms* rather than their source variables, so the expected
name is built the same way formulaic builds it. The comment now records the
`log(X2)` vs `X2` distinction so it doesn't regress.

### Verification

Inline `[np.exp(X2) ~ Z1]` matches the same model with the transform
precomputed as a data column, on both coefficients and standard errors.
Removes the `XFAIL_TRANSFORMED_ENDOGENOUS` markers from #1421.
