### PR TITLE
build: split reporting into optional extras

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -13,6 +13,58 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  test-minimal-install:
+    name: "Test minimal installation"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install base package
+        run: |
+          python -m venv /tmp/pyfixest-minimal
+          /tmp/pyfixest-minimal/bin/python -m pip install .
+
+      - name: Check core API without optional dependencies
+        run: |
+          /tmp/pyfixest-minimal/bin/python - <<'PY'
+          from importlib.util import find_spec
+
+          optional = [
+              "great_tables",
+              "lets_plot",
+              "maketables",
+              "matplotlib",
+              "seaborn",
+              "tabulate",
+              "tqdm",
+          ]
+          installed = [package for package in optional if find_spec(package) is not None]
+          assert not installed, f"Unexpected optional dependencies: {installed}"
+
+          import pyfixest as pf
+
+          fit = pf.feols("Y ~ X1", pf.get_data(N=100))
+          fit.summary()
+
+          try:
+              fit.etable()
+          except ImportError as exc:
+              assert "pyfixest[tables]" in str(exc)
+          else:
+              raise AssertionError("etable() should require the tables extra")
+
+          try:
+              fit.coefplot(plot_backend="matplotlib")
+          except ImportError as exc:
+              assert "pyfixest[plots]" in str(exc)
+          else:
+              raise AssertionError("coefplot() should require the plots extra")
+          PY
+
   test-python:
     name: "Tests Python (${{ matrix.environment }}, ${{ matrix.os }})"
     runs-on: ${{ matrix.os }}

--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -23,6 +23,10 @@ fit3 = pf.feols("Y ~ X1 + X2 | f1", data = df)
   plain-text formatter. Table and plotting packages are imported only when their
   corresponding features are called. Internal progress bars and the seaborn-only
   plotting path have been removed.
+- Install publication tables with `pip install "pyfixest[tables]"`, plotting
+  backends with `pip install "pyfixest[plots]"`, or every end-user feature with
+  `pip install "pyfixest[all]"`. NumPy, pandas, Formulaic, SciPy, Narwhals, and
+  Joblib remain in the base installation.
 
 ### Inference Types
 

--- a/pixi.lock
+++ b/pixi.lock
@@ -431,7 +431,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl
       - pypi: https://download-r2.pytorch.org/whl/cu128/torch-2.10.0%2Bcu128-cp312-cp312-manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ab/a8/cdf8b3e4c98132f965f88c2313a4b493266832ad47fb52f23d14d4f86bb5/triton-3.6.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/b2/75/419e54d92b1b97128a12f8dcd53b40b5144a33a69026496287a3ab7557e4/wildboottest-0.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/af/aa/ead46a88f9ec3a432a4832dfedb84092fc35af2d0ba40cd04aea3889f247/wrapt-2.1.2-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
@@ -27845,23 +27844,28 @@ packages:
 - pypi: ./
   name: pyfixest
   version: 0.60.0
-  sha256: 75cfd97fdaf1d3534094deb3a8080d8afe14714e69eb59d249ec1400db556db8
+  sha256: da96f52a04be6e4d3b649b832858c56f09c3f2da2a970b2434bcd34a354b51bf
   requires_dist:
   - formulaic>=1.2.0,<1.3
   - joblib>=1.4.2
-  - maketables>=0.1.0
-  - narwhals>=1.13.3
+  - narwhals>=1.17
   - numpy>=1.25.2
-  - pandas>=1.1.0
+  - pandas>=1.3
   - scipy>=1.6
-  - seaborn>=0.13.2
-  - tabulate>=0.9.0
-  - tqdm>=4.0.0
+  - lets-plot>=4.0.0 ; extra == 'all'
+  - maketables>=0.1.0 ; extra == 'all'
+  - matplotlib>=3.7.0 ; extra == 'all'
+  - numba>=0.58.0 ; extra == 'all'
+  - tabulate>=0.9.0 ; extra == 'all'
+  - torch>=2.0 ; extra == 'all'
   - linearmodels ; extra == 'benchmarks'
   - pyarrow ; extra == 'benchmarks'
   - statsmodels ; extra == 'benchmarks'
   - numba>=0.58.0 ; extra == 'numba'
+  - matplotlib>=3.7.0 ; extra == 'plots'
   - lets-plot>=4.0.0 ; extra == 'plots'
+  - maketables>=0.1.0 ; extra == 'tables'
+  - tabulate>=0.9.0 ; extra == 'tables'
   - torch>=2.0 ; extra == 'torch'
   requires_python: '>=3.10'
 - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
@@ -38208,23 +38212,6 @@ packages:
   - pkg:pypi/tornado?source=compressed-mapping
   size: 859726
   timestamp: 1774358173994
-- pypi: https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl
-  name: tqdm
-  version: 4.67.3
-  sha256: ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf
-  requires_dist:
-  - colorama ; sys_platform == 'win32'
-  - importlib-metadata ; python_full_version < '3.8'
-  - pytest>=6 ; extra == 'dev'
-  - pytest-cov ; extra == 'dev'
-  - pytest-timeout ; extra == 'dev'
-  - pytest-asyncio>=0.24 ; extra == 'dev'
-  - nbval ; extra == 'dev'
-  - requests ; extra == 'discord'
-  - slack-sdk ; extra == 'slack'
-  - requests ; extra == 'telegram'
-  - ipywidgets>=6 ; extra == 'notebook'
-  requires_python: '>=3.7'
 - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.3-pyh8f84b5b_0.conda
   sha256: 9ef8e47cf00e4d6dcc114eb32a1504cc18206300572ef14d76634ba29dfe1eb6
   md5: e5ce43272193b38c2e9037446c1d9206

--- a/pyfixest/did/saturated_twfe.py
+++ b/pyfixest/did/saturated_twfe.py
@@ -20,7 +20,7 @@ def _import_matplotlib():
     except ImportError:
         raise ImportError(
             "Event-study plotting requires matplotlib. "
-            "Install it with `pip install matplotlib`."
+            "Install it with `pip install 'pyfixest[plots]'`."
         ) from None
     return plt
 

--- a/pyfixest/did/visualize.py
+++ b/pyfixest/did/visualize.py
@@ -15,7 +15,7 @@ def _import_matplotlib():
     except ImportError:
         raise ImportError(
             "DiD plotting requires matplotlib. "
-            "Install it with `pip install matplotlib`."
+            "Install it with `pip install 'pyfixest[plots]'`."
         ) from None
     return plt
 

--- a/pyfixest/estimation/post_estimation/decomposition.py
+++ b/pyfixest/estimation/post_estimation/decomposition.py
@@ -774,8 +774,8 @@ class GelbachDecomposition:
             from maketables import MTable
         except ImportError:
             raise ImportError(
-                "`etable()` requires maketables. "
-                "Install it with `pip install maketables`."
+                "`etable()` requires the optional `tables` dependencies. "
+                "Install them with `pip install 'pyfixest[tables]'`."
             ) from None
 
         if column_heads is not None and len(column_heads) != 3:

--- a/pyfixest/estimation/post_estimation/ritest.py
+++ b/pyfixest/estimation/post_estimation/ritest.py
@@ -424,7 +424,7 @@ def _plot_ritest_pvalue(
         except ImportError:
             raise ImportError(
                 "The matplotlib backend requires matplotlib. "
-                "Install it with `pip install matplotlib`."
+                "Install it with `pip install 'pyfixest[plots]'`."
             ) from None
 
         stats = np.asarray(ri_stats, dtype=float)

--- a/pyfixest/report/summarize.py
+++ b/pyfixest/report/summarize.py
@@ -180,7 +180,8 @@ def etable(
         import maketables
     except ImportError:
         raise ImportError(
-            "`etable()` requires maketables. Install it with `pip install maketables`."
+            "`etable()` requires the optional `tables` dependencies. "
+            "Install them with `pip install 'pyfixest[tables]'`."
         ) from None
 
     # Apply pyfixest default for signif_code (different from maketables default)

--- a/pyfixest/report/visualize.py
+++ b/pyfixest/report/visualize.py
@@ -58,7 +58,7 @@ def _import_matplotlib():
     except ImportError:
         raise ImportError(
             "The matplotlib backend requires matplotlib. "
-            "Install it with `pip install matplotlib`."
+            "Install it with `pip install 'pyfixest[plots]'`."
         ) from None
     return plt
 
@@ -88,7 +88,8 @@ def set_figsize(figsize: tuple[int, int] | None, plot_backend: str) -> tuple[int
         if not _HAS_LETS_PLOT:
             raise ImportError(
                 "The 'lets_plot' package is required for the 'lets_plot' backend. "
-                "Please install it with 'pip install lets-plot' or use the 'matplotlib' backend."
+                "Install it with `pip install 'pyfixest[plots]'` or use the "
+                "matplotlib backend."
             )
         return (500, 300)
     else:
@@ -534,7 +535,8 @@ def _coefplot(plot_backend, *, figsize, **plot_kwargs):
         if not _HAS_LETS_PLOT:
             raise ImportError(
                 "The 'lets_plot' package is required for the 'lets_plot' backend. "
-                "Please install it with 'pip install lets-plot' or use the 'matplotlib' backend."
+                "Install it with `pip install 'pyfixest[plots]'` or use the "
+                "matplotlib backend."
             )
         return _coefplot_lets_plot(figsize=figsize, **plot_kwargs)
     elif plot_backend == "matplotlib":

--- a/pyfixest/report/visualize_decomposition.py
+++ b/pyfixest/report/visualize_decomposition.py
@@ -116,8 +116,9 @@ def create_decomposition_plot(
         import matplotlib.pyplot as plt
     except ImportError:
         raise ImportError(
-            "matplotlib is required for coefplot. Install with: pip install matplotlib"
-        )
+            "Decomposition plotting requires matplotlib. "
+            "Install it with `pip install 'pyfixest[plots]'`."
+        ) from None
 
     # Create configuration
     config = PlotConfig(figsize=figsize or (12, 8))
@@ -675,7 +676,10 @@ def _finalize_plot(
     try:
         import matplotlib.pyplot as plt
     except ImportError:
-        raise ImportError("matplotlib is required for coefplot")
+        raise ImportError(
+            "Decomposition plotting requires matplotlib. "
+            "Install it with `pip install 'pyfixest[plots]'`."
+        ) from None
 
     bar_data = plot_data["bar_data"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,14 +38,10 @@ urls.Tracker = "https://github.com/py-econometrics/pyfixest/issues"
 dependencies = [
     "formulaic>=1.2.0,<1.3",
     "joblib>=1.4.2",
-    "maketables>=0.1.0",
-    "narwhals>=1.13.3",
+    "narwhals>=1.17",
     "numpy>=1.25.2",
-    "pandas>=1.1.0",
+    "pandas>=1.3",
     "scipy>=1.6",
-    "seaborn>=0.13.2",
-    "tabulate>=0.9.0",
-    "tqdm>=4.0.0",
 ]
 
 [project.optional-dependencies]
@@ -56,7 +52,20 @@ torch = [
     "torch>=2.0",
 ]
 plots = [
+    "matplotlib>=3.7.0",
     "lets-plot>=4.0.0",
+]
+tables = [
+    "maketables>=0.1.0",
+    "tabulate>=0.9.0",
+]
+all = [
+    "lets-plot>=4.0.0",
+    "maketables>=0.1.0",
+    "matplotlib>=3.7.0",
+    "numba>=0.58.0",
+    "tabulate>=0.9.0",
+    "torch>=2.0",
 ]
 benchmarks = [
     "linearmodels",
@@ -172,10 +181,8 @@ module = [
     "lets_plot.*",
     "formulaic.*",
     "wildboottest.*",
-    "tabulate.*",
     "joblib.*",
     "narwhals.*",
-    "tqdm.*",
 ]
 ignore_missing_imports = true
 
@@ -205,7 +212,7 @@ doubleml = ">=0.10.1"
 pytest-sugar = ">=1.1.1"
 
 [tool.pixi.pypi-dependencies]
-pyfixest = { path = ".", editable = true, extras = ["plots", "numba"] }
+pyfixest = { path = ".", editable = true, extras = ["plots", "tables", "numba"] }
 wildboottest = ">=0.3.2"
 maturin-import-hook = ">=0.2.0"
 maturin = ">=1.8"

--- a/tests/test_optional_dependencies.py
+++ b/tests/test_optional_dependencies.py
@@ -37,14 +37,14 @@ def test_core_estimation_without_reporting_dependencies():
         try:
             fit.etable()
         except ImportError as exc:
-            assert "maketables" in str(exc)
+            assert "pyfixest[tables]" in str(exc)
         else:
-            raise AssertionError("etable() should require maketables")
+            raise AssertionError("etable() should require the tables extra")
 
         try:
             fit.coefplot()
         except ImportError as exc:
-            assert "matplotlib" in str(exc)
+            assert "pyfixest[plots]" in str(exc)
         else:
             raise AssertionError("coefplot() should require a plotting backend")
         """


### PR DESCRIPTION
## Summary

- Reduce the base install to the packages needed for estimation and inference: Formulaic, joblib, Narwhals, NumPy, pandas, and SciPy.
- Add `tables` and `plots` extras, retain `numba` and `torch`, and add `all` as the union of those end-user feature extras.
- Give actionable installation errors such as `pip install "pyfixest[tables]"` when an optional feature is called.
- Add a minimal-install CI job that installs only the base package, fits a model, calls `summary()`, and verifies that optional packages were not installed.
- Regenerate `pixi.lock` for the dependency split.

Benchmark-only dependencies remain in the existing `benchmarks` extra and are intentionally excluded from `all`.

## Validation

- Clean temporary environment installed the base project with only its six direct dependencies and passed an estimation/summary smoke test
- Verified `all` equals the union of `tables`, `plots`, `numba`, and `torch`
- `pixi run test-py` (complete stack: 805 passed, 13 skipped, 1 xfailed)
- Workflow validation, TOML checks, Ruff, and mypy

## Stack

1. #1461 — lazy-load reporting dependencies
2. **#1462 — split reporting into optional extras**
3. #1463 — explain optional dependency extras

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
