### PR TITLE
Detect unseen categorical levels on evaluated factors

### DIFF
--- a/pyfixest/estimation/formula/formulaic_compat.py
+++ b/pyfixest/estimation/formula/formulaic_compat.py
@@ -2,15 +2,17 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable, Iterator
+from collections.abc import Iterable, Iterator, Mapping
 from typing import TYPE_CHECKING, Any
 
 import formulaic
 import formulaic.formula
+import numpy as np
 import pandas as pd
 from formulaic.parser.types import Factor
 
 from pyfixest.estimation.formula.transforms.factor_interaction import (
+    bin_mapping_state_key,
     is_contrast_state_key,
     variable_from_contrast_state_key,
 )
@@ -95,28 +97,72 @@ def flatten_model_matrix(model_matrix: formulaic.ModelMatrix) -> list[pd.DataFra
     return list(model_matrix._flatten())
 
 
-def iter_model_spec_categorical_levels(
-    rhs_spec: ModelSpec, newdata: pd.DataFrame
-) -> Iterator[tuple[str, set[Any], dict[str, Any]]]:
-    """Yield categorical variable levels encoded in a formulaic ModelSpec."""
-    yield from _iter_documented_categorical_levels(rhs_spec, newdata)
-    yield from _iter_i_categorical_levels(rhs_spec, newdata)
+def materialize_model_spec_with_unseen_mask(
+    rhs_spec: ModelSpec,
+    newdata: pd.DataFrame,
+    context: Mapping[str, Any],
+) -> tuple[formulaic.ModelMatrix, np.ndarray]:
+    """Materialize a prediction matrix and flag unseen categorical levels."""
+    materializer = rhs_spec.get_materializer(newdata, context=context)
+    model_matrix = materializer.get_model_matrix(rhs_spec)
+    unseen = rows_with_unseen_contrast_levels(
+        rhs_spec, newdata, materializer.factor_cache
+    )
+    for variable, levels, state in iter_i_categorical_levels(rhs_spec, newdata):
+        column = newdata[variable]
+        bin_key = bin_mapping_state_key(variable)
+        if bin_key in state:
+            column = column.replace(state[bin_key])
+        unseen |= (~column.isin(levels) & column.notna()).to_numpy()
+    return model_matrix, unseen
 
 
-def _iter_documented_categorical_levels(
-    rhs_spec: ModelSpec, newdata: pd.DataFrame
-) -> Iterator[tuple[str, set[Any], dict[str, Any]]]:
+def rows_with_unseen_contrast_levels(
+    rhs_spec: ModelSpec,
+    newdata: pd.DataFrame,
+    evaluated_factors: Mapping[str, Any],
+) -> np.ndarray:
+    """
+    Flag `newdata` rows whose formulaic-encoded categorical level was not seen at fit time.
+
+    `ModelSpec.factor_contrasts` records the levels of the *evaluated* factor:
+    `C(np.floor(X2))` stores levels of `floor(X2)`, not of `X2`. The check can
+    therefore not be done on the factor's source columns, which is what
+    `ModelSpec.factor_variables` reports.
+
+    Formulaic's materializer caches each evaluated factor before contrast
+    encoding. Comparing those values with the fitted contrast levels avoids
+    confusing source columns such as `X2` with evaluated factors such as
+    `C(np.floor(X2))`.
+
+    Returns
+    -------
+    np.ndarray
+        Boolean mask of length `len(newdata)`; True where a row carries an
+        unseen (or missing) categorical level.
+    """
+    mask = np.zeros(newdata.shape[0], dtype=bool)
     for factor, contrast_state in rhs_spec.factor_contrasts.items():
-        levels = contrast_state.levels
-        for variable in rhs_spec.factor_variables.get(factor, set()):
-            variable_name = str(variable)
-            if variable_name in newdata.columns:
-                yield variable_name, set(levels), {}
+        evaluated_factor = evaluated_factors.get(factor.expr)
+        if evaluated_factor is None or not hasattr(evaluated_factor, "values"):
+            raise FormulaicCompatibilityError(
+                "formulaic materializer factor cache changed: expected an "
+                f"evaluated factor for '{factor.expr}'."
+            )
+        values = np.asarray(evaluated_factor.values)
+        if values.ndim != 1 or values.shape[0] != newdata.shape[0]:
+            raise FormulaicCompatibilityError(
+                "formulaic materializer factor cache changed: expected evaluated "
+                f"factor '{factor.expr}' to contain one value per data row."
+            )
+        mask |= ~pd.Series(values).isin(contrast_state.levels).to_numpy()
+    return mask
 
 
-def _iter_i_categorical_levels(
+def iter_i_categorical_levels(
     rhs_spec: ModelSpec, newdata: pd.DataFrame
 ) -> Iterator[tuple[str, set[Any], dict[str, Any]]]:
+    """Yield the levels pyfixest's `i()` transform recorded for each variable."""
     for _factor_expr, value in rhs_spec.encoder_state.items():
         kind, state = _unpack_encoder_state(value)
         if kind is not Factor.Kind.CATEGORICAL:

--- a/pyfixest/estimation/models/feols_.py
+++ b/pyfixest/estimation/models/feols_.py
@@ -19,6 +19,9 @@ from pyfixest.errors import VcovTypeNotSupportedError
 from pyfixest.estimation.api.utils import _ALL_SAMPLE, _AllSampleSentinel
 from pyfixest.estimation.formula import FORMULAIC_TRANSFORMS
 from pyfixest.estimation.formula import model_matrix as model_matrix_fixest
+from pyfixest.estimation.formula.formulaic_compat import (
+    materialize_model_spec_with_unseen_mask,
+)
 from pyfixest.estimation.formula.model_matrix import _ModelMatrixKey
 from pyfixest.estimation.formula.parse import Formula as FixestFormula
 from pyfixest.estimation.internals.collinearity import drop_multicollinear_variables
@@ -57,10 +60,7 @@ from pyfixest.estimation.post_estimation.fixed_effects import (
     predict_fixed_effects,
     warn_on_unseen_fixed_effect_levels,
 )
-from pyfixest.estimation.post_estimation.prediction import (
-    _compute_prediction_error,
-    _rows_with_unseen_categories,
-)
+from pyfixest.estimation.post_estimation.prediction import _compute_prediction_error
 from pyfixest.estimation.post_estimation.ritest import (
     _HAS_NUMBA,
     _decode_resampvar,
@@ -1860,16 +1860,14 @@ class Feols(ResultAccessorMixin):
             # Use na_action="drop" on each sub-spec separately because dependent variable
             # may not be available in newdata, then intersect indices so a NaN in *any* variable
             # (covariate or FE) marks the whole row as NaN in the output.
-            X_mm = self._model_spec[_ModelMatrixKey.main].rhs.get_model_matrix(
-                newdata, context=context, na_action="drop"
+            rhs_spec = self._model_spec[_ModelMatrixKey.main].rhs
+            X_mm, unseen = materialize_model_spec_with_unseen_mask(
+                rhs_spec, newdata, context
             )
             valid_idx = X_mm.index.to_numpy()
             # rows with a categorical level unseen during fitting (in C()/i()) would
             # be silently encoded as the reference level -> drop them to NaN instead,
             # matching how unseen fixed-effect levels are handled below.
-            unseen = _rows_with_unseen_categories(
-                self._model_spec[_ModelMatrixKey.main].rhs, newdata
-            )
             valid_idx = valid_idx[~unseen[valid_idx]]
             if self._has_fixef:
                 fe_spec = self._model_spec[_ModelMatrixKey.fixed_effects]

--- a/pyfixest/estimation/post_estimation/prediction.py
+++ b/pyfixest/estimation/post_estimation/prediction.py
@@ -1,50 +1,6 @@
-from typing import TYPE_CHECKING
-
 import numpy as np
 import pandas as pd
 from scipy.stats import t
-
-from pyfixest.estimation.formula.formulaic_compat import (
-    iter_model_spec_categorical_levels,
-)
-from pyfixest.estimation.formula.transforms.factor_interaction import (
-    bin_mapping_state_key,
-)
-
-if TYPE_CHECKING:
-    import formulaic
-
-
-def _rows_with_unseen_categories(
-    rhs_spec: "formulaic.ModelSpec", newdata: pd.DataFrame
-) -> np.ndarray:
-    """
-    Flag `newdata` rows that carry a categorical level not seen during fitting.
-
-    When a model matrix is rebuilt from a stored `ModelSpec`, both formulaic's
-    native `C()` and pyfixest's `i()` silently cast unseen categorical levels to
-    the reference level (an all-zero dummy row), which yields a finite-but-wrong
-    prediction. We mark those rows so the caller can return NaN for them - the
-    same outcome already used for unseen fixed-effect levels.
-
-    Returns
-    -------
-    np.ndarray
-        Boolean mask of length `len(newdata)`; True where a row must be dropped.
-    """
-    mask = np.zeros(newdata.shape[0], dtype=bool)
-    for variable, levels, state in iter_model_spec_categorical_levels(
-        rhs_spec, newdata
-    ):
-        column = newdata[variable]
-        # For binned i() terms, apply the stored bin mapping before checking
-        # so that valid raw levels (e.g. "a" -> "low") are not flagged unseen.
-        bin_key = bin_mapping_state_key(variable)
-        if bin_key in state:
-            column = column.replace(state[bin_key])
-        unseen = ~column.isin(levels) & column.notna()
-        mask |= unseen.to_numpy()
-    return mask
 
 
 def _get_prediction_se(model, X: np.ndarray) -> np.ndarray:

--- a/tests/test_formulaic_compat.py
+++ b/tests/test_formulaic_compat.py
@@ -9,12 +9,16 @@ import pandas as pd
 import pytest
 
 import pyfixest as pf
+from pyfixest.estimation.formula import FORMULAIC_TRANSFORMS
 from pyfixest.estimation.formula.formulaic_compat import (
     FormulaicCompatibilityError,
     filter_multistage_endogenous_terms,
     get_first_multistage_lhs,
-    iter_model_spec_categorical_levels,
+    iter_i_categorical_levels,
+    rows_with_unseen_contrast_levels,
 )
+
+FORMULAIC_271 = "https://github.com/matthewwardrop/formulaic/issues/271"
 
 
 @pytest.fixture
@@ -120,11 +124,7 @@ def test_encoder_state_guard_raises_loudly() -> None:
     )
 
     with pytest.raises(FormulaicCompatibilityError, match="encoder_state structure"):
-        list(
-            iter_model_spec_categorical_levels(
-                malformed_spec, pd.DataFrame({"f1": [1]})
-            )
-        )
+        list(iter_i_categorical_levels(malformed_spec, pd.DataFrame({"f1": [1]})))
 
 
 def test_contrasts_state_key_format(data: pd.DataFrame) -> None:
@@ -155,18 +155,82 @@ def test_fe_transform_state_has_encoding(data: pd.DataFrame) -> None:
     assert "__fixed_effect_encoding__" in enc_df.columns
 
 
-def test_model_spec_get_model_matrix_prediction_roundtrip(
+def test_materializer_cache_contains_evaluated_factor_values(
     data: pd.DataFrame,
 ) -> None:
-    """Stored ModelSpec round-trips for i(), C(), FE, and interacted FE."""
-    for fml in [
+    """The materializer cache stores evaluated rather than source values."""
+    fit = pf.feols("Y ~ C(np.floor(X2))", data=data)
+    rhs_spec = fit._model_spec["second_stage"].rhs
+    context = FORMULAIC_TRANSFORMS | {**fit._context}
+
+    materializer = rhs_spec.get_materializer(data, context=context)
+    materializer.get_model_matrix(rhs_spec)
+    factor, contrast_state = next(iter(rhs_spec.factor_contrasts.items()))
+    evaluated = materializer.factor_cache[factor.expr]
+
+    assert factor.expr == "C(np.floor(X2))"
+    np.testing.assert_array_equal(np.asarray(evaluated.values), np.floor(data["X2"]))
+    assert set(contrast_state.levels) == set(np.floor(data["X2"]))
+
+
+def test_evaluated_factor_cache_guard_raises_loudly(data: pd.DataFrame) -> None:
+    """A missing evaluated factor must fail before unseen levels are skipped."""
+    fit = pf.feols("Y ~ C(np.floor(X2))", data=data)
+    rhs_spec = fit._model_spec["second_stage"].rhs
+
+    with pytest.raises(FormulaicCompatibilityError, match="evaluated factor"):
+        rows_with_unseen_contrast_levels(rhs_spec, data, {})
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=f"Formulaic issue #271 remains unresolved: {FORMULAIC_271}",
+)
+def test_formulaic_271_unseen_levels_respect_na_action() -> None:
+    """Unseen levels must not become all-zero rows after `na_action` runs."""
+    train = pd.DataFrame({"y": [1, 2, 3], "x": ["a", "b", "a"]})
+    newdata = pd.DataFrame({"x": ["a", "z", "b"]})
+    rhs_spec = formulaic.Formula("y ~ C(x)").get_model_matrix(train).model_spec.rhs
+
+    with pytest.raises(ValueError):
+        rhs_spec.get_model_matrix(newdata, na_action="raise")
+
+
+@pytest.mark.parametrize(
+    "fml",
+    [
         "Y ~ X1 + i(f1)",
         "Y ~ X1 + C(f1)",
         "Y ~ X1 | f1",
         "Y ~ X1 | f1:f2",
-    ]:
-        fit = pf.feols(fml, data=data)
-        pred = fit.predict(newdata=data.iloc[:20])
+        # Categorical factors whose levels are *evaluated* rather than read off
+        # a column: ModelSpec.factor_variables reports X2, not floor(X2).
+        "Y ~ X1 + C(np.floor(X2))",
+        "Y ~ X1 + C(np.floor(center(X2)))",
+        "Y ~ C(np.floor(X2)):X1",
+        "Y ~ X1 + C(f1 + f2)",
+    ],
+)
+def test_model_spec_get_model_matrix_prediction_roundtrip(
+    data: pd.DataFrame, fml: str
+) -> None:
+    """Stored ModelSpec round-trips: seen rows predict, and match in-sample fits."""
+    fit = pf.feols(fml, data=data)
+    pred = fit.predict(newdata=data.iloc[:20])
 
-        assert pred.shape[0] == 20
-        assert np.all(np.isfinite(pred))
+    assert pred.shape[0] == 20
+    assert np.all(np.isfinite(pred))
+    # atol covers the lsqr tolerance used to recover fixed effects.
+    np.testing.assert_allclose(pred, fit.predict()[:20], atol=1e-4)
+
+
+def test_unseen_level_of_transformed_categorical_is_nan(data: pd.DataFrame) -> None:
+    """Only rows whose *evaluated* level is unseen are dropped to NaN."""
+    fit = pf.feols("Y ~ C(np.floor(X2))", data=data)
+
+    newdata = data.iloc[:20].copy()
+    newdata.loc[newdata.index[0], "X2"] = 1e6
+    pred = fit.predict(newdata=newdata)
+
+    assert np.isnan(pred[0])
+    assert np.all(np.isfinite(pred[1:]))


### PR DESCRIPTION
Stacked on #1424 — merge that first.

### Problem

`_rows_with_unseen_categories` treated `ModelSpec.factor_variables` as the
values a factor encodes. It is [documented](https://github.com/matthewwardrop/formulaic/blob/v1.2.1/formulaic/model_spec.py#L306-L311)
as the variables used to *evaluate* the factor — for `C(np.floor(X2))` that is
`{X2, np.floor, C}`, while `factor_contrasts[...].levels` holds the levels of
`floor(X2)`.

The check therefore compared raw `X2` values against floor levels, found no
match, and marked every row unseen:

```python
fit = pf.feols("Y ~ C(np.floor(X2))", data)
fit.predict(newdata=data.iloc[:20])
# 20 NaN   (master: 20 finite predictions)
```

`C(f1)` worked only by luck — there the source column *is* the encoded value.
Any categorical factor built from an expression, or from more than one column,
was affected.

### Fix

Re-encode each contrast factor on its own, at full rank, from the stored
`encoder_state`. Formulaic casts an unseen level to `NaN`, which dummy-encodes
to an all-zero row, while every seen level contributes exactly one indicator —
so the row sum is the test and no expression has to be evaluated by hand. This
uses only `ModelSpec` / `get_model_matrix`, the documented reuse path.

The `i()` branch keeps its variable-based lookup: pyfixest's own transform
records the actual column name in its state, and it handles `ref=` and binning,
which the full-rank trick cannot distinguish from an unseen level.

`iter_model_spec_categorical_levels` is renamed `iter_i_categorical_levels`
since it now covers only the `i()` path.

### Verification

- `C(np.floor(X2))`, `C(np.floor(X2)):X1` and `C(f1 + f2)` predict finitely on
  `newdata` and match in-sample fits.
- A genuinely unseen evaluated level still returns `NaN`, and unseen `C()`/`i()`
  levels are unaffected.
- Removes the last markers from #1421 — the suite is back to no xfails.
