### PR TITLE
Update `pixi.lock` for the formulaic version bound

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -27845,9 +27845,9 @@ packages:
 - pypi: ./
   name: pyfixest
   version: 0.60.0
-  sha256: b6f43a9d2103d1e17c1ab03d54839e9df416a757d784282322858b7bb0c071bc
+  sha256: 75cfd97fdaf1d3534094deb3a8080d8afe14714e69eb59d249ec1400db556db8
   requires_dist:
-  - formulaic>=1.1.0
+  - formulaic>=1.2.0,<1.3
   - joblib>=1.4.2
   - maketables>=0.1.0
   - narwhals>=1.13.3


### PR DESCRIPTION
Stacked on #1425 — merge that first.

`pyproject.toml` on this branch requires `formulaic>=1.2.0,<1.3`, but
`pixi.lock` still recorded the old `>=1.1.0`.

Two consequences:

- `pixi run --locked ...` refuses to start with `lock-file not up-to-date with
  the workspace`, so CI jobs that use `--locked` can't run.
- A plain `pixi run test-py` silently rewrites the tracked `pixi.lock`, so the
  file keeps showing up dirty in unrelated work.

Regenerated with `pixi lock`. The diff is just the requirement line and the
source hash. Since the dependency bump is intentional, the updated lock belongs
with it.
