### PR TITLE
test(docs): check the rendered llms index and links

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -110,6 +110,9 @@ jobs:
       - name: Build and render docs
         run: pixi run -e docs docs-render
 
+      - name: Check rendered llms index and links
+        run: pixi run -e docs python scripts/check_agent_docs.py --site docs/_site
+
       - name: Save docs artifact
         uses: actions/upload-artifact@v7
         with:

--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -41,6 +41,11 @@ fit3 = pf.feols("Y ~ X1 + X2 | f1", data = df)
   also refresh `pixi.lock` in the newer v7 format. Both ask for pixi 0.71.0 or
   newer.
 
+### Documentation
+
+- CI now checks that every rendered page is listed in `llms.txt` and that
+  internal links in the machine-readable pages resolve.
+
 ### Inference Types
 
 - `tidy()`, `confint()`, and `summary()` gain an `inference_type` argument.

--- a/docs/tutorials/instrumental-variables.qmd
+++ b/docs/tutorials/instrumental-variables.qmd
@@ -130,7 +130,7 @@ ivf_df = pf.get_ivf_data()
 ivf_df.head()
 ```
 
-We create a synthetic dataset with $N = 2{,}000$ observations. The **true causal effect** of `num_children` on `earnings` is $\beta = -0.15$ — this is the treatment effect the IV estimator should recover (full DGP in the [Appendix](#appendix-dgp-design-notes)).
+We create a synthetic dataset with $N = 2{,}000$ observations. The **true causal effect** of `num_children` on `earnings` is $\beta = -0.15$ — this is the treatment effect the IV estimator should recover. See the [`get_ivf_data` API reference](../reference/utils.dgps.get_ivf_data.qmd) for the full data-generating process.
 
 ### Naive OLS
 

--- a/pyfixest/estimation/api/feglm.py
+++ b/pyfixest/estimation/api/feglm.py
@@ -160,7 +160,7 @@ def feglm(
         `MapDemeaner()` (Rust MAP algorithm, tol=1e-6, maxiter=10_000).
         For other options - including the optional Numba backend and the
         torch-based LSMR backends - see the
-        [Demeaner Backends vignette](../../how-to/demeaner-backends.qmd).
+        [Demeaner Backends vignette](/how-to/demeaner-backends.qmd).
 
         .. deprecated::
             The ``cupy`` / ``scipy`` LSMR backends are deprecated and will

--- a/pyfixest/estimation/api/feols.py
+++ b/pyfixest/estimation/api/feols.py
@@ -144,7 +144,7 @@ def feols(
         `MapDemeaner()` (Rust MAP algorithm, tol=1e-6, maxiter=10_000).
         For other options - including the optional Numba backend and the
         torch-based LSMR backends - see the
-        [Demeaner Backends vignette](../../how-to/demeaner-backends.qmd).
+        [Demeaner Backends vignette](/how-to/demeaner-backends.qmd).
 
         .. deprecated::
             The ``cupy`` / ``scipy`` LSMR backends are deprecated and will

--- a/pyfixest/estimation/api/fepois.py
+++ b/pyfixest/estimation/api/fepois.py
@@ -127,7 +127,7 @@ def fepois(
         `MapDemeaner()` (Rust MAP algorithm, tol=1e-6, maxiter=10_000).
         For other options - including the optional Numba backend and the
         torch-based LSMR backends - see the
-        [Demeaner Backends vignette](../../how-to/demeaner-backends.qmd).
+        [Demeaner Backends vignette](/how-to/demeaner-backends.qmd).
 
         .. deprecated::
             The ``cupy`` / ``scipy`` LSMR backends are deprecated and will

--- a/scripts/check_agent_docs.py
+++ b/scripts/check_agent_docs.py
@@ -1,0 +1,100 @@
+"""Check the rendered llms.txt index and the internal links in its pages."""
+
+from __future__ import annotations
+
+import argparse
+import posixpath
+import re
+from pathlib import Path, PurePosixPath
+from urllib.parse import unquote, urlsplit
+
+_MARKDOWN_LINK_RE = re.compile(
+    r"(?<!!)\[[^\]]+\]\((?P<target><[^>]+>|[^)\s]+)"
+    r"(?:\s+(?:\"[^\"]*\"|'[^']*'))?\)"
+)
+_HTML_LINK_RE = re.compile(r"<a\s+[^>]*href=[\"'](?P<target>[^\"']+)[\"']", re.I)
+
+
+class AgentDocsError(ValueError):
+    """Report one or more violations of the rendered documentation contract."""
+
+
+def _markdown_targets(text: str) -> list[str]:
+    matches = [*_MARKDOWN_LINK_RE.finditer(text), *_HTML_LINK_RE.finditer(text)]
+    return [match.group("target").strip("<>") for match in matches]
+
+
+def _local_path(target: str, source: PurePosixPath) -> PurePosixPath | None:
+    """Resolve a link target against its page, or return None if it is not local."""
+    parsed = urlsplit(target)
+    is_email = "@" in parsed.path and "/" not in parsed.path
+    if parsed.scheme or parsed.netloc or not parsed.path or is_email:
+        return None
+    decoded = unquote(parsed.path)
+    if not decoded.startswith("/"):
+        decoded = str(source.parent / decoded)
+    normalized = posixpath.normpath(decoded.lstrip("/"))
+    path = PurePosixPath("index.html" if normalized == "." else normalized)
+    if path.is_absolute() or ".." in path.parts:
+        raise AgentDocsError(f"Local link escapes the rendered site: {target}")
+    return path
+
+
+def _path_exists(site: Path, target: PurePosixPath) -> bool:
+    root = site.resolve()
+    candidates = (target, target.with_suffix(".html"), target / "index.html")
+    resolved = [(root / candidate).resolve() for candidate in candidates]
+    return any(path.is_relative_to(root) and path.is_file() for path in resolved)
+
+
+def _check_links(site: Path, source: PurePosixPath, errors: list[str]) -> set[str]:
+    """Resolve every link on one page, recording the targets that do not exist."""
+    targets: set[str] = set()
+    for target in _markdown_targets((site / source).read_text(encoding="utf-8")):
+        try:
+            path = _local_path(target, source)
+        except AgentDocsError as exc:
+            errors.append(f"{exc} (in {source})")
+            continue
+        if path is not None:
+            targets.add(path.as_posix())
+            if not _path_exists(site, path):
+                errors.append(f"Broken internal link in {source}: {target}")
+    return targets
+
+
+def check_agent_docs(*, site: Path) -> None:
+    """Check that llms.txt indexes every rendered page and that its links resolve."""
+    errors: list[str] = []
+    index = PurePosixPath("llms.txt")
+    if not (site / index).is_file():
+        raise AgentDocsError(f"Missing rendered index: {site / index}")
+
+    indexed = {t for t in _check_links(site, index, errors) if t.endswith(".llms.md")}
+    if not indexed:
+        errors.append("llms.txt does not index any .llms.md pages.")
+    rendered = {path.relative_to(site).as_posix() for path in site.rglob("*.llms.md")}
+    for page in rendered - indexed:
+        errors.append(f"Rendered page is missing from llms.txt: {page}")
+    for page in indexed - rendered:
+        errors.append(f"llms.txt indexes a missing page: {page}")
+    for page in sorted(indexed & rendered):
+        _check_links(site, PurePosixPath(page), errors)
+    if errors:
+        raise AgentDocsError("\n".join(sorted(errors)))
+
+
+def main() -> int:
+    """Run the rendered-documentation checks from the command line."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--site", type=Path, default=Path("docs/_site"))
+    try:
+        check_agent_docs(site=parser.parse_args().site)
+    except AgentDocsError as exc:
+        parser.exit(1, f"agent docs check failed:\n{exc}\n")
+    print("agent docs check passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_agent_docs.py
+++ b/tests/test_agent_docs.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.check_agent_docs import AgentDocsError, check_agent_docs
+
+
+def _write_site(path: Path, *, link: str = "guide.llms.md") -> None:
+    path.mkdir()
+    (path / "llms.txt").write_text(f"- [Guide]({link})\n", encoding="utf-8")
+    (path / "guide.llms.md").write_text("The needle is here.\n", encoding="utf-8")
+
+
+def test_agent_docs_rejects_index_without_pages(tmp_path: Path) -> None:
+    site = tmp_path / "site"
+    _write_site(site, link="guide.html")
+    (site / "guide.html").write_text("<p>Guide</p>\n", encoding="utf-8")
+
+    with pytest.raises(AgentDocsError, match=r"does not index any \.llms\.md"):
+        check_agent_docs(site=site)
+
+
+def test_agent_docs_rejects_missing_indexed_page(tmp_path: Path) -> None:
+    site = tmp_path / "site"
+    _write_site(site)
+    (site / "guide.llms.md").unlink()
+
+    with pytest.raises(AgentDocsError, match="indexes a missing page"):
+        check_agent_docs(site=site)
+
+
+def test_agent_docs_rejects_unindexed_rendered_page(tmp_path: Path) -> None:
+    site = tmp_path / "site"
+    _write_site(site)
+    (site / "orphan.llms.md").write_text("# Orphan\n", encoding="utf-8")
+
+    with pytest.raises(AgentDocsError, match=r"missing from llms\.txt"):
+        check_agent_docs(site=site)
+
+
+def test_agent_docs_rejects_broken_internal_link(tmp_path: Path) -> None:
+    site = tmp_path / "site"
+    _write_site(site)
+    (site / "guide.llms.md").write_text(
+        "The needle is here. [Missing](missing.llms.md)\n", encoding="utf-8"
+    )
+
+    with pytest.raises(AgentDocsError, match="Broken internal link"):
+        check_agent_docs(site=site)
+
+
+@pytest.mark.parametrize("location", ["index", "page"])
+def test_agent_docs_rejects_path_outside_site(tmp_path: Path, location: str) -> None:
+    site = tmp_path / "site"
+    _write_site(site)
+    page = "llms.txt" if location == "index" else "guide.llms.md"
+    (site / page).write_text("[Outside](../outside.llms.md)\n", encoding="utf-8")
+
+    with pytest.raises(AgentDocsError, match="escapes the rendered site"):
+        check_agent_docs(site=site)
+
+
+def test_agent_docs_accepts_external_targets(tmp_path: Path) -> None:
+    site = tmp_path / "site"
+    _write_site(site)
+    (site / "guide.llms.md").write_text(
+        "[Web](https://pyfixest.org/missing.html) [Mail](mailto:nobody@example.com)"
+        " [Author](nobody@example.com)\n",
+        encoding="utf-8",
+    )
+
+    check_agent_docs(site=site)
+
+
+def test_agent_docs_accepts_root_relative_link(tmp_path: Path) -> None:
+    site = tmp_path / "site"
+    _write_site(site)
+    (site / "llms.txt").write_text(
+        "- [Guide](guide.llms.md)\n- [How to](how-to/setup.llms.md)\n", encoding="utf-8"
+    )
+    (site / "how-to").mkdir()
+    (site / "how-to" / "setup.llms.md").write_text(
+        "See the [guide](/guide.llms.md) and the [site](/index.html).\n",
+        encoding="utf-8",
+    )
+    (site / "index.html").write_text("<p>Home</p>\n", encoding="utf-8")
+
+    check_agent_docs(site=site)


### PR DESCRIPTION
## Summary

Quarto renders `llms.txt` and a `.llms.md` per page but checks none of it, so a page can silently drop out of the index and a relative link inside a machine-readable page can point nowhere. This adds a dependency-free checker, `scripts/check_agent_docs.py` (100 lines), and runs it in the `build-docs` CI job right after the render. It makes exactly two assertions: every rendered `.llms.md` is indexed and every indexed page exists, and every internal link in `llms.txt` and the indexed pages resolves inside the site root. No fragment checking, no content contracts.

The check already found one real bug: the `demeaner` docstrings in `feols`, `fepois`, and `feglm` used `../../how-to/demeaner-backends.qmd`, which escapes the site from `reference/`; they now use the root-relative form. The IV tutorial also linked a `#appendix-dgp-design-notes` anchor that does not exist; that is fixed here too, although the checker deliberately does not inspect fragments. Independent of the other documentation branches; replaces the earlier stacked version of this PR.

## Verification

`pytest tests/test_agent_docs.py` (8 passed); changed-file ruff check and format; workflow schema validation; a full `docs-render` (94/94 pages, 12 min) followed by the checker, which passes. Breaking one link in a rendered `.llms.md` makes it exit 1 naming the page and target. The `mypy` hook is scoped to `^pyfixest/` and skips `scripts/`, so it is reported as skipped, not passed.
