### PR TITLE
docs: add agent breadcrumbs to the package, README, and landing page

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,10 @@ This will launch a github codespace (there is a free tier for 60h a month, thank
 
 Please refer to the [contributing section](https://pyfixest.org/contributing.html) of our documentation to get started with local development.
 
+When working offline or with a coding agent, start with [`AGENTS.md`](AGENTS.md).
+It contains the repository map, development workflow, testing commands, and
+documentation requirements used in this checkout.
+
 The repository's [architecture](docs/developer/architecture.md),
 [testing policy](docs/developer/testing.md),
 [`fixest` compatibility ledger](docs/developer/fixest-compatibility.md), and

--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ The package aims to mimic the syntax and functionality of [Laurent Bergé's](htt
 
 For questions on `PyFixest`, head over to our [GitHub discussions](https://github.com/py-econometrics/pyfixest/discussions), or join our [Discord server](https://discord.gg/gBAydeDMVK).
 
+## Using PyFixest with AI agents
+
+Installed releases ship the documentation next to the code: `python -c "import importlib.resources as r; print(r.files('pyfixest') / 'docs')"` prints the directory; start with its `llms.txt`. The same pages are online at [pyfixest.org/llms.txt](https://pyfixest.org/llms.txt), the [cheat sheet](https://pyfixest.org/cheatsheet.html) condenses the API onto one page, and the [AI agent guide](https://pyfixest.org/skills.html) explains how to use them with a coding agent.
+
 ## Features
 
 - **Estimation**

--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -41,6 +41,11 @@ fit3 = pf.feols("Y ~ X1 + X2 | f1", data = df)
   also refresh `pixi.lock` in the newer v7 format. Both ask for pixi 0.71.0 or
   newer.
 
+### Documentation
+
+- The package docstring, README, and landing page now point agents at the
+  machine-readable documentation and the repository.
+
 ### Inference Types
 
 - `tidy()`, `confint()`, and `summary()` gain an `inference_type` argument.

--- a/docs/pyfixest.md
+++ b/docs/pyfixest.md
@@ -22,6 +22,10 @@ The package aims to mimic the syntax and functionality of [Laurent Bergé's](htt
 
 For questions on `PyFixest`, head over to our [GitHub discussions](https://github.com/py-econometrics/pyfixest/discussions), or join our [Discord server](https://discord.gg/gBAydeDMVK).
 
+## Using PyFixest with AI agents
+
+Installed releases ship the documentation next to the code: `python -c "import importlib.resources as r; print(r.files('pyfixest') / 'docs')"` prints the directory; start with its `llms.txt`. The same pages are online at [llms.txt](llms.txt), and the [AI agent guide](skills.md) explains how to use them with a coding agent.
+
 ## Features
 
 - **Estimation**

--- a/pyfixest/__init__.py
+++ b/pyfixest/__init__.py
@@ -1,3 +1,12 @@
+"""Fast high-dimensional fixed-effects estimation for Python.
+
+Docs:    installed, version-matched corpus at
+         importlib.resources.files("pyfixest") / "docs" (start with llms.txt;
+         absent in a source checkout, where docs/ and AGENTS.md apply);
+         latest release at https://pyfixest.org/llms.txt
+Source:  https://github.com/py-econometrics/pyfixest
+"""
+
 import importlib as _importlib
 from importlib.metadata import PackageNotFoundError, version
 

--- a/tests/test_agent_breadcrumbs.py
+++ b/tests/test_agent_breadcrumbs.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+
+def _run_in_fresh_interpreter(script: str) -> None:
+    """Run `script` in a subprocess that imports pyfixest for the first time."""
+    repo_root = Path(__file__).resolve().parents[1]
+    result = subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(script)],
+        capture_output=True,
+        text=True,
+        cwd=repo_root,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr or result.stdout
+
+
+def test_module_docstring_points_at_docs_and_source() -> None:
+    _run_in_fresh_interpreter(
+        """
+        import pyfixest as pf
+
+        assert 'importlib.resources.files("pyfixest") / "docs"' in pf.__doc__
+        assert "https://pyfixest.org/llms.txt" in pf.__doc__
+        assert "https://github.com/py-econometrics/pyfixest" in pf.__doc__
+        """
+    )
+
+
+def test_module_docstring_preserves_lazy_imports() -> None:
+    _run_in_fresh_interpreter(
+        """
+        import sys
+
+        import pyfixest as pf
+
+        assert "pyfixest.estimation.api.feols" not in sys.modules
+        assert pf.feols.__name__ == "feols"
+        assert "pyfixest.estimation.api.feols" in sys.modules
+        assert set(dir(pf)) == set(pf.__all__)
+        """
+    )


### PR DESCRIPTION
## Summary

Coding agents read `pyfixest/__init__.py`, the README, and the site landing page before anything else, and none of them said where the machine-readable docs live. The package now carries a short docstring pointing at the installed, version-matched corpus (`importlib.resources.files("pyfixest") / "docs"`, start with its `llms.txt`), the online copy at pyfixest.org/llms.txt, and the repository. The README and `docs/pyfixest.md` gain a matching "Using PyFixest with AI agents" section, and `CONTRIBUTING.md` points contributors working offline or with an agent at `AGENTS.md`.

The docstring is deliberately short: it must stay readable in `help(pf)` and must not tempt anyone into eager imports. A test asserts the pointer content and that `pyfixest.estimation.api.feols` stays absent from `sys.modules` until first attribute access. The bundled docs directory the docstring names ships in a later PR; the Skills line follows with the skill PR. Independent of the other documentation branches; replaces the earlier stacked version of this PR.

## Verification

`pytest tests/test_agent_breadcrumbs.py` (2 passed); `prek run ruff-check / ruff-format / mypy` on the changed Python files; `docs-build` and `quarto render docs/pyfixest.md` with the new section's links resolving in `_site/pyfixest.html`; all hooks on the changed Markdown; `git diff --check`. Full `docs-render` deferred to CI.
