### PR TITLE
Document the formula parsing changes in the changelog

### DIFF
--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -69,7 +69,86 @@ fit.confint(inference_type="savi", mixture_precision=mixture_precision)
   exactly. We slightly deviate from `fixest::feglm(family="gaussian")`, which uses slightly different small sample corrections between OLS and GLM with Gaussian link.
 - Logit and probit IRLS initialise at new values for better numerical stability.
 
+### Formula Parsing on `formulaic`
+
+Formula parsing no longer splits strings by hand. `feols()` and friends now hand
+the formula to `formulaic`, keep the resulting `ModelSpec`, and reuse it to build
+model matrices for `predict()` and `fixef()`. Most formula terms consequently use
+`formulaic`'s syntax and semantics directly. PyFixest still preprocesses its
+fixest-style multiple-estimation syntax and deprecated legacy spellings. Reusing
+the fitted `ModelSpec` removes a class of bugs where a model matrix was rebuilt
+from `newdata` with different encodings than the one it was fitted on.
+
+The required `formulaic` version is now `>=1.2.0,<1.3`.
+
+Behaviour that changed as a result:
+
+- **Model names are canonical `formulaic` formulas.** They now carry an explicit
+  intercept, order terms by interaction order, and normalise whitespace:
+
+  ```python
+  pf.feols("Y ~ sw(X2+X1, X1)", data)
+  # 0.60.0: ["Y ~ X2+X1", "Y ~ X1"]
+  # 0.70.0: ["Y ~ 1 + X2 + X1", "Y ~ 1 + X1"]
+  ```
+
+  Anything keyed on the old spelling needs updating -- `rename_models` mappings
+  in `etable()`, `coefplot()` and `iplot()`, and lookups into
+  `FixestMulti.all_fitted_models`.
+
+- **Duplicate specifications collapse to one model.** Because names are
+  canonical, a multiple-estimation expansion that produces the same model twice
+  is now estimated and reported once:
+
+  ```python
+  pf.feols("Y ~ csw0(X2, f3) + X2", data)
+  # 0.60.0: 3 models, including the duplicate "Y ~ X2 + X2"
+  # 0.70.0: 2 models
+  ```
+
+- **`fixef()` returns a `pd.DataFrame`** with columns `variable`, `code`,
+  `level` and `coefficient`, instead of `dict[str, dict[str, float]]`. Replace
+  `fit.fixef()["C(f1)"][level]` with a lookup on the frame. The estimates are
+  unchanged, except that with two or more fixed effects the reference level of
+  the second and later ones is now listed explicitly with a coefficient of `0`
+  rather than omitted.
+
+- **Fixed-effect interactions use `:` as their canonical spelling.** Write
+  `Y ~ X1 | f1:f2` to absorb the interaction of `f1` and `f2`. Formulas, model
+  names, summaries, `fixef()` output and prediction messages all use `f1:f2`.
+  The former `f1^f2` spelling remains accepted temporarily, but emits a
+  `DeprecationWarning` and is immediately normalised to `f1:f2`.
+
+- **`predict(newdata=...)` works with `i()`, interacted fixed effects
+  (`f1:f2`) and `poly()`.** These previously raised `NotImplementedError`; the
+  stored `ModelSpec` now encodes `newdata` against the levels seen at fit time.
+  Rows carrying a categorical level that was not seen during fitting return
+  `NaN`, matching how unseen fixed effect levels were already handled. IV
+  models still do not support `predict()`.
+
+- **Malformed formulas may raise `formulaic.errors.FormulaSyntaxError`** rather
+  than `pyfixest.errors.FormulaSyntaxError`. The two are unrelated classes --
+  neither inherits from the other, and neither is a `ValueError` -- so code
+  catching the pyfixest exception has to catch both.
+
+- **`pyfixest.estimation.formula.factor_interaction` moved** to
+  `pyfixest.estimation.formula.transforms.factor_interaction`. The `i()`
+  operator itself is unaffected; only the import path changed.
+
 ### Deprecations and Removals
+
+Formula syntax:
+
+- Using `^` for a fixed-effect interaction (`Y ~ X1 | f1^f2`) is deprecated in
+  favour of `:` (`Y ~ X1 | f1:f2`). The old spelling still works and now emits
+  a `DeprecationWarning`.
+- The fixest-style instrumental variable syntax `Y ~ X1 | X2 ~ Z1` is deprecated
+  in favour of `formulaic`'s `Y ~ X1 + [X2 ~ Z1]`. The old spelling still works
+  and now emits a `DeprecationWarning`.
+- Specifying multiple dependent variables with `+` (`Y + Y2 ~ X1`) is deprecated
+  in favour of `sw(Y, Y2) ~ X1`. The old spelling still works and now emits a
+  `DeprecationWarning`. A `+` nested inside a transform (`I(Y + Y2) ~ X1`) is a
+  single dependent variable and is unaffected.
 
 As previously announced, we removed:
 


### PR DESCRIPTION
Stacked on #1426 — merge that first.

Adds a `### Formula Parsing on formulaic` section to the 0.70.0 changelog. The
refactor is a good change, but several user-visible behaviours moved without a
note, so anyone upgrading hits them cold.

Documented, each verified by running 0.60.0 and this branch side by side:

- **Model names are canonical formulaic formulas** — explicit intercept, terms
  ordered by interaction order, normalised whitespace. `Y ~ sw(X2+X1, X1)` goes
  from `["Y ~ X2+X1", "Y ~ X1"]` to `["Y ~ 1 + X2 + X1", "Y ~ 1 + X1"]`. This
  breaks `rename_models` mappings and lookups into `all_fitted_models`.
- **Duplicate specifications collapse.** `Y ~ csw0(X2, f3) + X2` returns 2
  models instead of 3. Intended, but worth stating.
- **`fixef()` returns a DataFrame** instead of `dict[str, dict[str, float]]`,
  with a migration line. Estimates are unchanged, except the reference level of
  the second and later fixed effects is now listed explicitly with a
  coefficient of 0 rather than omitted.
- **`predict(newdata=...)` now works with `i()`, `^` and `poly()`**, which
  previously raised `NotImplementedError`. IV still doesn't.
- **Exception class** — malformed formulas may raise
  `formulaic.errors.FormulaSyntaxError` instead of the pyfixest one. I checked
  the hierarchy: they're unrelated and neither is a `ValueError`, so callers
  have to catch both.
- **`estimation.formula.factor_interaction` moved** under `transforms/`.
- **Deprecations** — fixest-style IV (`Y ~ X1 | X2 ~ Z1`) and multiple
  dependents via `+`, both of which now emit a `DeprecationWarning`.

Bug fixes from PRs #1422–#1425 are listed under `### Bug Fixes`.

The `formulaic>=1.2.0,<1.3` requirement is mentioned too.
