### PR TITLE
feat(predict): warn on NaN predictions from newdata covariates

### DIFF
--- a/pyfixest/estimation/models/feols_.py
+++ b/pyfixest/estimation/models/feols_.py
@@ -1759,8 +1759,18 @@ class Feols(ResultAccessorMixin):
         Predict values of the model on new data.
 
         Return a flat np.array with predicted values of the regression model.
-        If new fixed effect levels are introduced in `newdata`, predicted values
-        for such observations will be set to NaN.
+
+        NaN and singleton handling differs by branch and mirrors R's `fixest`:
+
+        - If `newdata` is None, predictions are returned for the estimation
+          sample only. Rows with NaNs and singleton fixed effect levels were
+          already dropped when the model was fit, so the result has length equal
+          to the number of observations used in estimation and contains no NaNs.
+        - If `newdata` is passed, one prediction is returned per row of
+          `newdata`. Rows that cannot be predicted return NaN: a NaN in a right
+          hand side covariate, or a fixed effect level not seen in the
+          estimation sample. In both cases `predict` warns about the affected
+          rows.
 
         Parameters
         ----------

--- a/pyfixest/estimation/post_estimation/prediction.py
+++ b/pyfixest/estimation/post_estimation/prediction.py
@@ -74,6 +74,19 @@ def get_design_matrix_and_yhat(
             X = X[np.array(model._coefnames)[coef_idx]]
             X = X.to_numpy()
 
+            # Rows dropped by the model matrix have a NaN in a right hand side
+            # covariate and cannot be predicted. Warn, mirroring the unseen fixed
+            # effect level warning, so NaN predictions are not returned silently.
+            n_dropped = newdata.shape[0] - len(X_index)
+            if n_dropped > 0:
+                warnings.warn(
+                    f"{n_dropped} row(s) in newdata contain a NaN in a right hand "
+                    "side covariate and cannot be predicted; predictions for these "
+                    "observations will be NaN.",
+                    UserWarning,
+                    stacklevel=3,  # emit warning at `predict` caller
+                )
+
             # Initialize y_hat with NaNs, fill in only for valid (X_index) rows
             y_hat = np.full(newdata.shape[0], np.nan)
             y_hat[X_index] = X @ model._beta_hat[coef_idx]

--- a/tests/test_predict_na_handling.py
+++ b/tests/test_predict_na_handling.py
@@ -1,0 +1,69 @@
+"""Tests for NaN and singleton handling in Feols.predict (issue #1236).
+
+These tests pin down the documented contract of `Feols.predict`:
+
+* ``newdata=None`` predicts on the estimation sample, where rows with NaNs and
+  singleton fixed effect levels were already dropped during fitting. The result
+  therefore has length ``_N`` and contains no NaNs.
+* ``newdata=<df>`` predicts on every row of the passed data. Rows that cannot be
+  predicted (NaN in a right hand side covariate, or an unseen fixed effect level)
+  return NaN, and ``predict`` warns about them.
+
+No R / rpy2 dependency so these run in the default test environment.
+"""
+
+import warnings
+
+import numpy as np
+import pytest
+
+import pyfixest as pf
+
+
+def test_predict_none_drops_nas_newdata_keeps_rows():
+    """newdata=None returns the estimation sample; newdata keeps every row."""
+    data = pf.get_data(N=1_000, seed=0, model="Feols")
+    fit = pf.feols("Y ~ X1", data=data)
+
+    pred_none = fit.predict(newdata=None)
+    pred_full = fit.predict(newdata=data)
+
+    # newdata=None: estimation sample only, NaN rows already dropped.
+    assert len(pred_none) == fit._N
+    assert fit._N < data.shape[0]
+    assert not np.isnan(pred_none).any()
+
+    # newdata=data: one prediction per input row.
+    assert len(pred_full) == data.shape[0]
+
+    # a row with a NaN covariate cannot be predicted -> NaN.
+    nan_x1 = np.where(data["X1"].isna().to_numpy())[0]
+    assert nan_x1.size > 0
+    assert np.isnan(pred_full[nan_x1]).all()
+
+
+def test_predict_newdata_covariate_nan_warns():
+    """predict(newdata) must warn when a covariate NaN forces NaN predictions."""
+    data = pf.get_data(N=1_000, seed=0, model="Feols")
+    fit = pf.feols("Y ~ X1", data=data)
+
+    assert data["X1"].isna().any()
+
+    with pytest.warns(UserWarning, match="cannot be predicted"):
+        pred = fit.predict(newdata=data)
+
+    assert np.isnan(pred).any()
+
+
+def test_predict_newdata_no_missing_does_not_warn():
+    """No warning when newdata has no rows that fail to predict."""
+    data = pf.get_data(N=1_000, seed=0, model="Feols").dropna()
+    fit = pf.feols("Y ~ X1", data=data)
+
+    with warnings.catch_warnings(record=True) as record:
+        warnings.simplefilter("always")
+        pred = fit.predict(newdata=data)
+
+    assert len(pred) == data.shape[0]
+    assert not np.isnan(pred).any()
+    assert not [w for w in record if issubclass(w.category, UserWarning)]

--- a/tests/test_predict_na_handling.py
+++ b/tests/test_predict_na_handling.py
@@ -30,7 +30,7 @@ def test_predict_none_drops_nas_newdata_keeps_rows():
 
     # newdata=None: estimation sample only, NaN rows already dropped.
     assert len(pred_none) == fit._N
-    assert fit._N < data.shape[0]
+    assert data.shape[0] > fit._N
     assert not np.isnan(pred_none).any()
 
     # newdata=data: one prediction per input row.


### PR DESCRIPTION
Feols.predict returns predictions for the estimation sample when newdata is None (NaNs and singleton fixed effect levels already dropped), but returns one prediction per row when newdata is passed. Rows with an unseen fixed effect level already warn and return NaN; rows with a NaN in a right hand side covariate returned NaN silently.

Warn for those covariate NaN rows too, mirroring the unseen level warning, so predict no longer returns NaN predictions without notice. Document the NaN and singleton handling of both branches in the predict docstring. Behavior for returned values is unchanged.

Part of #1236