### PR TITLE
Use : as formulaic-native fixed effect interaction

### DIFF
--- a/docs/acknowledgements.md
+++ b/docs/acknowledgements.md
@@ -14,7 +14,7 @@ More concretely, we have borrowed the following API conventions and ideas direct
 
 | Feature | What PyFixest borrows |
 |---|---|
-| **Formula syntax** | `feols()`, `fepois()`, `feglm()` function and argument names; the `i()` interaction operator; multiple estimation syntax via `sw()`, `sw0()`, `csw()`, `csw0()`; fixed effects interactions via `fe1^fe2` |
+| **Formula syntax** | `feols()`, `fepois()`, `feglm()` function and argument names; the `i()` interaction operator; multiple estimation syntax via `sw()`, `sw0()`, `csw()`, `csw0()` |
 | **Multiple Estimation Optimizations** | The core idea that most of the work of fixed effects regression can be pooled / cached when estimating multiple models with the same fixed effects structure|
 | **Demeaning / FWL** | The alternating-projections algorithm in PyFixest is a standalone implementation in numba/rust, but uses the same convergence criteria and default parameters |
 | **Small-sample corrections** | The `ssc()` function to control small sample adjustments, and all of its defaults - `adj`, `fixef_K`, `cluster_adj`, `cluster_df` - mirror fixest exactly (see fixest's [standard errors vignette](https://cran.r-project.org/web/packages/fixest/vignettes/standard_errors.html)) |

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -42,7 +42,7 @@ Other syntax:
   Example (cat × numeric): `Y ~ i(industry, exposure)` creates industry-specific slopes on `exposure`.
   Example (cat × cat): `Y ~ i(state, year, ref2=2000)` creates state-by-year indicators with 2000 as the base year.
 - Standard interactions work as well. `X1 * X2` expands to `X1 + X2 + X1:X2`, while `X1:X2` is the interaction term only.
-- Interacted FEs: `"Y ~ X1 | FE1 ^ FE2"` (creates a combined FE).
+- Interacted FEs: `"Y ~ X1 | FE1:FE2"` (creates a combined FE).
 
 ### Multiple Estimation Operators
 

--- a/docs/tutorials/formula-syntax.qmd
+++ b/docs/tutorials/formula-syntax.qmd
@@ -67,10 +67,10 @@ We can add fixed effects behind the `|` operator: here we add two fixed effects 
 fit6 = pf.feols("Y ~ X1 + X2 | f1 + f2", data=data)
 ```
 
-We can interact two fixed effects via the `^` operator.
+We can interact two fixed effects via the `:` operator.
 
 ```{python}
-fit7 = pf.feols("Y ~ X1 + X2 | f1^f2", data=data)
+fit7 = pf.feols("Y ~ X1 + X2 | f1:f2", data=data)
 ```
 
 For details on fixed effects regression, take a look at the [OLS with Fixed Effects](ols-fixed-effects.qmd) vignette.

--- a/pyfixest/estimation/api/feglm.py
+++ b/pyfixest/estimation/api/feglm.py
@@ -85,7 +85,7 @@ def feglm(
         - Cumulative stepwise regression (csw, csw0)
         - Multiple dependent variables (Y1 + Y2 ~ X)
         - Interaction of variables (i(X1,X2))
-        - Interacted fixed effects (fe1^fe2)
+        - Interacted fixed effects (fe1:fe2)
         Compatible with formula parsing via the formulaic module.
 
     data : DataFrameType

--- a/pyfixest/estimation/api/feols.py
+++ b/pyfixest/estimation/api/feols.py
@@ -62,7 +62,7 @@ def feols(
         Syntax: "Y ~ X1 + X2 | FE1 + FE2 | X1 ~ Z1". "|" separates dependent variable,
         fixed effects, and instruments. Special syntax includes stepwise regressions,
         cumulative stepwise regression, multiple dependent variables,
-        interaction of variables (i(X1,X2)), and interacted fixed effects (fe1^fe2).
+        interaction of variables (i(X1,X2)), and interacted fixed effects (fe1:fe2).
 
     data : DataFrameType
         A pandas or polars dataframe containing the variables in the formula.

--- a/pyfixest/estimation/api/fepois.py
+++ b/pyfixest/estimation/api/fepois.py
@@ -55,7 +55,7 @@ def fepois(
         - Cumulative stepwise regression (csw, csw0)
         - Multiple dependent variables (Y1 + Y2 ~ X)
         - Interaction of variables (i(X1,X2))
-        - Interacted fixed effects (fe1^fe2)
+        - Interacted fixed effects (fe1:fe2)
         Compatible with formula parsing via the formulaic module.
 
     data : DataFrameType

--- a/pyfixest/estimation/formula/parse.py
+++ b/pyfixest/estimation/formula/parse.py
@@ -22,9 +22,6 @@ from pyfixest.estimation.formula.formulaic_compat import (
     get_first_multistage_rhs,
     is_structured_formula,
 )
-from pyfixest.estimation.formula.transforms.fixed_effects_encoding import (
-    _FixedEffectsOperatorResolver,
-)
 from pyfixest.estimation.formula.utils import (
     _MULTIPLE_ESTIMATION_PATTERN,
     _get_position_of_first_parenthesis_pair,
@@ -35,7 +32,6 @@ from pyfixest.estimation.formula.utils import (
 
 _PARSER: Final[FormulaParser] = DefaultFormulaParser(
     feature_flags=FORMULAIC_FEATURE_FLAG,
-    operator_resolver=_FixedEffectsOperatorResolver(),
     include_intercept=True,
 )
 
@@ -144,7 +140,7 @@ class Formula:
         if self.is_instrumental_variable:
             formula = f"{formula} + [{self.endogenous} ~ {self.instruments}]"
         if self.is_fixed_effects:
-            formula = f"{formula} | {str(self.fixed_effects).replace(':', '^')}"
+            formula = f"{formula} | {self.fixed_effects}"
         return formula
 
     @property

--- a/pyfixest/estimation/formula/transforms/fixed_effects_encoding.py
+++ b/pyfixest/estimation/formula/transforms/fixed_effects_encoding.py
@@ -1,10 +1,6 @@
-import functools
-import itertools
 from typing import Final
 
 import pandas as pd
-from formulaic.parser import DefaultOperatorResolver
-from formulaic.parser.types import Operator, OrderedSet
 from formulaic.utils.stateful_transforms import stateful_transform
 
 FIXED_EFFECT_ENCODING: Final[str] = "__fixed_effect_encoding__"
@@ -23,28 +19,3 @@ def encode_fixed_effects(*args, _state=None, _metadata=None, _spec=None):
     return data.merge(
         _state[FIXED_EFFECT_ENCODING], on=data.columns.tolist(), how="left"
     )[FIXED_EFFECT_ENCODING]
-
-
-class _FixedEffectsOperatorResolver(DefaultOperatorResolver):
-    def __init__(self):
-        super().__init__()
-
-    @property
-    def operators(self) -> list[Operator]:
-        operators = [
-            operator for operator in super().operators if operator.symbol != "^"
-        ]
-
-        operators.append(
-            Operator(
-                symbol="^",
-                arity=2,
-                precedence=500,
-                associativity="left",
-                to_terms=lambda *term_sets: OrderedSet(
-                    functools.reduce(lambda x, y: x * y, term)
-                    for term in itertools.product(*term_sets)
-                ),
-            )
-        )
-        return operators

--- a/pyfixest/estimation/formula/utils.py
+++ b/pyfixest/estimation/formula/utils.py
@@ -10,16 +10,17 @@ from pyfixest.errors import FormulaSyntaxError
 def _str_split_by_sep(string: str, separator: str = "+") -> list[str]:
     """
     Split on top-level *separator*, skipping any occurrences nested inside
-    parentheses.  The main use-case is splitting formula terms on ``+``
-    without breaking apart multi-estimation operators like ``sw(a, b + c)``.
+    brackets. The main use-case is splitting formula terms on ``+`` without
+    breaking apart multi-estimation operators like ``sw(a, b + c)`` or
+    Formulaic multistage expressions like ``[x ~ z1 + z2]``.
     """
     args: list[str] = []
     depth = 0
     current: list[str] = []
     for c in string:
-        if c == "(":
+        if c in "([{":
             depth += 1
-        elif c == ")":
+        elif c in ")]}":
             depth -= 1
         elif c == separator and depth == 0:
             args.append("".join(current).strip())
@@ -82,7 +83,31 @@ _MULTIPLE_ESTIMATION_PATTERN = re.compile(
 
 def _preprocess(formula: str) -> str:
     formula = _preprocess_fixest_instrumental_variable(formula)
+    formula = _preprocess_fixed_effect_interactions(formula)
     formula = _preprocess_fixest_multiple_dependents(formula)
+    return formula
+
+
+def _preprocess_fixed_effect_interactions(formula: str) -> str:
+    """Translate legacy top-level fixed-effect interactions to Formulaic syntax."""
+    parts = _str_split_by_sep(formula, separator="|")
+    if len(parts) < 2:
+        return formula
+
+    fixed_effect_parts = _str_split_by_sep(parts[1], separator="^")
+    if len(fixed_effect_parts) == 1:
+        return formula
+
+    formula_old = formula
+    parts[1] = ":".join(fixed_effect_parts)
+    formula = " | ".join(parts)
+    warnings.warn(
+        "The `^` operator for fixed-effect interactions is deprecated and will "
+        "throw an error in a future version. "
+        f"Instead of `{formula_old}` use `{formula}`",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     return formula
 
 

--- a/pyfixest/estimation/models/feols_.py
+++ b/pyfixest/estimation/models/feols_.py
@@ -338,7 +338,7 @@ class Feols(ResultAccessorMixin):
         self._fml = FixestFormula.formula
         self._has_fixef = False
         self._fixef = (
-            str(FixestFormula.fixed_effects).replace(" ", "").replace(":", "^")
+            str(FixestFormula.fixed_effects).replace(" ", "")
             if FixestFormula.is_fixed_effects
             else None
         )
@@ -450,7 +450,7 @@ class Feols(ResultAccessorMixin):
 
         self._has_fixef = self._fe is not None
         self._fixef = (
-            str(self.FixestFormula.fixed_effects).replace(" ", "").replace(":", "^")
+            str(self.FixestFormula.fixed_effects).replace(" ", "")
             if self.FixestFormula.is_fixed_effects
             else None
         )

--- a/pyfixest/estimation/post_estimation/fixed_effects.py
+++ b/pyfixest/estimation/post_estimation/fixed_effects.py
@@ -34,8 +34,8 @@ class FixedEffect:
         Internal encoded fixed-effect name used as the corresponding model-matrix
         column, for example `__fixed_effect__(firm)`.
     variable : str
-        User-facing fixed-effect name. Interacted variables are joined with `^`,
-        for example `firm^year`.
+        User-facing fixed-effect name. Interacted variables are joined with `:`,
+        for example `firm:year`.
     codes : NDArray[np.int64]
         Integer codes identifying fixed-effect levels observed in the estimation
         sample after singleton removal.
@@ -220,7 +220,7 @@ def warn_on_unseen_fixed_effect_levels(
             missing = newdata.loc[unseen, source_columns].drop_duplicates()
             warnings.warn(
                 f"{missing.shape[0]} unseen level(s) for fixed effect "
-                f"`{'^'.join(source_columns)}`: {missing.iloc[:20]}\n"
+                f"`{':'.join(source_columns)}`: {missing.iloc[:20]}\n"
                 "Predictions for affected observations will be NaN",
                 UserWarning,
                 stacklevel=3,
@@ -250,7 +250,7 @@ def get_fixed_effect_encoding_data(
         column for column in encoding.columns if column != FIXED_EFFECT_ENCODING
     ]
     return (
-        "^".join(value_columns),
+        ":".join(value_columns),
         encoding[FIXED_EFFECT_ENCODING].to_numpy(dtype=np.int64),
         tuple(encoding[column].to_numpy(copy=True) for column in value_columns),
     )

--- a/tests/test_formula_parse.py
+++ b/tests/test_formula_parse.py
@@ -7,6 +7,8 @@ This module contains:
 - Part 3: Edge case tests
 """
 
+import warnings
+
 import formulaic
 import numpy as np
 import pytest
@@ -14,7 +16,10 @@ import pytest
 import pyfixest as pf
 from pyfixest.errors import FormulaSyntaxError
 from pyfixest.estimation.formula.parse import Formula, _expand_all_multiple_estimation
-from pyfixest.estimation.formula.utils import _get_position_of_first_parenthesis_pair
+from pyfixest.estimation.formula.utils import (
+    _get_position_of_first_parenthesis_pair,
+    _preprocess_fixed_effect_interactions,
+)
 
 # =============================================================================
 # Fixtures
@@ -477,6 +482,73 @@ class TestFormulaParse:
         assert "f1 + f2" in result
 
 
+class TestFixedEffectInteractions:
+    """Tests for canonical and legacy fixed-effect interaction syntax."""
+
+    def test_canonical_interaction_parses_without_warning(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            parsed = Formula.parse("Y ~ X1 | f1:f2")[0]
+
+        assert str(parsed._formula.rhs[1]) == "1 + f1:f2"
+        assert parsed.formula == "Y ~ X1 | f1:f2"
+
+    def test_legacy_interaction_warns_once_and_is_canonical(self):
+        canonical = Formula.parse("Y ~ X1 | f1:f2")[0]
+
+        with pytest.warns(
+            DeprecationWarning,
+            match=r"Instead of `Y ~ X1 \| f1\^f2` use `Y ~ X1 \| f1:f2`",
+        ) as caught:
+            legacy = Formula.parse("Y ~ X1 | f1^f2")[0]
+
+        assert len(caught) == 1
+        assert legacy._formula.rhs[1] == canonical._formula.rhs[1]
+        assert legacy.formula == canonical.formula == "Y ~ X1 | f1:f2"
+
+    @pytest.mark.parametrize(
+        "fixed_effects,expected",
+        [
+            ("f1^f2^f3", "f1:f2:f3"),
+            ("f1^f2:f3 + f4^f5", "f1:f2:f3 + f4:f5"),
+        ],
+    )
+    def test_legacy_chained_and_mixed_interactions(self, fixed_effects, expected):
+        with pytest.warns(DeprecationWarning) as caught:
+            parsed = Formula.parse(f"Y ~ X1 | {fixed_effects}")[0]
+
+        assert len(caught) == 1
+        assert set(str(parsed.fixed_effects).split(" + ")) == set(expected.split(" + "))
+        assert "^" not in parsed.formula
+
+    def test_rewrite_is_scoped_to_top_level_fixed_effects(self):
+        formula = "Y^out ~ (X1 + X2)^2 + [X3 ~ (Z1 + Z2)^2] | I(f1^2) + f2^f3"
+
+        with pytest.warns(DeprecationWarning) as caught:
+            translated = _preprocess_fixed_effect_interactions(formula)
+
+        assert len(caught) == 1
+        assert translated == (
+            "Y^out ~ (X1 + X2)^2 + [X3 ~ (Z1 + Z2)^2] | I(f1^2) + f2:f3"
+        )
+
+    def test_formulaic_power_operators_match_outside_fixed_effects(self):
+        caret = Formula.parse("Y ~ (X1 + X2)^2 | f1:f2")[0]
+        double_star = Formula.parse("Y ~ (X1 + X2)**2 | f1:f2")[0]
+
+        assert caret._formula.rhs[0] == double_star._formula.rhs[0]
+        assert str(caret._formula.rhs[0]) == "1 + X1 + X2 + X1:X2"
+
+    def test_nested_fe_and_iv_power_expressions_are_untouched(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            nested_fe = Formula.parse("Y ~ X1 | I(f1^2)")[0]
+            iv_power = Formula.parse("Y ~ X1 + [X2 ~ (Z1 + Z2)^2] | f1:f2")[0]
+
+        assert str(nested_fe.fixed_effects) == "I(f1 ^ 2)"
+        assert str(iv_power.instruments) == "1 + Z1 + Z2 + Z1:Z2"
+
+
 class TestValidation:
     """Tests for formula validation / error handling."""
 
@@ -573,6 +645,18 @@ def test_explicit_no_fe_iv_coefficients_match(test_data):
 
     assert np.allclose(fit_implicit.coef().values, fit_explicit.coef().values)
     assert np.allclose(fit_implicit.se().values, fit_explicit.se().values)
+
+
+def test_interacted_fixed_effect_matches_manual_interaction(test_data):
+    """Interacted fixed effects match an explicitly constructed group."""
+    data = test_data.dropna(subset=["Y", "X1", "f1", "f2"]).copy()
+    data["f1_f2"] = list(zip(data["f1"], data["f2"], strict=True))
+
+    interacted = pf.feols("Y ~ X1 | f1:f2", data=data, fixef_rm="none")
+    manual = pf.feols("Y ~ X1 | f1_f2", data=data, fixef_rm="none")
+
+    np.testing.assert_allclose(interacted.coef(), manual.coef())
+    np.testing.assert_allclose(interacted.se(), manual.se())
 
 
 # =============================================================================

--- a/tests/test_formulaic_compat.py
+++ b/tests/test_formulaic_compat.py
@@ -140,7 +140,7 @@ def test_model_spec_get_model_matrix_prediction_roundtrip(
         "Y ~ X1 + i(f1)",
         "Y ~ X1 + C(f1)",
         "Y ~ X1 | f1",
-        "Y ~ X1 | f1^f2",
+        "Y ~ X1 | f1:f2",
     ]:
         fit = pf.feols(fml, data=data)
         pred = fit.predict(newdata=data.iloc[:20])

--- a/tests/test_i.py
+++ b/tests/test_i.py
@@ -396,8 +396,9 @@ def test_factor_x_continuous(df_test, fml):
 @pytest.mark.against_r_core
 def test_interacted_fixed_effects(df_test):
     """Test i() with interacted fixed effects."""
-    fml = "Y ~ i(f_str) | fe1^fe2"
-    py_names, py_values, r_names, r_values = compare_with_r(fml, df_test)
+    r_fml = "Y ~ i(f_str) | fe1^fe2"
+    py_fml = "Y ~ i(f_str) | fe1:fe2"
+    py_names, py_values, r_names, r_values = compare_with_r(r_fml, df_test, py_fml)
     assert_models_match(py_names, py_values, r_names, r_values)
 
 

--- a/tests/test_others.py
+++ b/tests/test_others.py
@@ -265,12 +265,12 @@ def test_predict_newdata_poly_transform(fml):
 @pytest.mark.parametrize(
     "fml",
     [
-        "Y ~ X1 | f1^f2",
-        "Y ~ X1 + X2 | f1^f2",
+        "Y ~ X1 | f1:f2",
+        "Y ~ X1 + X2 | f1:f2",
     ],
 )
 def test_predict_newdata_fe_interaction(fml):
-    """Test predict(newdata=...) works for models with fixed-effect interactions (^)."""
+    """Test predict(newdata=...) works for fixed-effect interactions."""
     data = get_data(N=500, seed=42).dropna()
     newdata = data.iloc[:100]
 
@@ -461,12 +461,14 @@ def test_fixef_nan_fe_level_excluded():
 
 
 def test_fixef_interacted_labels():
-    """Interacted FEs decode to `g^h` keys with `val1,val2` level labels."""
+    """Interacted FEs decode to `g:h` keys with `val1,val2` level labels."""
     df = _fixef_test_data()
-    fit = feols("Y ~ X1 | g^h", data=df)
+    fit = feols("Y ~ X1 | g:h", data=df)
     coefficients = fit.fixef(atol=1e-12, btol=1e-12)
 
-    assert coefficients["variable"].unique().tolist() == ["g^h"]
+    assert fit._fml == "Y ~ X1 | g:h"
+    assert fit._fixef == "g:h"
+    assert coefficients["variable"].unique().tolist() == ["g:h"]
     levels = set(coefficients["level"])
     assert all("," in level for level in levels)
     observed = {f"{g},{h}" for g, h in zip(df["g"], df["h"], strict=True)}
@@ -475,6 +477,12 @@ def test_fixef_interacted_labels():
     np.testing.assert_allclose(
         fit.predict(), fit.predict(newdata=df), rtol=1e-6, atol=1e-8
     )
+
+    newdata = df.iloc[:2].copy()
+    newdata.iloc[0, newdata.columns.get_loc("g")] = "unseen"
+    with pytest.warns(UserWarning, match=r"fixed effect `g:h`"):
+        prediction = fit.predict(newdata=newdata)
+    assert np.isnan(prediction[0])
 
 
 def test_fixef_excludes_singleton_levels_from_prediction():
@@ -489,7 +497,7 @@ def test_fixef_excludes_singleton_levels_from_prediction():
     )
 
     with pytest.warns(UserWarning, match="1 singleton fixed effect"):
-        fit = feols("Y ~ X1 | g^h", data=df)
+        fit = feols("Y ~ X1 | g:h", data=df)
 
     prediction = fit.predict(newdata=df)
     fixed_effects = fit.fixef()

--- a/tests/test_predict_resid_fixef.py
+++ b/tests/test_predict_resid_fixef.py
@@ -78,7 +78,7 @@ def test_poisson_prediction_internally(data, weights, fml):
     [
         "Y~ X1 | f1",
         "Y~ X1 | f1 + f2",
-        "Y~ X1 | f1^f2",
+        "Y~ X1 | f1:f2",
     ],
 )
 def test_vs_fixest(data, fml):
@@ -92,14 +92,15 @@ def test_vs_fixest(data, fml):
     fepois_mod.fixef(atol=1e-12, btol=1e-12)
 
     # fixest estimation
+    r_fml = fml.replace("f1:f2", "f1^f2")
     r_fixest_ols = fixest.feols(
-        ro.Formula(fml),
+        ro.Formula(r_fml),
         data=data,
         se="hetero",
     )
 
     r_fixest_pois = fixest.fepois(
-        ro.Formula(fml),
+        ro.Formula(r_fml),
         data=data,
         se="hetero",
     )
@@ -173,7 +174,7 @@ def test_vs_fixest(data, fml):
     data_off["off"] = np.log(np.random.default_rng(0).uniform(0.5, 3.0, len(data_off)))
     fepois_mod_off = pf.fepois(fml=fml, data=data_off, offset="off")
     r_fixest_pois_off = fixest.fepois(
-        ro.Formula(fml), data=data_off, offset=ro.Formula("~off")
+        ro.Formula(r_fml), data=data_off, offset=ro.Formula("~off")
     )
     data2_off = data_off.copy()[1:500]
     if not np.allclose(
@@ -251,7 +252,7 @@ def test_predict_nas():
     [
         "Y~ X1 | f1",
         "Y~ X1 | f1 + f2",
-        "Y~ X1 | f1^f2",
+        "Y~ X1 | f1:f2",
     ],
 )
 def test_new_fixef_level(data, fml):
@@ -259,8 +260,9 @@ def test_new_fixef_level(data, fml):
 
     feols_mod = pf.feols(fml=fml, data=data, vcov="HC1")
     # fixest estimation
+    r_fml = fml.replace("f1:f2", "f1^f2")
     r_fixest_ols = fixest.feols(
-        ro.Formula(fml),
+        ro.Formula(r_fml),
         data=data,
         se="hetero",
     )

--- a/tests/test_vs_fixest.py
+++ b/tests/test_vs_fixest.py
@@ -78,9 +78,9 @@ ols_fmls = [
 
 ols_but_not_poisson_fml = [
     ("log(Y) ~ X1"),
-    ("Y~X1|f2^f3"),
-    ("Y~X1|f1 + f2^f3"),
-    ("Y~X1|f2^f3^f1"),
+    ("Y~X1|f2:f3"),
+    ("Y~X1|f1 + f2:f3"),
+    ("Y~X1|f2:f3:f1"),
 ]
 
 empty_models = [
@@ -103,7 +103,7 @@ iv_fmls = [
     # "log(Y) ~ X2 + C(f1) | X1 ~ Z1",
     "Y ~ 1 | f1 | X1 ~ Z1",
     "Y ~ 1 | f1 + f3 | X1 ~ Z1",
-    "Y ~ 1 | f1^f2 | X1 ~ Z1",
+    "Y ~ 1 | f1:f2 | X1 ~ Z1",
     "Y ~  X2| f3 | X1 ~ Z1",
     # tests of overidentified models
     "Y ~ 1 | X1 ~ Z1 + Z2",
@@ -1480,6 +1480,7 @@ def _py_fml_to_r_fml(py_fml):
     syntax converter,
     i.e. 'Y1 + X2 ~ X' -> 'c(Y1, Y2) ~ X'
     """
+    py_fml = _fixed_effect_interactions_to_fixest(py_fml)
     py_fml = py_fml.replace(" ", "").replace("C(", "as.factor(")
 
     fml2 = py_fml.split("|")
@@ -1507,7 +1508,17 @@ def _c_to_as_factor(py_fml):
     # Use re.sub() to perform the replacement
     r_fml = re.sub(pattern, replacement, py_fml)
 
-    return r_fml
+    return _fixed_effect_interactions_to_fixest(r_fml)
+
+
+def _fixed_effect_interactions_to_fixest(fml):
+    """Translate PyFixest fixed-effect interactions to R fixest syntax."""
+    parts = fml.split("|")
+    for index, part in enumerate(parts[1:], start=1):
+        if "~" not in part:
+            parts[index] = part.replace(":", "^")
+            break
+    return "|".join(parts)
 
 
 def get_data_r(fml, data):
@@ -1617,7 +1628,7 @@ ssc_fmls = [
     "Y ~ X1 + X2 | f2",
     "Y ~ X1 + X2 | f1 + f2",
     "Y ~ X1 + X2 | f1 + f2 + f3",
-    "Y ~ X1 + X2 | f1^f2",
+    "Y ~ X1 + X2 | f1:f2",
 ]
 
 
@@ -1641,7 +1652,7 @@ def test_ssc(fml, dropna, weights, vcov, k_adj, G_adj, k_fixef, model):
         )
 
     r_kwargs = {
-        "fml": ro.Formula(fml),
+        "fml": ro.Formula(_fixed_effect_interactions_to_fixest(fml)),
         "vcov": vcov if vcov in ["iid", "hetero"] else ro.Formula(f"~{vcov}"),
         "data": df,
         "ssc": fixest.ssc(k_adj, k_fixef, False, G_adj, "min", "min"),


### PR DESCRIPTION
This PR replace the `fixest`-style fixed-effect interaction syntax `f1^f2` with the formulaic-native syntax `f1:f2`. A custom preprocessing step ensures backwards-compatibility for now but `^` is deprecated. See #1422 for further background details.