### PR TITLE
docs: explain optional dependency extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,21 +61,24 @@ python -m pip install git+https://github.com/py-econometrics/pyfixest
 <details>
 <summary>Optional dependencies</summary>
 
-For visualization features using the `lets-plot` backend, install:
+The base installation includes estimation, inference, `tidy()`, and `summary()`.
+Install the feature extras you need:
 
 ```bash
-python -m pip install pyfixest[plots]
+python -m pip install "pyfixest[tables]"  # etable and publication-ready tables
+python -m pip install "pyfixest[plots]"   # matplotlib and lets-plot backends
+python -m pip install "pyfixest[numba]"   # optional accelerated algorithms
+python -m pip install "pyfixest[torch]"   # PyTorch demeaner backends
+python -m pip install "pyfixest[all]"     # all end-user features above
 ```
 
-`matplotlib` is included by default, so plotting works without this extra.
+The `tables` extra installs maketables, Great Tables, and Markdown table support.
+The `plots` extra installs both supported plotting backends. Calling an optional
+feature without its extra raises an installation message; importing PyFixest and
+fitting or summarizing a model do not require these packages.
 
-To run the LSMR demeaner via `PyTorch` (CPU and GPU), you need to install `PyTorch`, which you can do via
-
-```bash
-python -m pip install pyfixest[torch]
-```
-
-For GPU acceleration on CUDA, you additionally need to install a CUDA-enabled torch build. See the [PyTorch installation guide](https://pytorch.org/get-started/locally/) for details.
+For GPU acceleration on CUDA, install a CUDA-enabled torch build. See the
+[PyTorch installation guide](https://pytorch.org/get-started/locally/) for details.
 
 Then use the typed `demeaner` API:
 

--- a/docs/how-to/panel_variance_reduction.qmd
+++ b/docs/how-to/panel_variance_reduction.qmd
@@ -10,7 +10,6 @@ categories: [Panel, AB Testing]
 import numpy as np
 import pandas as pd
 from IPython.display import display
-from tqdm import tqdm
 
 import pyfixest as pf
 from pyfixest.utils.dgps import get_sharkfin
@@ -314,7 +313,7 @@ def _run_simulation(N, sigma_unit, n_sim=100):
     cuped_se_arr = np.zeros(n_sim)
     panel_se_arr = np.zeros(n_sim)
 
-    for i in tqdm(range(n_sim)):
+    for i in range(n_sim):
         data = get_sharkfin(
             num_units=N,
             num_periods=30,
@@ -361,7 +360,7 @@ def _power(nobs, n_sim):
         cuped_reject_null_arr = np.zeros(n_sim)
         panel_reject_null_arr = np.zeros(n_sim)
 
-        for i in tqdm(range(n_sim)):
+        for i in range(n_sim):
             data = get_sharkfin(
                 num_units=N,
                 num_periods=30,

--- a/docs/pyfixest.md
+++ b/docs/pyfixest.md
@@ -58,21 +58,24 @@ python -m pip install git+https://github.com/py-econometrics/pyfixest
 <details>
 <summary>Optional dependencies</summary>
 
-For visualization features using the `lets-plot` backend, install:
+The base installation includes estimation, inference, `tidy()`, and `summary()`.
+Install the feature extras you need:
 
 ```bash
-python -m pip install pyfixest[plots]
+python -m pip install "pyfixest[tables]"  # etable and publication-ready tables
+python -m pip install "pyfixest[plots]"   # matplotlib and lets-plot backends
+python -m pip install "pyfixest[numba]"   # optional accelerated algorithms
+python -m pip install "pyfixest[torch]"   # PyTorch demeaner backends
+python -m pip install "pyfixest[all]"     # all end-user features above
 ```
 
-`matplotlib` is included by default, so plotting works without this extra.
+The `tables` extra installs maketables, Great Tables, and Markdown table support.
+The `plots` extra installs both supported plotting backends. Calling an optional
+feature without its extra raises an installation message; importing PyFixest and
+fitting or summarizing a model do not require these packages.
 
-To run the LSMR demeaner via `PyTorch` (CPU and GPU), you need to install `PyTorch`, which you can do via
-
-```bash
-python -m pip install pyfixest[torch]
-```
-
-For GPU acceleration on CUDA, you additionally need to install a CUDA-enabled torch build. See the [PyTorch installation guide](https://pytorch.org/get-started/locally/) for details.
+For GPU acceleration on CUDA, install a CUDA-enabled torch build. See the
+[PyTorch installation guide](https://pytorch.org/get-started/locally/) for details.
 
 Then use the typed `demeaner` API:
 

--- a/docs/tutorials/regression-tables.qmd
+++ b/docs/tutorials/regression-tables.qmd
@@ -21,6 +21,15 @@ The `pf.etable()` API remains unchanged and `pf.make_table()` has been removed (
 
 Pyfixest comes with functions to generate publication-ready tables. Regression tables are generated with `pf.etable()`, which can output different formats, for instance using the [Great Tables](https://posit-dev.github.io/great-tables/articles/intro.html) package or generating formatted LaTex Tables using [booktabs](https://ctan.org/pkg/booktabs?lang=en). Descriptive statistics tables can be created with `DTable()` and custom tables with `maketables.MTable()`.
 
+Table rendering is optional. Install it before following this guide:
+
+```bash
+python -m pip install "pyfixest[tables]"
+```
+
+The base installation still provides `fit.summary()` for a plain-text model
+summary without the table-rendering packages.
+
 To begin, we load some libraries and fit a set of regression models.
 
 ```{python}


### PR DESCRIPTION
## Summary

- Document the base installation and the `tables`, `plots`, `numba`, `torch`, and `all` extras in the README and package landing page.
- Add the `tables` installation step to the regression-table tutorial while clarifying that base `summary()` remains available.
- Remove the final documentation-only `tqdm` use from the panel variance-reduction guide.

## Validation

- Full 94-page `pixi run docs-render` completed successfully, including executable API and tutorial examples
- `pixi run test-py` (complete stack: 805 passed, 13 skipped, 1 xfailed)
- Pre-commit checks passed for all changed documentation files

## Stack

1. #1461 — lazy-load reporting dependencies
2. #1462 — split reporting into optional extras
3. **#1463 — explain optional dependency extras**

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
