### PR TITLE
docs: update IV formula syntax

### DIFF
--- a/docs/skills.md
+++ b/docs/skills.md
@@ -22,18 +22,24 @@ This page provides a ready-to-use skill file for analytics projects that use PyF
 
 ## Formula Syntax
 
-Formulas follow fixest syntax and are split into 1–3 parts by `|`:
+Formulas use Formulaic syntax. Fixed effects follow the right-hand side after
+`|`, while IV specifications use a bracketed multistage term:
 
 - One-part: `"Y ~ X1 + X2"` (no fixed effects, no IV)
 - Two-part: `"Y ~ X1 + X2 | FE1 + FE2"` (fixed effects)
-- Two-part IV: `"Y ~ X1 + X2 | X_endog ~ Z1 + Z2"` (IV without fixed effects)
-- Three-part IV: `"Y ~ X1 + X2 | FE1 + FE2 | X_endog ~ Z1 + Z2"` (IV with fixed effects)
+- IV without fixed effects: `"Y ~ X1 + X2 + [X_endog ~ Z1 + Z2]"`
+- IV with fixed effects: `"Y ~ X1 + X2 + [X_endog ~ Z1 + Z2] | FE1 + FE2"`
 
 IV behavior:
-- The IV part must be `endogenous ~ instruments`.
+- The bracketed IV term must be `[endogenous ~ instruments]`.
 - Exogenous variables from the second-stage RHS are automatically added to the first stage.
 - Endogenous variables are automatically added to the second stage.
 - Multiple endogenous variables are not supported.
+
+The legacy fixest-style IV forms using a final `| endogenous ~ instruments`
+segment are deprecated in PyFixest 0.70. They raise a `DeprecationWarning` and
+will become an error in a future release. See the
+[formula-parsing changelog](/changelog.qmd#formula-parsing-on-formulaic).
 
 Other syntax:
 - Multiple depvars are expanded to multiple estimations: `"Y1 + Y2 ~ X1"` behaves like `"sw(Y1, Y2) ~ X1"`.

--- a/docs/tutorials/formula-syntax.qmd
+++ b/docs/tutorials/formula-syntax.qmd
@@ -77,18 +77,23 @@ For details on fixed effects regression, take a look at the [OLS with Fixed Effe
 
 ## Instrumental Variables (IV) Syntax
 
-For IV estimation, `PyFixest` uses a three-part formula syntax:
+For IV estimation, PyFixest 0.70 uses Formulaic's bracketed multistage syntax:
 
 ```python
-"Y ~ exogenous_controls | fixed_effects | endogenous ~ instruments"
+"Y ~ exogenous_controls + [endogenous ~ instruments] | fixed_effects"
 ```
 
 Here is a minimal example with fixed effects:
 
 ```{python}
-fit_iv = pf.feols("Y ~ X2 | f1 + f2 | X1 ~ Z1", data=data)
+fit_iv = pf.feols("Y ~ X2 + [X1 ~ Z1] | f1 + f2", data=data)
 fit_iv.summary()
 ```
+
+The former fixest-style syntax, such as `Y ~ X2 | f1 + f2 | X1 ~ Z1`, is
+deprecated: it raises a `DeprecationWarning` in 0.70 and will become an error
+in a future release. See the [formula-parsing changelog](/changelog.qmd#formula-parsing-on-formulaic)
+for details.
 
 For details on IV estimation, take a look at the
 [Instrumental Variables](instrumental-variables.qmd) vignette.

--- a/docs/tutorials/instrumental-variables.qmd
+++ b/docs/tutorials/instrumental-variables.qmd
@@ -96,11 +96,31 @@ digraph IV2 {
 
 `PyFixest` estimates the IV using two-stage least squares (2SLS) estimator where it first projects $T$ onto $Z$ (and all other exogenous variables) to obtain $\hat{T}$, then uses $\hat{T}$ to estimate the causal effect of $T$ on $Y$. Because $\hat{T}$ is not a function of $U$, we can think of the dashed path from the unobserved variable as blocked or removed.
 
-In `PyFixest`, the IV syntax is:
+## IV formula syntax in PyFixest 0.70
+
+Starting with PyFixest 0.70, write an IV specification with Formulaic's
+bracketed multistage syntax:
 
 ```
-Y ~ exogenous_controls | fixed_effects | endogenous ~ instrument
+Y ~ exogenous_controls + [endogenous ~ instruments] | fixed_effects
 ```
+
+For example, an IV regression with exogenous controls and fixed effects is
+specified as follows:
+
+```python
+fit_iv = pf.feols("Y ~ X2 + [X1 ~ Z1] | f1 + f2", data=data)
+```
+
+::: {.callout-warning}
+## Legacy IV syntax is deprecated
+
+The former fixest-style syntax, `Y ~ X2 | f1 + f2 | X1 ~ Z1`, still works in
+0.70, but raises a `DeprecationWarning` and will become an error in a future
+release. Update formulas to the bracketed syntax above. See the
+[Formula Parsing on `formulaic` section of the changelog](/changelog.qmd#formula-parsing-on-formulaic)
+for the full set of formula-parsing changes in 0.70.
+:::
 
 ::: {.callout-note}
 ## Fixed Effects with IV
@@ -163,7 +183,7 @@ $$\hat{\beta}_{\text{Wald}} = \frac{\bar{Y}_{Z=1} - \bar{Y}_{Z=0}}{\bar{T}_{Z=1}
 In `PyFixest`, we can fit the IV model using the formula interface:
 
 ```{python}
-fit_iv = pf.feols("earnings ~ 1 | num_children ~ ivf_success", data=ivf_df)
+fit_iv = pf.feols("earnings ~ 1 + [num_children ~ ivf_success]", data=ivf_df)
 
 pf.etable([
     fit_ols,
@@ -240,7 +260,10 @@ fit_itt = pf.feols("revenue ~ assigned_treatment | user_type", data=ab_df)
 fit_fs = pf.feols("adopted_feature ~ assigned_treatment | user_type", data=ab_df)
 
 # IV / LATE
-fit_late = pf.feols("revenue ~ 1 | user_type | adopted_feature ~ assigned_treatment", data=ab_df)
+fit_late = pf.feols(
+    "revenue ~ 1 + [adopted_feature ~ assigned_treatment] | user_type",
+    data=ab_df,
+)
 ```
 
 ### Compare All Three
@@ -314,7 +337,7 @@ fit_ols_b = pf.feols("wages ~ immigration + log_population", data=bartik_df)
 
 # IV: using the Bartik instrument
 fit_iv_b = pf.feols(
-    "wages ~ log_population | immigration ~ bartik_instrument",
+    "wages ~ log_population + [immigration ~ bartik_instrument]",
     data=bartik_df,
 )
 ```


### PR DESCRIPTION
## Summary

- document Formulaic's bracketed IV syntax for PyFixest 0.70
- update IV examples in the IV vignette, formula-syntax tutorial, and Skills page
- retain the legacy fixest-style syntax as an explicitly deprecated migration path, linked to the changelog

## Why

The formula-parser release makes `[endogenous ~ instruments]` the supported IV form while the former pipe-delimited form remains temporarily available with a `DeprecationWarning`.

## Validation

- `pixi run -e py312-r pytest tests/test_formulaic_compat.py -x -q --no-cov`
- rendered the IV, Formula Syntax, and Skills pages with the pinned docs runtime
- fitted all IV formulas shown in the updated examples
