### PR TITLE
fix: honor predict() lsqr tolerance after caching

### DIFF
--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -177,6 +177,11 @@ We also removed:
   no not-yet-treated observations), instead of failing later with an opaque
   broadcasting `ValueError` in the vcov computation
   ([#1244](https://github.com/py-econometrics/pyfixest/issues/1244)).
+- `predict()` now honors its `atol` and `btol` arguments on every call. The fixed
+  effects recovered by `lsqr()` were cached after the first call and reused
+  regardless of the tolerance requested later, so `predict(atol=1e-12)` silently
+  returned values computed at the earlier, looser tolerance. Cached fixed effects
+  that are already tighter than requested are still reused.
 
 
 ## PyFixest 0.60.0

--- a/pyfixest/estimation/models/feglm_.py
+++ b/pyfixest/estimation/models/feglm_.py
@@ -328,6 +328,10 @@ class Feglm(Feols):
             Another stopping tolerance for scipy.sparse.linalg.lsqr().
             See https://docs.scipy.org/doc/
                 scipy/reference/generated/scipy.sparse.linalg.lsqr.html
+            The fixed effects are cached after they are first computed. Passing an
+            `atol` or `btol` below the cached one recomputes them at the tighter
+            tolerance; a looser one reuses the cached values rather than degrading
+            them.
         type : str, optional
             The type of prediction to be computed.
             Can be either "response" (default) or "link".

--- a/pyfixest/estimation/models/feols_.py
+++ b/pyfixest/estimation/models/feols_.py
@@ -1786,6 +1786,10 @@ class Feols(ResultAccessorMixin):
             Another stopping tolerance for scipy.sparse.linalg.lsqr().
             See https://docs.scipy.org/doc/
                 scipy/reference/generated/scipy.sparse.linalg.lsqr.html
+            The fixed effects are cached after they are first computed. Passing an
+            `atol` or `btol` below the cached one recomputes them at the tighter
+            tolerance; a looser one reuses the cached values rather than degrading
+            them.
         type:
             The type of prediction to be made. Can be either 'link' or 'response'.
              Defaults to 'link'. 'link' and 'response' lead

--- a/pyfixest/estimation/models/feols_.py
+++ b/pyfixest/estimation/models/feols_.py
@@ -217,6 +217,8 @@ class Feols(ResultAccessorMixin):
         A DataFrame with the estimated fixed effects.
     _sumFE : np.ndarray
         Sum of all fixed effects for each observation.
+    _fixef_lsqr_tol : tuple[float, float] | None
+        The (atol, btol) pair used to compute the cached fixed effects.
     _rmse : float
         Root mean squared error of the model.
     _r2 : float
@@ -379,6 +381,7 @@ class Feols(ResultAccessorMixin):
         self._fixef_coefficients: dict[str, FixedEffect] = {}
         self._alpha = None
         self._sumFE = None
+        self._fixef_lsqr_tol: tuple[float, float] | None = None
 
         # set in get_performance()
         self._rmse = np.nan
@@ -1745,6 +1748,7 @@ class Feols(ResultAccessorMixin):
         )
         self._alpha = alpha
         self._sumFE = D2.dot(alpha)
+        self._fixef_lsqr_tol = (atol, btol)
 
         return fixed_effects_to_frame(self._fixef_coefficients)
 
@@ -1878,8 +1882,13 @@ class Feols(ResultAccessorMixin):
                 warn_on_unseen_fixed_effect_levels(fe_mm, fe_spec, newdata)
                 valid_fixed_effects = fe_mm.notna().all(axis="columns").to_numpy()
                 valid_idx = valid_idx[valid_fixed_effects[valid_idx]]
-                if self._sumFE is None:
+                cached_tol = self._fixef_lsqr_tol
+                if self._sumFE is None or cached_tol is None:
                     self.fixef(atol, btol)
+                elif atol < cached_tol[0] or btol < cached_tol[1]:
+                    # cached fixed effects are looser than requested; recompute at
+                    # the tighter tolerance of the two so accuracy never degrades
+                    self.fixef(min(atol, cached_tol[0]), min(btol, cached_tol[1]))
                 fe_hat = predict_fixed_effects(
                     model_matrix=fe_mm.loc[valid_idx],
                     coefficients=self._fixef_coefficients,

--- a/pyfixest/estimation/models/fepois_.py
+++ b/pyfixest/estimation/models/fepois_.py
@@ -223,6 +223,10 @@ class Fepois(Feglm):
             Another stopping tolerance for scipy.sparse.linalg.lsqr().
             See https://docs.scipy.org/doc/
                 scipy/reference/generated/scipy.sparse.linalg.lsqr.html
+            The fixed effects are cached after they are first computed. Passing an
+            `atol` or `btol` below the cached one recomputes them at the tighter
+            tolerance; a looser one reuses the cached values rather than degrading
+            them.
         type : str, optional
             The type of prediction to be computed.
             Can be either "response" (default) or "link".

--- a/tests/test_others.py
+++ b/tests/test_others.py
@@ -505,35 +505,3 @@ def test_fixef_excludes_singleton_levels_from_prediction():
     assert np.isfinite(prediction[:-1]).all()
     assert np.isnan(prediction[-1])
     assert set(fixed_effects["level"]) == {"a,u", "b,v"}
-
-
-def test_predict_honors_lsqr_tolerance_after_caching():
-    """`atol`/`btol` must apply on every call, not only the first one."""
-    rng = np.random.default_rng(11)
-    n = 500
-    df = pd.DataFrame(
-        {
-            "x1": rng.normal(size=n),
-            "x2": rng.normal(size=n),
-            "f1": rng.integers(0, 10, size=n).astype(str),
-            "f2": rng.integers(0, 4, size=n).astype(str),
-        }
-    )
-    df["y"] = 1 + 2 * df["x1"] - df["x2"] + rng.normal(size=n)
-    fml = "y ~ x1 + x2 | f1 + f2"
-
-    fresh = feols(fml, data=df)
-    tight = fresh.predict(newdata=df, atol=1e-12, btol=1e-12)
-
-    cached = feols(fml, data=df)
-    cached.predict(newdata=df)
-    after_cache = cached.predict(newdata=df, atol=1e-12, btol=1e-12)
-
-    np.testing.assert_allclose(after_cache, tight, rtol=0, atol=1e-10)
-
-    # a looser later request must not discard already tighter fixed effects
-    downgraded = feols(fml, data=df)
-    downgraded.fixef(atol=1e-12, btol=1e-12)
-    np.testing.assert_allclose(
-        downgraded.predict(newdata=df), tight, rtol=0, atol=1e-10
-    )

--- a/tests/test_others.py
+++ b/tests/test_others.py
@@ -505,3 +505,35 @@ def test_fixef_excludes_singleton_levels_from_prediction():
     assert np.isfinite(prediction[:-1]).all()
     assert np.isnan(prediction[-1])
     assert set(fixed_effects["level"]) == {"a,u", "b,v"}
+
+
+def test_predict_honors_lsqr_tolerance_after_caching():
+    """`atol`/`btol` must apply on every call, not only the first one."""
+    rng = np.random.default_rng(11)
+    n = 500
+    df = pd.DataFrame(
+        {
+            "x1": rng.normal(size=n),
+            "x2": rng.normal(size=n),
+            "f1": rng.integers(0, 10, size=n).astype(str),
+            "f2": rng.integers(0, 4, size=n).astype(str),
+        }
+    )
+    df["y"] = 1 + 2 * df["x1"] - df["x2"] + rng.normal(size=n)
+    fml = "y ~ x1 + x2 | f1 + f2"
+
+    fresh = feols(fml, data=df)
+    tight = fresh.predict(newdata=df, atol=1e-12, btol=1e-12)
+
+    cached = feols(fml, data=df)
+    cached.predict(newdata=df)
+    after_cache = cached.predict(newdata=df, atol=1e-12, btol=1e-12)
+
+    np.testing.assert_allclose(after_cache, tight, rtol=0, atol=1e-10)
+
+    # a looser later request must not discard already tighter fixed effects
+    downgraded = feols(fml, data=df)
+    downgraded.fixef(atol=1e-12, btol=1e-12)
+    np.testing.assert_allclose(
+        downgraded.predict(newdata=df), tight, rtol=0, atol=1e-10
+    )

--- a/tests/test_predict_resid_fixef.py
+++ b/tests/test_predict_resid_fixef.py
@@ -385,3 +385,35 @@ def test_context_capture_with_out_of_sample_predict():
         np.testing.assert_almost_equal(
             context_fit.predict(data_test), explicit_fit.predict(data_test), decimal=3
         )
+
+
+def test_predict_honors_lsqr_tolerance_after_caching():
+    """`atol`/`btol` must apply on every call, not only the first one."""
+    rng = np.random.default_rng(11)
+    n = 500
+    df = pd.DataFrame(
+        {
+            "x1": rng.normal(size=n),
+            "x2": rng.normal(size=n),
+            "f1": rng.integers(0, 10, size=n).astype(str),
+            "f2": rng.integers(0, 4, size=n).astype(str),
+        }
+    )
+    df["y"] = 1 + 2 * df["x1"] - df["x2"] + rng.normal(size=n)
+    fml = "y ~ x1 + x2 | f1 + f2"
+
+    fresh = pf.feols(fml, data=df)
+    tight = fresh.predict(newdata=df, atol=1e-12, btol=1e-12)
+
+    cached = pf.feols(fml, data=df)
+    cached.predict(newdata=df)
+    after_cache = cached.predict(newdata=df, atol=1e-12, btol=1e-12)
+
+    np.testing.assert_allclose(after_cache, tight, rtol=0, atol=1e-10)
+
+    # a looser later request must not discard already tighter fixed effects
+    downgraded = pf.feols(fml, data=df)
+    downgraded.fixef(atol=1e-12, btol=1e-12)
+    np.testing.assert_allclose(
+        downgraded.predict(newdata=df), tight, rtol=0, atol=1e-10
+    )


### PR DESCRIPTION
`predict()` takes `atol`/`btol` for the lsqr solve that recovers the fixed effects, but the call site only checked `if self._sumFE is None`, so once the fixed effects were cached the tolerance you passed later was ignored and you silently got whatever the first call computed.

```python
fresh = pf.feols(fml, data=df)
tight = fresh.predict(newdata=df, atol=1e-12, btol=1e-12)   # err 9.4e-13

cached = pf.feols(fml, data=df)
cached.predict(newdata=df)                                   # caches at 1e-6
cached.predict(newdata=df, atol=1e-12, btol=1e-12)           # err 6.5e-06
```

same arguments, seven orders of magnitude apart depending on what ran before. i checked against an exact lstsq solve on the FE dummies, which reproduces the fitted values to ~5e-15, so the tight one is the right answer.

only recomputing when the request is tighter than what's cached, never looser, since going the other way would throw away precision someone explicitly asked for. `test_fixef_interacted_labels` already relies on that, it calls `fixef(atol=1e-12)` then a default `predict()` and expects the accurate values to survive.

added a regression test covering both directions. ran the non-R suite against a clean-tree baseline and the failure set is identical, though i couldn't run the rpy2 comparisons locally so those are down to CI.