### PR TITLE
Treat a nested `+` in the dependent as one outcome

### DIFF
--- a/pyfixest/estimation/formula/parse.py
+++ b/pyfixest/estimation/formula/parse.py
@@ -81,10 +81,12 @@ class Formula:
                 f"Received {len(self._formula.rhs)}:\n"
                 f"{self._formula}"
             )
-        if len(self.dependent.required_variables) > 1:
+        # Count terms, not source variables: `I(Y + Y2)` is one dependent
+        # expression evaluated from two columns.
+        if len(self.dependent) > 1:
             raise FormulaSyntaxError(
-                f"Formula must have exactly one variable on the left hand side. "
-                f"Received: {self.dependent.required_variables}"
+                f"Formula must have exactly one term on the left hand side. "
+                f"Received: {[str(term) for term in self.dependent]}"
             )
         if self.is_instrumental_variable:
             self._validate_instrumental_variable_specification()

--- a/pyfixest/estimation/formula/utils.py
+++ b/pyfixest/estimation/formula/utils.py
@@ -145,10 +145,12 @@ def _preprocess_fixest_multiple_dependents(formula: str) -> str:
     if "~" not in formula:
         raise FormulaSyntaxError("Formula must contain '~'.")
     dependent, rest = re.split(r"\s*~\s*", formula, maxsplit=1)
-    if "+" in dependent:
-        # Multiple dependent variables
+    # Only a top-level `+` separates dependents: `I(Y + Y2)` is a single
+    # transformed dependent, not two.
+    dependents = _str_split_by_sep(dependent, separator="+")
+    if len(dependents) > 1:
         formula_old = formula
-        formula = f"{_MultipleEstimationType.sw.name}({', '.join(_str_split_by_sep(dependent, separator='+'))}) ~ {rest}"
+        formula = f"{_MultipleEstimationType.sw.name}({', '.join(dependents)}) ~ {rest}"
         warnings.warn(
             "Specifiying multiple dependent variables with `+` is deprecated and will throw an error in a future version. "
             f"Instead of `{formula_old}` use `{formula}`",

--- a/tests/test_formula_parse.py
+++ b/tests/test_formula_parse.py
@@ -688,6 +688,32 @@ class TestEdgeCases:
         result = Formula.parse("Y + Y2 + Y3 ~ X1")
         assert len(result) == 3
 
+    @pytest.mark.parametrize(
+        "formula,expected_second_stage",
+        [
+            ("I(Y + Y2) ~ X1", "I(Y + Y2) ~ 1 + X1"),
+            ("I(Y + Y2 + Y3) ~ X1", "I(Y + Y2 + Y3) ~ 1 + X1"),
+            ("log(Y + Y2) ~ X1", "log(Y + Y2) ~ 1 + X1"),
+        ],
+    )
+    def test_transformed_dependent_with_plus(self, formula, expected_second_stage):
+        """A `+` nested in a transform is not a multiple-dependent separator."""
+        result = Formula.parse(formula)
+        assert len(result) == 1
+        assert result[0].second_stage == expected_second_stage
+
+    def test_transformed_dependent_matches_precomputed_column(self, test_data):
+        """`I(Y + Y2)` estimates the summed outcome, not two separate models."""
+        data = test_data.dropna().copy()
+        data["Y_sum"] = data["Y"] + data["Y2"]
+
+        transformed = pf.feols("I(Y + Y2) ~ X1", data)
+        precomputed = pf.feols("Y_sum ~ X1", data)
+
+        np.testing.assert_allclose(
+            transformed.coef().to_numpy(), precomputed.coef().to_numpy()
+        )
+
     def test_iv_endogenous_in_second_stage(self):
         """Endogenous variable should be added to second_stage covariates."""
         result = Formula.parse("Y ~ X1 | Z1 ~ W1")


### PR DESCRIPTION
Stacked on #1423 — merge that first.

### Problem

Two places treated a `+` anywhere on the left hand side as a separator between
multiple dependent variables:

1. `_preprocess_fixest_multiple_dependents` tested `"+" in dependent`, so
   `I(Y + Y2)` was rewritten to a one-argument `sw(...)` and rejected.
2. `Formula.__post_init__` counted `dependent.required_variables`, which is 2
   for `I(Y + Y2)` — one expression evaluated from two columns.

```python
pf.feols("I(Y + Y2) ~ X1", data)
# FormulaSyntaxError: 'sw(...)' requires at least 2 arguments, got 1
```

### Fix

Split the left hand side on **top-level** `+` only, so a `+` nested inside a
transform stays part of the expression, and count dependent *terms* instead of
source variables.

`Y + Y2 ~ X1` still expands to two models and still emits its
`DeprecationWarning`.

### Verification

`I(Y + Y2) ~ X1` estimates one model whose coefficients match the same
regression on a precomputed `Y + Y2` column. Removes the
`XFAIL_DEPENDENT_PLUS` markers and the `ols-identity-sum` snapshot marker from
#1421.
