### PR TITLE
perf: halve model matrix construction time

### DIFF
--- a/pyfixest/estimation/formula/model_matrix.py
+++ b/pyfixest/estimation/formula/model_matrix.py
@@ -365,8 +365,9 @@ def create_model_matrix(
         }
         | {**capture_context(context)},
     )
-    drop_rows: set[int] = set(range(n_observations)).difference(
-        model_matrix[_ModelMatrixKey.main]["lhs"].index
+    drop_rows = _dropped_rows(
+        kept=model_matrix[_ModelMatrixKey.main]["lhs"].index,
+        n_observations=n_observations,
     )
     return ModelMatrix(
         model_matrix,
@@ -374,6 +375,17 @@ def create_model_matrix(
         drop_singletons=drop_singletons,
         drop_intercept=drop_intercept,
     )
+
+
+def _dropped_rows(kept: pd.Index, n_observations: int) -> set[int]:
+    """Row labels in `range(n_observations)` that `kept` does not contain.
+
+    `create_model_matrix` resets the data index beforehand, so row labels and
+    row positions coincide and the complement can be taken with a mask.
+    """
+    is_kept = np.zeros(n_observations, dtype=bool)
+    is_kept[kept.to_numpy()] = True
+    return set(np.flatnonzero(~is_kept).tolist())
 
 
 def _get_formulaic_formula(

--- a/pyfixest/estimation/formula/model_matrix.py
+++ b/pyfixest/estimation/formula/model_matrix.py
@@ -158,7 +158,7 @@ class ModelMatrix:
         n_dropped = int(is_dropped.sum())
         if not n_dropped:
             return
-        self._na_index |= frozenset(self._data.index[is_dropped].tolist())
+        self._na_index = self._na_index.union(self._data.index[is_dropped].tolist())
         self._data = self._data.loc[~is_dropped]
         warnings.warn(f"{n_dropped} {reason} dropped from the model.")
 

--- a/pyfixest/estimation/formula/model_matrix.py
+++ b/pyfixest/estimation/formula/model_matrix.py
@@ -7,6 +7,7 @@ import formulaic
 import numpy as np
 import pandas as pd
 from formulaic.parser import DefaultFormulaParser
+from numpy.typing import NDArray
 
 from pyfixest.core.detect_singletons import detect_singletons
 from pyfixest.estimation.formula import FORMULAIC_FEATURE_FLAG
@@ -69,15 +70,16 @@ class ModelMatrix:
     def __init__(
         self,
         model_matrix: formulaic.ModelMatrix,
-        drop_rows: set[int],
+        drop_rows: frozenset[int],
         drop_singletons: bool = True,
         drop_intercept: bool = False,
     ) -> None:
         self._drop_intercept = drop_intercept
         self._model_spec = model_matrix.model_spec
+        self._na_index = drop_rows
         self._collect_columns(model_matrix)
         self._collect_data(model_matrix)
-        self._process(dropped_rows=drop_rows, drop_singletons=drop_singletons)
+        self._process(drop_singletons=drop_singletons)
 
     @staticmethod
     def _get_columns(mm: formulaic.ModelMatrix, *keys: str) -> list[str] | None:
@@ -112,31 +114,26 @@ class ModelMatrix:
         data = pd.concat(datas, ignore_index=False, axis=1)
         self._data = data.loc[:, ~data.columns.duplicated()]
 
-    def _process(self, dropped_rows: set[int], drop_singletons: bool = False) -> None:
-        if self.dependent.shape[1] != 1:
+    def _process(self, drop_singletons: bool = False) -> None:
+        if self._dependent is None or len(self._dependent) != 1:
             # If the dependent variable is not numeric, formulaic's contrast encoding kicks in
             # creating multiple columns for the dependent variable
             # TODO: Make this check more explicit?
             raise TypeError("The dependent variable must be numeric.")
-        if self.endogenous is not None and self.endogenous.shape[1] != 1:
+        if self._endogenous is not None and len(self._endogenous) != 1:
             raise TypeError("The endogenous variable must be numeric.")
-        # Drop rows with non-finite values
-        is_infinite = pd.Series(
-            ~np.isfinite(self._data).all(axis=1), index=self._data.index
+        # integer and boolean columns are finite by construction
+        maybe_infinite = self._data.select_dtypes(exclude=["integer", "bool"])
+        self._drop(
+            ~np.isfinite(maybe_infinite.to_numpy()).all(axis=1),
+            "rows with infinite values",
         )
-        if is_infinite.any():
-            infinite_indices = is_infinite[is_infinite].index.tolist()
-            dropped_rows |= set(infinite_indices)
-            self._data.drop(infinite_indices, inplace=True)
-            warnings.warn(
-                f"{is_infinite.sum()} rows with infinite values dropped from the model.",
-            )
         if self._fixed_effects is not None:
             # Ensure fixed effects are `int32`
             self._data[self._fixed_effects] = self._data[self._fixed_effects].astype(
                 "int32"
             )
-        if self.fixed_effects is not None or self._drop_intercept:
+        if self._fixed_effects is not None or self._drop_intercept:
             if self._independent is not None:
                 self._independent = [
                     col for col in self._independent if col != "Intercept"
@@ -146,19 +143,24 @@ class ModelMatrix:
                     col for col in self._instruments if col != "Intercept"
                 ]
         # Drop singletons if specified
-        if drop_singletons and self.fixed_effects is not None:
-            is_singleton = pd.Series(
-                detect_singletons(self.fixed_effects.to_numpy()),
-                index=self._data.index,
+        if drop_singletons and self._fixed_effects is not None:
+            fixed_effects = self._data.loc[:, self._fixed_effects]
+            self._drop(
+                detect_singletons(fixed_effects.to_numpy()),
+                "singleton fixed effect(s)",
             )
-            if is_singleton.any():
-                singleton_indices = self._data[is_singleton].index.tolist()
-                dropped_rows |= set(singleton_indices)
-                self._data.drop(singleton_indices, inplace=True)
-                warnings.warn(
-                    f"{is_singleton.sum()} singleton fixed effect(s) dropped from the model."
-                )
-        self._na_index = frozenset(dropped_rows)
+
+    def _drop(self, is_dropped: NDArray[np.bool_], reason: str) -> None:
+        """Drop the masked rows from `self._data` and add their labels to `na_index`.
+
+        `reason` completes the warning "{n} {reason} dropped from the model."
+        """
+        n_dropped = int(is_dropped.sum())
+        if not n_dropped:
+            return
+        self._na_index |= frozenset(self._data.index[is_dropped].tolist())
+        self._data = self._data.loc[~is_dropped]
+        warnings.warn(f"{n_dropped} {reason} dropped from the model.")
 
     @property
     def dependent(self) -> pd.DataFrame:
@@ -377,7 +379,7 @@ def create_model_matrix(
     )
 
 
-def _dropped_rows(kept: pd.Index, n_observations: int) -> set[int]:
+def _dropped_rows(kept: pd.Index, n_observations: int) -> frozenset[int]:
     """Row labels in `range(n_observations)` that `kept` does not contain.
 
     `create_model_matrix` resets the data index beforehand, so row labels and
@@ -385,7 +387,7 @@ def _dropped_rows(kept: pd.Index, n_observations: int) -> set[int]:
     """
     is_kept = np.zeros(n_observations, dtype=bool)
     is_kept[kept.to_numpy()] = True
-    return set(np.flatnonzero(~is_kept).tolist())
+    return frozenset(np.flatnonzero(~is_kept).tolist())
 
 
 def _get_formulaic_formula(

--- a/pyfixest/estimation/models/feols_.py
+++ b/pyfixest/estimation/models/feols_.py
@@ -411,7 +411,7 @@ class Feols(ResultAccessorMixin):
         )
 
         self._Y = model_matrix.dependent
-        self._Y_untransformed = model_matrix.dependent.copy()
+        self._Y_untransformed = self._Y.copy()
         self._X = model_matrix.independent
         self._fe = model_matrix.fixed_effects
         self._endogvar = model_matrix.endogenous
@@ -428,7 +428,7 @@ class Feols(ResultAccessorMixin):
             if is_icovar is not None and is_icovar.any()
             else None
         )
-        self._X_is_empty = not model_matrix.independent.shape[0] > 0
+        self._X_is_empty = self._X.shape[0] == 0
         self._model_spec = model_matrix.model_spec
 
         self._coefnames = self._X.columns.tolist()
@@ -441,11 +441,9 @@ class Feols(ResultAccessorMixin):
         self._k_fe = self._fe.nunique(axis=0) if self._has_fixef else None
         self._n_fe = len(self._k_fe) if self._has_fixef else 0
 
-        # update data
-        self._data.drop(
-            self._data.index[~self._data.index.isin(model_matrix.dependent.index)],
-            inplace=True,
-        )
+        # an empty drop still rebuilds the whole frame, so guard it
+        if self._na_index:
+            self._data.drop(index=list(self._na_index), inplace=True)
 
         self._weights = self._set_weights()
         self._N, self._N_rows = self._set_nobs()


### PR DESCRIPTION
Two changes to model matrix construction. No behavior change — `prepare_model_matrix` is roughly twice as fast.

## What

**`create_model_matrix`** built the set of NA-dropped rows with `set(range(n)).difference(lhs.index)`: a Python set holding every row label, with `set.difference` iterating the kept `RangeIndex` one element at a time. On a million rows that is 68ms, and it produces the empty set whenever nothing was dropped — the common case. Now a boolean mask.

**`ModelMatrix._process`** dropped rows by label list and read the `dependent` / `fixed_effects` properties (each one a full column-block copy) for checks that only need the column names. It now selects rows with a mask and inspects the stored column lists. `Feols.prepare_model_matrix` re-derived the surviving rows with `index.isin`, which `na_index` already records; it now drops those labels directly and does nothing when nothing was dropped.

`ModelMatrix` also owns the dropped-label set instead of mutating one passed in by its caller, and keeps it as the `frozenset` its only readers — the demean caches — actually want.

+49 / −37 across two files.

## Runtime

AKM panel, 3 FE (worker × firm × year), 1 covariate. `prepare_model_matrix` / whole `feols` call:

| rows | before | after | feols before | feols after |
|---:|---:|---:|---:|---:|
| 100k | 22ms | 14ms | 42ms | 35ms |
| 1M | 174ms | 90ms | 356ms | 258ms |
| 3M | 524ms | 275ms | 1.03s | 0.79s |
| 6M | 1.06s | 0.54s | 2.29s | 1.77s |
| 10M | 1.76s | 0.88s | 3.82s | 2.96s |
| 20M | 3.58s | 1.78s | 15.2s | 13.9s |

The cost is linear in rows and the saving is a flat **178 → 89 ns/row**, so the halving holds at every size rather than being amortized away.

Per-row cost does depend on fixed-effect cardinality. In a long panel with fixed cardinality (50k workers × 5k firms, growing T) it is 44 ns/row rather than 89, and `prepare_model_matrix` still accounts for a stable ~35% of a `feols` call from 1M to 20M rows.

## Testing

`test_vs_fixest` and `against_r_core` show no new failures — the only failures are pre-existing flaky `torch_mps` float32 comparisons, which vary between 28 and 32 across repeat runs on unmodified `master`.

A 25-scenario differential harness against `master` (coefficients, SEs, `_N`, `_na_index`, surviving index, warning strings) is byte-identical on all scenarios: inf/NaN in Y, X, weights and offset, singleton drops, `log(0)`, IV, weights, `i()`, `C()`, all-integer data, `fepois`, `quantreg`, multiple estimation, `split=`, `predict`/`fixef` after dropping, and the empty and single-row frames. Verified under pandas 2.3.3 as well as 3.0.1.

## Note for reviewers

Both rewrites rely on labels equalling positions, which `create_model_matrix` establishes by resetting the index in place. Where `master` degraded silently, the new code raises: an out-of-range label gives `IndexError` in `_dropped_rows`, and a missing label gives `KeyError` in the `feols_.py` drop. No caller can reach either today, and the precondition is documented at `_dropped_rows`.
