### PR TITLE
refactor: lazy-load reporting dependencies

### DIFF
--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -17,6 +17,13 @@ fit3 = pf.feols("Y ~ X1 + X2 | f1", data = df)
 
 ## PyFixest 0.70.0 (In Development)
 
+### Lighter Core Imports
+
+- `summary()` remains available in the base installation and now uses pandas'
+  plain-text formatter. Table and plotting packages are imported only when their
+  corresponding features are called. Internal progress bars and the seaborn-only
+  plotting path have been removed.
+
 ### Inference Types
 
 - `tidy()`, `confint()`, and `summary()` gain an `inference_type` argument.

--- a/pyfixest/did/saturated_twfe.py
+++ b/pyfixest/did/saturated_twfe.py
@@ -1,7 +1,8 @@
+from __future__ import annotations
+
 import re
 import warnings
 
-import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 from scipy.stats import norm
@@ -10,6 +11,18 @@ from pyfixest.estimation import feols
 from pyfixest.estimation.models.feols_ import Feols
 
 from .did2s import DID
+
+
+def _import_matplotlib():
+    """Import matplotlib only when an event-study plot is requested."""
+    try:
+        import matplotlib.pyplot as plt
+    except ImportError:
+        raise ImportError(
+            "Event-study plotting requires matplotlib. "
+            "Install it with `pip install matplotlib`."
+        ) from None
+    return plt
 
 
 class SaturatedEventStudy(DID):
@@ -137,6 +150,7 @@ class SaturatedEventStudy(DID):
 
     def iplot(self):
         """Plot DID estimates."""
+        plt = _import_matplotlib()
         cmp = plt.get_cmap("Set1")
 
         _, ax = plt.subplots(figsize=(10, 6))
@@ -284,6 +298,7 @@ class SaturatedEventStudy(DID):
         None
         """
         df_agg = self.aggregate(agg=agg, weighting=weighting)
+        plt = _import_matplotlib()
 
         time = np.array(df_agg.index, dtype=float).astype(float)
         est = df_agg["Estimate"].values.astype(float)

--- a/pyfixest/did/visualize.py
+++ b/pyfixest/did/visualize.py
@@ -1,5 +1,23 @@
-import matplotlib.pyplot as plt
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import pandas as pd
+
+if TYPE_CHECKING:
+    import matplotlib.pyplot as plt
+
+
+def _import_matplotlib():
+    """Import matplotlib only when a DiD plot is requested."""
+    try:
+        import matplotlib.pyplot as plt
+    except ImportError:
+        raise ImportError(
+            "DiD plotting requires matplotlib. "
+            "Install it with `pip install matplotlib`."
+        ) from None
+    return plt
 
 
 def panelview(
@@ -251,6 +269,7 @@ def _plot_panelview_output_plot(
     ylim: tuple[float, float] | None = None,
     figsize: tuple | None = (11, 3),
 ) -> plt.Axes:
+    plt = _import_matplotlib()
     if not ax:
         _, ax = plt.subplots(figsize=figsize)
     for unit_id in data_pivot.index:
@@ -350,6 +369,7 @@ def _plot_panelview(
     noticks: bool | None = False,
     title: str | None = None,
 ) -> plt.Axes:
+    plt = _import_matplotlib()
     if not ax:
         _, ax = plt.subplots(figsize=figsize)
     cax = ax.matshow(treatment_quilt, cmap="viridis", aspect="auto")

--- a/pyfixest/estimation/FixestMulti_.py
+++ b/pyfixest/estimation/FixestMulti_.py
@@ -74,20 +74,15 @@ class FixestMulti(TidyColumnAccessors):
 
         self.all_fitted_models: dict[str, Feols | Fepois | Feiv] = {}
 
-        # set functions inherited from other modules
-        _module = import_module("pyfixest.report")
-        _tmp = _module.coefplot
-        self.coefplot = functools.partial(_tmp, models=self.all_fitted_models.values())
-        self.coefplot.__doc__ = _tmp.__doc__
-        _tmp = _module.iplot
-        self.iplot = functools.partial(_tmp, models=self.all_fitted_models.values())
-        self.iplot.__doc__ = _tmp.__doc__
-        _tmp = _module.summary
-        self.summary = functools.partial(_tmp, models=self.all_fitted_models.values())
-        self.summary.__doc__ = _tmp.__doc__
-        _tmp = _module.etable
-        self.etable = functools.partial(_tmp, models=self.all_fitted_models.values())
-        self.etable.__doc__ = _tmp.__doc__
+        def _call_report_method(name: str, *args, **kwargs):
+            module = import_module("pyfixest.report")
+            method = getattr(module, name)
+            return method(self.all_fitted_models.values(), *args, **kwargs)
+
+        self.coefplot = functools.partial(_call_report_method, "coefplot")
+        self.iplot = functools.partial(_call_report_method, "iplot")
+        self.summary = functools.partial(_call_report_method, "summary")
+        self.etable = functools.partial(_call_report_method, "etable")
 
     @property
     def _is_iv(self) -> bool:

--- a/pyfixest/estimation/models/_result_accessor_mixin.py
+++ b/pyfixest/estimation/models/_result_accessor_mixin.py
@@ -151,23 +151,16 @@ class ResultAccessorMixin(TidyColumnAccessors):
 
     def _bind_report_methods(self):
         """Bind summary, coefplot, iplot, and etable from pyfixest.report as instance methods."""
-        _module = import_module("pyfixest.report")
 
-        _tmp = _module.summary
-        self.summary = functools.partial(_tmp, models=[self])
-        self.summary.__doc__ = _tmp.__doc__
+        def _call_report_method(name: str, *args, **kwargs):
+            module = import_module("pyfixest.report")
+            method = getattr(module, name)
+            return method([self], *args, **kwargs)
 
-        _tmp = _module.coefplot
-        self.coefplot = functools.partial(_tmp, models=[self])
-        self.coefplot.__doc__ = _tmp.__doc__
-
-        _tmp = _module.iplot
-        self.iplot = functools.partial(_tmp, models=[self])
-        self.iplot.__doc__ = _tmp.__doc__
-
-        _tmp = _module.etable
-        self.etable = functools.partial(_tmp, models=[self])
-        self.etable.__doc__ = _tmp.__doc__
+        self.summary = functools.partial(_call_report_method, "summary")
+        self.coefplot = functools.partial(_call_report_method, "coefplot")
+        self.iplot = functools.partial(_call_report_method, "iplot")
+        self.etable = functools.partial(_call_report_method, "etable")
 
     def evalue(
         self,

--- a/pyfixest/estimation/models/feols_.py
+++ b/pyfixest/estimation/models/feols_.py
@@ -4,7 +4,7 @@ import re
 import warnings
 from collections.abc import Mapping
 from importlib import import_module
-from typing import Any, Literal, cast
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 import formulaic
 import numpy as np
@@ -47,10 +47,6 @@ from pyfixest.estimation.internals.vcov_utils import (
     run_crv_loop,
 )
 from pyfixest.estimation.models._result_accessor_mixin import ResultAccessorMixin
-from pyfixest.estimation.post_estimation.decomposition import (
-    GelbachDecomposition,
-    _decompose_arg_check,
-)
 from pyfixest.estimation.post_estimation.fixed_effects import (
     FixedEffect,
     build_fixed_effects,
@@ -61,14 +57,6 @@ from pyfixest.estimation.post_estimation.fixed_effects import (
     warn_on_unseen_fixed_effect_levels,
 )
 from pyfixest.estimation.post_estimation.prediction import _compute_prediction_error
-from pyfixest.estimation.post_estimation.ritest import (
-    _HAS_NUMBA,
-    _decode_resampvar,
-    _get_ritest_pvalue,
-    _get_ritest_stats_fast,
-    _get_ritest_stats_slow,
-    _plot_ritest_pvalue,
-)
 from pyfixest.estimation.post_estimation.wald import _wald_statistic
 from pyfixest.utils.dev_utils import (
     DataFrameType,
@@ -78,6 +66,9 @@ from pyfixest.utils.utils import (
     capture_context,
     get_ssc,
 )
+
+if TYPE_CHECKING:
+    from pyfixest.estimation.post_estimation.decomposition import GelbachDecomposition
 
 decomposition_type = Literal["gelbach"]
 prediction_type = Literal["response", "link"]
@@ -1559,6 +1550,11 @@ class Feols(ResultAccessorMixin):
         res = fit.decompose(decomp_var="x1", combine_covariates={"g1": re.compile("x2[1-2]"), "g2": re.compile("x23")})
         ```
         """
+        from pyfixest.estimation.post_estimation.decomposition import (
+            GelbachDecomposition,
+            _decompose_arg_check,
+        )
+
         has_param = param is not None
         has_decomp = decomp_var is not None
 
@@ -2003,6 +1999,14 @@ class Feols(ResultAccessorMixin):
         fit.ritest("X1", reps=1000, store_ritest_statistics=True)
         ```
         """
+        from pyfixest.estimation.post_estimation.ritest import (
+            _HAS_NUMBA,
+            _decode_resampvar,
+            _get_ritest_pvalue,
+            _get_ritest_stats_fast,
+            _get_ritest_stats_slow,
+        )
+
         resampvar = resampvar.replace(" ", "")
         resampvar_, h0_value, hypothesis, test_type = _decode_resampvar(resampvar)
 
@@ -2159,6 +2163,8 @@ class Feols(ResultAccessorMixin):
         A lets_plot or matplotlib figure with the distribution of the Randomization
         Inference Statistics.
         """
+        from pyfixest.estimation.post_estimation.ritest import _plot_ritest_pvalue
+
         if not hasattr(self, "_ritest_statistics"):
             raise ValueError(
                 """

--- a/pyfixest/estimation/post_estimation/decomposition.py
+++ b/pyfixest/estimation/post_estimation/decomposition.py
@@ -9,7 +9,6 @@ from joblib import Parallel, delayed
 from numpy.typing import NDArray
 from scipy.sparse import diags, hstack, spmatrix, vstack
 from scipy.sparse.linalg import lsqr
-from tqdm import tqdm
 
 # Panel name mappings for consistent API
 PANEL_ALIASES = {
@@ -367,7 +366,7 @@ class GelbachDecomposition:
             self.X_dict = {g: self.X_dict[g].tocsr() for g in self.X_dict}
 
         _bootstrapped = Parallel(n_jobs=self.nthreads)(
-            delayed(self._bootstrap)(rng=rng) for _ in tqdm(range(B))
+            delayed(self._bootstrap)(rng=rng) for _ in range(B)
         )
 
         # unpack
@@ -771,7 +770,13 @@ class GelbachDecomposition:
         ```{python}
         gb.etable(column_heads = ["Full Difference", "Unexplained Difference", "Explained Difference"])
         """
-        from maketables import MTable
+        try:
+            from maketables import MTable
+        except ImportError:
+            raise ImportError(
+                "`etable()` requires maketables. "
+                "Install it with `pip install maketables`."
+            ) from None
 
         if column_heads is not None and len(column_heads) != 3:
             raise ValueError("The 'column_heads' parameter must be a list of length 3.")

--- a/pyfixest/estimation/post_estimation/ritest.py
+++ b/pyfixest/estimation/post_estimation/ritest.py
@@ -1,9 +1,7 @@
 from importlib import import_module
 
-import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-import seaborn as sns
 
 # Make lets-plot an optional dependency
 try:
@@ -23,8 +21,7 @@ try:
 except ImportError:
     _HAS_LETS_PLOT = False
 
-from scipy.stats import norm
-from tqdm import tqdm
+from scipy.stats import gaussian_kde, norm
 
 # Numba is an optional dependency. The fast randomization-inference path uses it;
 # the slow path does not. We import lazily so the module loads cleanly even when
@@ -107,7 +104,7 @@ def _get_ritest_stats_slow(
 
     ri_stats = np.zeros(reps)
 
-    for i in tqdm(range(reps)):
+    for i in range(reps):
         D_treat = _resample(
             resampvar_arr=resampvar_arr,
             clustervar_arr=clustervar_arr,
@@ -407,7 +404,6 @@ def _plot_ritest_pvalue(
 
     if plot_backend == "lets_plot":
         if not _HAS_LETS_PLOT:
-            print("lets-plot is not installed. Falling back to matplotlib.")
             plot_backend = "matplotlib"
         else:
             plot = (
@@ -420,19 +416,33 @@ def _plot_ritest_pvalue(
                 + ylab(y_lab)
             )
 
-        return plot.show()
+            return plot.show()
 
-    elif plot_backend == "matplotlib":
-        plt.figure(figsize=(10, 6))
-        sns.kdeplot(data=df, x="ri_stats", fill=True, color="blue", alpha=0.5)
-        plt.axvline(x=sample_stat, color="red", linestyle="--")
-        plt.title(title)
-        plt.xlabel(x_lab)
-        plt.ylabel(y_lab)
+    if plot_backend == "matplotlib":
+        try:
+            import matplotlib.pyplot as plt
+        except ImportError:
+            raise ImportError(
+                "The matplotlib backend requires matplotlib. "
+                "Install it with `pip install matplotlib`."
+            ) from None
+
+        stats = np.asarray(ri_stats, dtype=float)
+        _, ax = plt.subplots(figsize=(10, 6))
+        if np.ptp(stats) == 0:
+            ax.hist(stats, density=True, color="blue", alpha=0.5)
+        else:
+            x_grid = np.linspace(stats.min(), stats.max(), 200)
+            density = gaussian_kde(stats)(x_grid)
+            ax.fill_between(x_grid, density, color="blue", alpha=0.5)
+        ax.axvline(x=sample_stat, color="red", linestyle="--")
+        ax.set_title(title)
+        ax.set_xlabel(x_lab)
+        ax.set_ylabel(y_lab)
         plt.show()
+        return None
 
-    else:
-        raise ValueError(f"Unsupported plot backend: {plot_backend}")
+    raise ValueError(f"Unsupported plot backend: {plot_backend}")
 
 
 def _decode_resampvar(resampvar: str) -> tuple[str, float, str, str]:

--- a/pyfixest/report/__init__.py
+++ b/pyfixest/report/__init__.py
@@ -1,12 +1,9 @@
-from pyfixest.report.summarize import (
-    etable,
-    summary,
-)
-from pyfixest.report.visualize import (
-    coefplot,
-    iplot,
-    qplot,
-)
+import importlib
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pyfixest.report.summarize import etable, summary
+    from pyfixest.report.visualize import coefplot, iplot, qplot
 
 __all__ = [
     "coefplot",
@@ -15,3 +12,22 @@ __all__ = [
     "qplot",
     "summary",
 ]
+
+_REPORT_MODULES = {
+    "etable": "pyfixest.report.summarize",
+    "summary": "pyfixest.report.summarize",
+    "coefplot": "pyfixest.report.visualize",
+    "iplot": "pyfixest.report.visualize",
+    "qplot": "pyfixest.report.visualize",
+}
+
+
+def __getattr__(name: str):
+    if name in _REPORT_MODULES:
+        module = importlib.import_module(_REPORT_MODULES[name])
+        return getattr(module, name)
+    raise AttributeError(f"module 'pyfixest.report' has no attribute {name!r}")
+
+
+def __dir__():
+    return __all__

--- a/pyfixest/report/summarize.py
+++ b/pyfixest/report/summarize.py
@@ -1,4 +1,3 @@
-import maketables
 import numpy as np
 import pandas as pd
 
@@ -177,6 +176,13 @@ def etable(
     pf.etable([fit1, fit2])
     ```
     """
+    try:
+        import maketables
+    except ImportError:
+        raise ImportError(
+            "`etable()` requires maketables. Install it with `pip install maketables`."
+        ) from None
+
     # Apply pyfixest default for signif_code (different from maketables default)
     if signif_code is None:
         signif_code = [0.001, 0.01, 0.05]
@@ -338,7 +344,7 @@ def summary(
         print("Inference: ", fxst._vcov_type_detail)
         print("Observations: ", fxst._N)
         print("")
-        print(df.to_markdown(floatfmt=f".{digits}f"))
+        print(df.to_string(float_format=lambda value: f"{value:.{digits}f}"))
         print("---")
 
         to_print = ""

--- a/pyfixest/report/utils.py
+++ b/pyfixest/report/utils.py
@@ -1,14 +1,22 @@
+from __future__ import annotations
+
 import re
 import warnings
 from collections import Counter
 from collections.abc import ValuesView
+from typing import TYPE_CHECKING, TypeAlias
 
-from pyfixest.estimation.FixestMulti_ import FixestMulti
-from pyfixest.estimation.models.feiv_ import Feiv
-from pyfixest.estimation.models.feols_ import Feols
-from pyfixest.estimation.models.fepois_ import Fepois
+if TYPE_CHECKING:
+    from pyfixest.estimation.FixestMulti_ import FixestMulti
+    from pyfixest.estimation.models.feiv_ import Feiv
+    from pyfixest.estimation.models.feols_ import Feols
+    from pyfixest.estimation.models.fepois_ import Fepois
 
-ModelInputType = FixestMulti | Feols | Fepois | Feiv | list[Feols | Fepois | Feiv]
+    ModelInputType: TypeAlias = (
+        FixestMulti | Feols | Fepois | Feiv | list[Feols | Fepois | Feiv]
+    )
+else:
+    ModelInputType: TypeAlias = object
 
 
 def _check_label_keys_in_covars(label_keys: list[str], covariate_names: list[str]):
@@ -242,6 +250,11 @@ def _post_processing_input_checks(
         TypeError: If the models argument is not of the expected type.
 
     """
+    from pyfixest.estimation.FixestMulti_ import FixestMulti
+    from pyfixest.estimation.models.feiv_ import Feiv
+    from pyfixest.estimation.models.feols_ import Feols
+    from pyfixest.estimation.models.fepois_ import Fepois
+
     models_list: list[Feols | Fepois | Feiv] = []
 
     if isinstance(models, (Feols, Fepois, Feiv)):

--- a/pyfixest/report/visualize.py
+++ b/pyfixest/report/visualize.py
@@ -1,8 +1,13 @@
-import math
+from __future__ import annotations
 
-import matplotlib.pyplot as plt
+import math
+from typing import TYPE_CHECKING
+
 import numpy as np
 import pandas as pd
+
+if TYPE_CHECKING:
+    import matplotlib.pyplot as plt
 
 # Make lets-plot an optional dependency
 try:
@@ -44,6 +49,18 @@ ModelInputType = FixestMulti | Feols | Fepois | Feiv | list[Feols | Fepois | Fei
 # Only setup lets-plot if it's available
 if _HAS_LETS_PLOT:
     LetsPlot.setup_html()
+
+
+def _import_matplotlib():
+    """Import matplotlib only when its plotting backend is requested."""
+    try:
+        import matplotlib.pyplot as plt
+    except ImportError:
+        raise ImportError(
+            "The matplotlib backend requires matplotlib. "
+            "Install it with `pip install matplotlib`."
+        ) from None
+    return plt
 
 
 def set_figsize(figsize: tuple[int, int] | None, plot_backend: str) -> tuple[int, int]:
@@ -521,6 +538,7 @@ def _coefplot(plot_backend, *, figsize, **plot_kwargs):
             )
         return _coefplot_lets_plot(figsize=figsize, **plot_kwargs)
     elif plot_backend == "matplotlib":
+        _import_matplotlib()
         return _coefplot_matplotlib(figsize=figsize, **plot_kwargs)
     else:
         raise ValueError("plot_backend must be either 'lets_plot' or 'matplotlib'.")
@@ -673,6 +691,7 @@ def _coefplot_matplotlib(
     matplotlib.figure.Figure
         A matplotlib Figure object.
     """
+    plt = _import_matplotlib()
     labels_dict = {} if labels is None else labels
 
     if not labels_dict or cat_template is not None:
@@ -798,6 +817,7 @@ def _qplot(
     (Figure, ndarray[Axes])
         Handle to the created figure and axes.
     """
+    plt = _import_matplotlib()
     if nrow is None and ncol is None:
         nrow = 1
     if (nrow is not None) and (ncol is not None):

--- a/tests/test_optional_dependencies.py
+++ b/tests/test_optional_dependencies.py
@@ -1,0 +1,53 @@
+import subprocess
+import sys
+import textwrap
+
+
+def test_core_estimation_without_reporting_dependencies():
+    code = textwrap.dedent(
+        """
+        import builtins
+
+        blocked = {
+            "great_tables",
+            "lets_plot",
+            "maketables",
+            "matplotlib",
+            "seaborn",
+            "tabulate",
+            "tqdm",
+        }
+        import_original = builtins.__import__
+
+        def import_without_optional_dependencies(name, *args, **kwargs):
+            if name.split(".", maxsplit=1)[0] in blocked:
+                raise ImportError(f"blocked optional dependency: {name}")
+            return import_original(name, *args, **kwargs)
+
+        builtins.__import__ = import_without_optional_dependencies
+
+        import pyfixest as pf
+        from pyfixest.report.utils import rename_categoricals
+
+        assert callable(rename_categoricals)
+
+        fit = pf.feols("Y ~ X1", pf.get_data(N=100))
+        fit.summary()
+
+        try:
+            fit.etable()
+        except ImportError as exc:
+            assert "maketables" in str(exc)
+        else:
+            raise AssertionError("etable() should require maketables")
+
+        try:
+            fit.coefplot()
+        except ImportError as exc:
+            assert "matplotlib" in str(exc)
+        else:
+            raise AssertionError("coefplot() should require a plotting backend")
+        """
+    )
+
+    subprocess.run([sys.executable, "-c", code], check=True, capture_output=True)


### PR DESCRIPTION
## Summary

- Keep `summary()` available in the base installation by rendering its pandas result directly.
- Lazy-load table, plotting, decomposition, and randomization-inference dependencies only when those features are called.
- Remove runtime uses of `tqdm` and `seaborn`; plain iteration and SciPy's KDE cover those paths.
- Add a subprocess regression test that blocks every proposed optional reporting dependency while fitting and summarizing a model.

## Validation

- `pixi run test-py` (805 passed, 13 skipped, 1 xfailed)
- Focused summary and optional-dependency tests
- Ruff formatting/checks and mypy on changed Python files
- Full documentation render on the complete stack

## Stack

1. **#1461 — lazy-load reporting dependencies**
2. #1462 — split reporting into optional extras
3. #1463 — explain optional dependency extras

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
