### PR TITLE
Use formula terms for parser cardinality checks

### DIFF
--- a/pyfixest/estimation/formula/formulaic_compat.py
+++ b/pyfixest/estimation/formula/formulaic_compat.py
@@ -25,6 +25,11 @@ class FormulaicCompatibilityError(RuntimeError):
     """Raised when formulaic internals no longer match pyfixest expectations."""
 
 
+def terms_without_intercept(formula: formulaic.formula.Formula) -> Iterator[Any]:
+    """Yield formula terms excluding Formulaic's intercept term."""
+    return (term for term in formula if term != "1")
+
+
 def is_structured_formula(rhs: formulaic.formula.Formula) -> bool:
     """Return whether formulaic parsed an IV RHS as a StructuredFormula."""
     return isinstance(rhs, formulaic.formula.StructuredFormula)

--- a/pyfixest/estimation/formula/parse.py
+++ b/pyfixest/estimation/formula/parse.py
@@ -21,6 +21,7 @@ from pyfixest.estimation.formula.formulaic_compat import (
     get_first_multistage_lhs,
     get_first_multistage_rhs,
     is_structured_formula,
+    terms_without_intercept,
 )
 from pyfixest.estimation.formula.utils import (
     _MULTIPLE_ESTIMATION_PATTERN,
@@ -100,13 +101,13 @@ class Formula:
                 f"Received {n_multistage_blocks} multistage blocks:\n "
                 f"{self._formula}"
             )
-        if len(self.endogenous.required_variables) > 1:
+        if len(self.endogenous) > 1:
             raise FormulaSyntaxError(
                 "Multiple endogenous variables are currently not supported. "
                 "See https://github.com/py-econometrics/pyfixest/issues/791"
             )
-        underdetermined = len(self.endogenous.required_variables) > len(
-            self.instruments.required_variables
+        underdetermined = len(self.endogenous) > len(
+            tuple(terms_without_intercept(self.instruments))
         )
         if underdetermined:
             raise UnderDeterminedIVError(
@@ -185,13 +186,12 @@ class Formula:
         if self.is_instrumental_variable:
             exogenous = filter_multistage_endogenous_terms(exogenous, self.endogenous)
 
-        if self.is_fixed_effects and exogenous.required_variables:
-            # drop intercept for fixed effects regressions
-            # unless for specifications without required_variables,
-            # e.g., `Y ~ 1 | f1`; this can be used to demean dependenent variabels
-            exogenous = formulaic.formula.SimpleFormula(
-                [term for term in exogenous if term != "1"]
-            )
+        exogenous_terms = tuple(terms_without_intercept(exogenous))
+        if self.is_fixed_effects and exogenous_terms:
+            # Drop the intercept for fixed effects regressions, except for
+            # intercept-only specifications such as `Y ~ 1 | f1`; these can be
+            # used to demean dependent variables.
+            exogenous = formulaic.formula.SimpleFormula(exogenous_terms)
 
         return exogenous
 
@@ -219,7 +219,7 @@ class Formula:
         if not self.is_fixed_effects:
             raise AttributeError("Not a fixed effects specification")
         return formulaic.formula.SimpleFormula(
-            [term for term in self._formula.rhs[1] if term != "1"]
+            terms_without_intercept(self._formula.rhs[1])
         )
 
     @property

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -388,17 +388,22 @@ def spline_data():
         ("feglm", "gaussian"),
     ],
 )
-def test_context_capture(spline_data, method, family):
+@pytest.mark.parametrize("fixed_effects", ["", " | f1 + f2"])
+def test_context_capture(spline_data, method, family, fixed_effects):
     method_kwargs = {"data": spline_data}
     if family:
         method_kwargs["family"] = family
 
-    explicit_fit = getattr(pf, method)("Y ~ X2_0 + 0_X2_1 + 1_X2", **method_kwargs)
+    explicit_fit = getattr(pf, method)(
+        f"Y ~ X2_0 + 0_X2_1 + 1_X2{fixed_effects}", **method_kwargs
+    )
     context_captured_fit = getattr(pf, method)(
-        "Y ~ _lspline(X2,[0,1])", context=0, **method_kwargs
+        f"Y ~ _lspline(X2,[0,1]){fixed_effects}", context=0, **method_kwargs
     )
     context_captured_fit_map = getattr(pf, method)(
-        "Y ~ _lspline(X2,[0,1])", context={"_lspline": _lspline}, **method_kwargs
+        f"Y ~ _lspline(X2,[0,1]){fixed_effects}",
+        context={"_lspline": _lspline},
+        **method_kwargs,
     )
 
     for context_fit in [context_captured_fit, context_captured_fit_map]:

--- a/tests/test_formulaic_compat.py
+++ b/tests/test_formulaic_compat.py
@@ -16,6 +16,7 @@ from pyfixest.estimation.formula.formulaic_compat import (
     get_first_multistage_lhs,
     iter_i_categorical_levels,
     rows_with_unseen_contrast_levels,
+    terms_without_intercept,
 )
 
 FORMULAIC_271 = "https://github.com/matthewwardrop/formulaic/issues/271"
@@ -50,6 +51,17 @@ def test_multistage_iv_parse_structure(data: pd.DataFrame) -> None:
     assert "Z1" in {str(v) for v in rhs.deps[0].rhs.required_variables}
 
 
+@pytest.mark.parametrize(
+    "formula, expected",
+    [("1", []), ("X1", ["X1"]), ("0 + X1", ["X1"])],
+)
+def test_terms_without_intercept(formula: str, expected: list[str]) -> None:
+    """Formulaic represents the intercept as the term `1`."""
+    terms = terms_without_intercept(formulaic.Formula(formula))
+
+    assert [str(term) for term in terms] == expected
+
+
 def test_hat_suffix_filtering(data: pd.DataFrame) -> None:
     """The _hat suffix from formulaic MULTISTAGE is filtered from exogenous."""
     fit = pf.feols("Y ~ X1 + [X2 ~ Z1]", data=data)
@@ -79,6 +91,19 @@ def test_transformed_endogenous_matches_precomputed_column(data: pd.DataFrame) -
 
     inline = pf.feols("Y ~ X1 + [np.exp(X2) ~ Z1]", data=data)
     column = pf.feols("Y ~ X1 + [exp_X2 ~ Z1]", data=precomputed)
+
+    np.testing.assert_allclose(inline.coef().to_numpy(), column.coef().to_numpy())
+    np.testing.assert_allclose(inline.se().to_numpy(), column.se().to_numpy())
+
+
+def test_multisource_endogenous_term_matches_precomputed_column(
+    data: pd.DataFrame,
+) -> None:
+    """One endogenous term may depend on multiple source columns."""
+    precomputed = data.assign(X1_plus_X2=data["X1"] + data["X2"])
+
+    inline = pf.feols("Y ~ 1 + [I(X1 + X2) ~ Z1]", data=data)
+    column = pf.feols("Y ~ 1 + [X1_plus_X2 ~ Z1]", data=precomputed)
 
     np.testing.assert_allclose(inline.coef().to_numpy(), column.coef().to_numpy())
     np.testing.assert_allclose(inline.se().to_numpy(), column.se().to_numpy())


### PR DESCRIPTION
## Summary

- centralize Formulaic intercept filtering in `terms_without_intercept`
- use formula terms for endogenous, instrument, and fixed-effect cardinality decisions
- retain `required_variables` where IV validation compares underlying source columns
- cover leading-digit covariate names with fixed effects and multi-source transformed endogenous terms