### PR TITLE
docs: ship an installable PyFixest agent skill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,7 +62,8 @@ benchmarks/data/
 .claude/
 .serena/
 # A stray root SKILL.md (e.g. copied from docs/skills.md). Repository skills
-# live in .agents/skills/ and are tracked.
+# live in .agents/skills/ and the user-facing skill lives in skills/pyfixest/;
+# both are tracked.
 /SKILL.md
 
 # Platform-local pyfixest release baseline (see docs/developer/testing.md)

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -45,7 +45,7 @@ website:
       - icon: robot
         href: llms.txt
         text: llms.txt
-      - text: "Skills.md"
+      - text: "AI agent guide"
         file: skills.md
       - icon: github
         href: https://github.com/py-econometrics/pyfixest/

--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -50,6 +50,9 @@ fit3 = pf.feols("Y ~ X1 + X2 | f1", data = df)
 - An executed cheat sheet (`cheatsheet.qmd`) replaces the hand-maintained skill
   text: every formula, `vcov` spelling, and unsupported combination on it runs
   at render time.
+- Releases ship an installable agent skill at `skills/pyfixest/SKILL.md`; it
+  resolves the bundled documentation at runtime, and a test executes its
+  examples.
 
 ### Inference Types
 

--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -51,8 +51,8 @@ fit3 = pf.feols("Y ~ X1 + X2 | f1", data = df)
   text: every formula, `vcov` spelling, and unsupported combination on it runs
   at render time.
 - Releases ship an installable agent skill at `skills/pyfixest/SKILL.md`; it
-  resolves the bundled documentation at runtime, and a test executes its
-  examples.
+  resolves the bundled documentation at runtime and routes tasks through the
+  cheat sheet's single maintained task table. A test executes its examples.
 
 ### Inference Types
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -11,16 +11,23 @@ skill that points at it.
 ## What ships with a release
 
 **The documentation.** Each wheel contains the rendered site as Markdown, next
-to the package. Locate it with:
+to the package. Locate it, and check that it is present:
 
 ```bash
-python -c "import importlib.resources as r; print(r.files('pyfixest') / 'docs')"
+python -c "import importlib.resources as r; p = r.files('pyfixest') / 'docs'; print(p, (p / 'llms.txt').is_file())"
 ```
 
-Start with `cheatsheet.llms.md` — one page with formula syntax, standard errors,
-post-estimation methods, tables, and a table naming the page to read for each
-task. `llms.txt` in the same directory lists every page. Because the corpus
-travels with the wheel, it always describes the installed version.
+If that prints `True`, start with `cheatsheet.llms.md` — one page with formula
+syntax, standard errors, post-estimation methods, tables, and a table naming the
+page to read for each task. `llms.txt` in the same directory lists every page
+and describes each. Because the corpus travels with the wheel, it always
+describes the installed version.
+
+If it prints `False`, `pyfixest` is importable but ships no documentation: it
+comes from a source checkout, or from a release older than the bundled corpus.
+In a checkout, read `docs/` and `AGENTS.md` in the repository. Otherwise read
+<https://pyfixest.org/cheatsheet.html>, which describes the latest release
+rather than the installed one.
 
 **The skill.** `SKILL.md` is a short router: it tells the agent how to find the
 directory above, which page to open for the task at hand, and a handful of core
@@ -57,8 +64,8 @@ Or open
 on GitHub and paste it into whichever skill file your tool reads.
 
 The skill needs `pyfixest` importable in the environment the agent uses, and
-nothing else — no API keys, no extra packages. Without a local PyFixest it falls
-back to <https://pyfixest.org>.
+nothing else — no API keys, no extra packages. Where the bundled documentation
+is missing it falls back to the repository, or to <https://pyfixest.org>.
 
 ## See also
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -50,8 +50,12 @@ Code, that is `~/.claude/skills/pyfixest` for every project, or
 `.claude/skills/pyfixest` for one project:
 
 ```bash
-cp -r "$(python -c "import pyfixest, pathlib; print(pathlib.Path(pyfixest.__file__).parents[1] / 'skills' / 'pyfixest')")" ~/.claude/skills/pyfixest
+SRC="$(python -c "import pyfixest, pathlib; print(pathlib.Path(pyfixest.__file__).parents[1] / 'skills' / 'pyfixest')")"
+mkdir -p ~/.claude/skills/pyfixest && cp -R "$SRC"/. ~/.claude/skills/pyfixest/
 ```
+
+Re-run the same two lines after upgrading PyFixest: they update the copy in
+place instead of nesting a second one inside it.
 
 You can also install it straight from the repository, without a local PyFixest:
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -1,157 +1,69 @@
-# Skills
+---
+title: "Using PyFixest with AI agents"
+description: "What ships with a PyFixest release for coding agents, where the installable agent skill lands after pip install, and how to install it."
+---
 
-This page provides a ready-to-use skill file for analytics projects that use PyFixest. The goal is to make LLM-assisted analysis more reliable by giving the model a concise, authoritative reference for PyFixest usage.
+Coding agents work better with PyFixest when they read PyFixest's own
+documentation instead of recalling an API from memory. Every release ships two
+things for that: a machine-readable copy of this site, and an installable agent
+skill that points at it.
 
-## How To Use
+## What ships with a release
 
-1. Copy the skill content below into a file named `SKILL.md` or `Agent.md` (or a tool-specific skill file) in your analytics project.
-2. Ensure your LLM tool is configured to read project skills.
-3. Use the formula and inference guidelines below as the authoritative PyFixest reference for the model.
+**The documentation.** Each wheel contains the rendered site as Markdown, next
+to the package. Locate it with:
 
-## Skill File (PyFixest)
-
-```markdown
-# PyFixest Skill
-
-## Core API (4 functions)
-
-- `pyfixest.feols(fml, data, vcov, weights, ssc, fixef_rm, ...)`: OLS/WLS/IV with fixed effects.
-- `pyfixest.fepois(fml, data, vcov, ...)`: Poisson regression with fixed effects.
-- `pyfixest.feglm(fml, data, family, vcov, ...)`: GLM regression (family: "logit", "probit", "gaussian") with fixed effects.
-- `pyfixest.quantreg(fml, data, quantile, ...)`: Quantile regression via interior point solver.
-
-## Formula Syntax
-
-Formulas follow fixest syntax and are split into 1–3 parts by `|`:
-
-- One-part: `"Y ~ X1 + X2"` (no fixed effects, no IV)
-- Two-part: `"Y ~ X1 + X2 | FE1 + FE2"` (fixed effects)
-- Two-part IV: `"Y ~ X1 + X2 | X_endog ~ Z1 + Z2"` (IV without fixed effects)
-- Three-part IV: `"Y ~ X1 + X2 | FE1 + FE2 | X_endog ~ Z1 + Z2"` (IV with fixed effects)
-
-IV behavior:
-- The IV part must be `endogenous ~ instruments`.
-- Exogenous variables from the second-stage RHS are automatically added to the first stage.
-- Endogenous variables are automatically added to the second stage.
-- Multiple endogenous variables are not supported.
-
-Other syntax:
-- Multiple depvars are expanded to multiple estimations: `"Y1 + Y2 ~ X1"` behaves like `"sw(Y1, Y2) ~ X1"`.
-- `i()` creates indicator expansions and interactions. It expands categorical variables into dummies and can interact a categorical variable with a numeric or another categorical variable.
-  Examples: `i(cat)`, `i(cat, ref="Base")`, `i(cat, x)` (numeric `x` gives varying slopes; categorical `x` gives cat-by-x indicators), `i(cat1, cat2, ref2="Base")`.
-  Example (cat × numeric): `Y ~ i(industry, exposure)` creates industry-specific slopes on `exposure`.
-  Example (cat × cat): `Y ~ i(state, year, ref2=2000)` creates state-by-year indicators with 2000 as the base year.
-- Standard interactions work as well. `X1 * X2` expands to `X1 + X2 + X1:X2`, while `X1:X2` is the interaction term only.
-- Interacted FEs: `"Y ~ X1 | FE1:FE2"` (creates a combined FE).
-
-### Multiple Estimation Operators
-
-Operators can appear anywhere in the formula (RHS, fixed effects, IV parts). They can be combined; expansion is recursive and produces all combinations. Note that multiple estimation can be significantly faster than independent model calls due to internal optimisations.
-
-`sw` (sequential stepwise):
-- `y ~ x1 + sw(x2, x3)` → `y ~ x1 + x2` and `y ~ x1 + x3`
-
-`sw0` (sequential stepwise with zero step):
-- `y ~ x1 + sw0(x2, x3)` → `y ~ x1`, `y ~ x1 + x2`, `y ~ x1 + x3`
-
-`csw` (cumulative stepwise):
-- `y ~ x1 + csw(x2, x3)` → `y ~ x1 + x2`, `y ~ x1 + x2 + x3`
-
-`csw0` (cumulative stepwise with zero step):
-- `y ~ x1 + csw0(x2, x3)` → `y ~ x1`, `y ~ x1 + x2`, `y ~ x1 + x2 + x3`
-
-`mvsw` (multiverse stepwise):
-- `y ~ mvsw(x1, x2, x3)` → all non-empty combinations plus the zero step:
-  `y ~ 1`, `y ~ x1`, `y ~ x2`, `y ~ x3`, `y ~ x1 + x2`, `y ~ x1 + x3`, `y ~ x2 + x3`, `y ~ x1 + x2 + x3`
-
-Combining operators example:
-- `y ~ csw(x1, x2) + sw(z1, z2)` expands to:
-  `y ~ x1 + z1`, `y ~ x1 + z2`, `y ~ x1 + x2 + z1`, `y ~ x1 + x2 + z2`
-
-You can run regressions for subsamples by using the `split` and `fsplit` arguments, where both split by the
-provided variable, but `fsplit` also provides a fit for the full sample.
-
-## Inference (vcov)
-
-Pass to `vcov`:
-
-- `"iid"` — IID errors
-- `"hetero"` — HC1 heteroskedasticity-robust (alias: `"HC1"`)
-- `"HC2"` — HC2 robust (not supported with fixed effects or IV)
-- `"HC3"` — HC3 robust (not supported with fixed effects or IV)
-- `{"CRV1": "cluster_var"}` — Cluster-robust variance
-- `{"CRV3": "cluster_var"}` — Leave-one-cluster-out jackknife
-- `"NW"` — Newey-West HAC (requires `vcov_kwargs` with `time_id`; optional `panel_id`, `lag`)
-- `"DK"` — Driscoll-Kraay HAC (requires `vcov_kwargs` with `time_id`; optional `panel_id`, `lag`)
-
-Two-way clustering: `{"CRV1": "var1 + var2"}`.
-
-Inference can be adjusted post-estimation: `fit.vcov("hetero").summary()`.
-
-## Post Processing
-
-Model objects support:
-
-- `.summary()` — Print regression summary
-- `.tidy()` — Tidy DataFrame of coefficients, SEs, t-stats, p-values, CIs
-- `.coef()` — Coefficient values
-- `.se()` — Standard errors
-- `.pvalue()` — P-values
-- `.confint()` — Confidence intervals
-- `.predict(newdata)` — Predictions
-- `.resid()` — Residuals
-- `.vcov()` — Variance-covariance matrix
-- `.tstat()` — T-statistics
-- `.fixef()` — Extract fixed effect estimates
-- `.wildboottest(param, reps, seed)` — Wild cluster bootstrap inference
-- `.ccv(treatment, pk, qk, ...)` — Causal cluster variance estimator
-- `.ritest(resampvar, reps, ...)` — Randomization inference
-- `.decompose(param, x1_vars, type, ...)` — Gelbach (2016) decomposition
-- `.wald_test(R, q)` — Linear hypothesis testing
-- `.update(X_new, y_new)` — Online coefficient update (Sherman-Morrison)
-- `.evalue()` / `.pvalue_savi()` — Anytime-valid (SAVI) e-values and sequential p-values
-- `.first_stage()` — First-stage results (IV only)
-- `.IV_Diag()` — IV diagnostic tests (IV only)
-
-For IV models, show first and second stage together: `pf.etable([fit._model_1st_stage, fit])`.
-
-## DiD / Causal Inference
-
-- `pf.did2s(data, yname, first_stage, second_stage, treatment, cluster)` — Two-stage DID (Gardner 2022).
-- `pf.event_study(data, yname, idname, tname, gname, estimator="twfe")` — Event study with multiple estimators.
-- `pf.lpdid(data, yname, idname, tname, gname)` — Local projections DID.
-- `pf.SaturatedEventStudy(data, yname, idname, tname, gname)` — Saturated event study with cohort-specific effects.
-- `pf.panelview(data, unit, time, treat)` — Panel treatment visualization.
-
-## Visualization
-
-- `pf.coefplot(models)` — Plot coefficients with confidence intervals.
-- `pf.iplot(models)` — Plot coefficients from `i()` interactions (event-study style).
-- `pf.qplot(models)` — Plot quantile regression coefficients.
-
-## Multiple Testing
-
-- `pf.bonferroni(models, param)` — Bonferroni-adjusted p-values.
-- `pf.rwolf(models, param, reps, seed)` — Romano-Wolf adjusted p-values.
-- `pf.wyoung(models, param, reps, seed)` — Westfall-Young adjusted p-values.
-
-## Utilities
-
-- `pf.get_data(N, seed)` — Generate example dataset for testing.
-- `pf.get_ivf_data()`, `pf.get_bartik_data()`, `pf.get_encouragement_data()` — IV example datasets.
-- `pf.get_twin_data()`, `pf.get_worker_panel()`, `pf.get_motherhood_event_study_data()` — Panel and event-study datasets.
-- `pf.ssc(k_adj, k_fixef, G_adj, G_df)` — Configure small sample corrections.
-
-## etable Basics
-
-For regression tables, use `pf.etable()`.
-
-- Build tables: `pf.etable([fit1, fit2, ...])` or `pf.etable(pf.feols("Y~csw(X1,X2)", data))`.
-- Output formats: `type="gt"` (default), `"md"`, `"tex"`, `"df"`.
-- Keep/drop variables: `keep="X1"` or `drop=["X2"]`.
-- Labels and fixed effects labels: `labels={...}`, `felabels={...}`.
-- Show p-values or CIs: `coef_fmt="b (se) [p]"` shows the coefficient (b), standard error in parentheses, p-value in brackets.
-- Title/caption: `caption="Regression Results"`.
-- Rename variables: `labels={"X1": "Age", "X2": "Schooling"}`.
-- Column headers for dependent variables: `model_heads=[...]` and `head_order="hd"`/`"dh"` to control header order (headlines vs depvars).
+```bash
+python -c "import importlib.resources as r; print(r.files('pyfixest') / 'docs')"
 ```
+
+Start with `cheatsheet.llms.md` — one page with formula syntax, standard errors,
+post-estimation methods, tables, and a table naming the page to read for each
+task. `llms.txt` in the same directory lists every page. Because the corpus
+travels with the wheel, it always describes the installed version.
+
+**The skill.** `SKILL.md` is a short router: it tells the agent how to find the
+directory above, which page to open for the task at hand, and a handful of core
+facts (formula grammar, `vcov` spellings, one `etable()` call) that PyFixest's
+test suite executes on every run.
+
+## Where the skill lands
+
+After `pip install pyfixest`, the skill sits beside the package, at
+`<site-packages>/skills/pyfixest/SKILL.md`. Print the directory with:
+
+```bash
+python -c "import pyfixest, pathlib; print(pathlib.Path(pyfixest.__file__).parents[1] / 'skills' / 'pyfixest')"
+```
+
+## How to install it
+
+Copy that directory into the place your agent reads skills from. For Claude
+Code, that is `~/.claude/skills/pyfixest` for every project, or
+`.claude/skills/pyfixest` for one project:
+
+```bash
+cp -r "$(python -c "import pyfixest, pathlib; print(pathlib.Path(pyfixest.__file__).parents[1] / 'skills' / 'pyfixest')")" ~/.claude/skills/pyfixest
+```
+
+You can also install it straight from the repository, without a local PyFixest:
+
+```bash
+npx skills add py-econometrics/pyfixest
+```
+
+Or open
+[`skills/pyfixest/SKILL.md`](https://github.com/py-econometrics/pyfixest/blob/master/skills/pyfixest/SKILL.md)
+on GitHub and paste it into whichever skill file your tool reads.
+
+The skill needs `pyfixest` importable in the environment the agent uses, and
+nothing else — no API keys, no extra packages. Without a local PyFixest it falls
+back to <https://pyfixest.org>.
+
+## See also
+
+- [PyFixest Cheat Sheet](cheatsheet.qmd) — the same task table, executed, on one
+  page.
+- [llms.txt](llms.txt) — the machine-readable index of this site.
+- [py-econometrics/pyfixest](https://github.com/py-econometrics/pyfixest) — the
+  source repository, including `AGENTS.md` for agents working *on* PyFixest.

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -30,9 +30,10 @@ In a checkout, read `docs/` and `AGENTS.md` in the repository. Otherwise read
 rather than the installed one.
 
 **The skill.** `SKILL.md` is a short router: it tells the agent how to find the
-directory above, which page to open for the task at hand, and a handful of core
-facts (formula grammar, `vcov` spellings, one `etable()` call) that PyFixest's
-test suite executes on every run.
+directory above and use the cheat sheet's task table to choose a page. The task
+table is maintained only in the cheat sheet. The skill also includes a handful
+of core facts (formula grammar, `vcov` spellings, one `etable()` call) that
+PyFixest's test suite executes on every run.
 
 ## Where the skill lands
 
@@ -73,8 +74,7 @@ is missing it falls back to the repository, or to <https://pyfixest.org>.
 
 ## See also
 
-- [PyFixest Cheat Sheet](cheatsheet.qmd) — the same task table, executed, on one
-  page.
+- [PyFixest Cheat Sheet](cheatsheet.qmd) — the task table and executed API examples.
 - [llms.txt](llms.txt) — the machine-readable index of this site.
 - [py-econometrics/pyfixest](https://github.com/py-econometrics/pyfixest) — the
   source repository, including `AGENTS.md` for agents working *on* PyFixest.

--- a/pyfixest/__init__.py
+++ b/pyfixest/__init__.py
@@ -1,3 +1,14 @@
+"""Fast high-dimensional fixed-effects estimation for Python.
+
+Docs:    installed, version-matched corpus at
+         importlib.resources.files("pyfixest") / "docs" (start with llms.txt;
+         absent in a source checkout, where docs/ and AGENTS.md apply);
+         latest release at https://pyfixest.org/llms.txt
+Source:  https://github.com/py-econometrics/pyfixest
+Skills:  skills/pyfixest/SKILL.md next to this package in site-packages;
+         also https://pyfixest.org/skills.html
+"""
+
 import importlib as _importlib
 from importlib.metadata import PackageNotFoundError, version
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,8 @@ benchmarks = [
 module-name = "pyfixest.core._core_impl"
 features = ["pyo3/extension-module"]
 python-source = "."
+# The installable agent skill ships with every release; see docs/skills.md.
+include = [{ path = "skills/pyfixest/**/*", format = ["wheel", "sdist"] }]
 exclude = [
     "tests/**",
     "docs/**",

--- a/skills/pyfixest/SKILL.md
+++ b/skills/pyfixest/SKILL.md
@@ -44,8 +44,9 @@ data = pf.get_data().dropna()
 # fixed effects follow the first |, : interacts them (`^` is deprecated)
 pf.feols("Y ~ X1 + X2 | f1 + f2", data=data)
 pf.feols("Y ~ X1 | f1:f2", data=data)
-# three-part IV: depvar ~ exogenous | fixed effects | endogenous ~ instruments
-pf.feols("Y ~ X2 | f1 | X1 ~ Z1", data=data)  # newer spelling: Y ~ X2 + [X1 ~ Z1] | f1
+# IV: a [endogenous ~ instruments] term on the right-hand side
+# (the fixest-style "Y ~ X2 | f1 | X1 ~ Z1" still works but is deprecated)
+pf.feols("Y ~ X2 + [X1 ~ Z1] | f1", data=data)
 # i(cat) expands a categorical, ref drops a level, i(cat, x) gives slopes on x
 pf.feols("Y ~ i(f1, ref=1.0) + i(f1, X2)", data=data)
 # vcov spellings; NW and DK additionally need vcov_kwargs with time metadata

--- a/skills/pyfixest/SKILL.md
+++ b/skills/pyfixest/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: pyfixest
+description: Routes coding agents into PyFixest's bundled, version-matched documentation for fixed-effects regression in Python (feols, fepois, feglm, quantreg, difference-in-differences estimators), standard errors and inference, and regression tables. Use when code imports pyfixest or a task mentions fixed effects, clustered standard errors, IV, event studies, or fixest-style formulas.
+---
+
+# PyFixest
+
+The installed package ships its own documentation. Locate it once:
+
+    python -c "import importlib.resources as r; print(r.files('pyfixest') / 'docs')"
+
+Read `cheatsheet.llms.md` in that directory first (one page: syntax, standard
+errors, methods, and the table below). `llms.txt` lists every page. If
+`pyfixest` is not importable, use https://pyfixest.org/cheatsheet.html and
+https://pyfixest.org/skills.html instead.
+
+## Where to go for each task
+
+| Task | Start here | Then |
+|---|---|---|
+| Fit a first model | `getting-started.llms.md` | `tutorials/ols-fixed-effects.llms.md` |
+| Formulas, fixed effects, interactions, multiple estimation | `tutorials/formula-syntax.llms.md` | `reference/estimation.api.feols.feols.llms.md` |
+| Instrumental variables | `tutorials/instrumental-variables.llms.md` | `reference/estimation.api.feols.feols.llms.md` |
+| Poisson or GLM | `tutorials/poisson-glm.llms.md` | `reference/estimation.api.fepois.fepois.llms.md`, `reference/estimation.api.feglm.feglm.llms.md` |
+| Quantile regression | `tutorials/quantile-regression.llms.md` | `reference/estimation.api.quantreg.quantreg.llms.md` |
+| Choose or change standard errors | `tutorials/standard-errors.llms.md` | `reference/estimation.models.feols_.Feols.vcov.llms.md` |
+| Tables, summaries, coefficient plots | `tutorials/regression-tables.llms.md` | `reference/index.llms.md` |
+| Difference-in-differences, event studies | `tutorials/difference-in-differences.llms.md` | `reference/index.llms.md#difference-in-differences` |
+| Predictions, residuals, fixed-effect estimates | `reference/estimation.models.feols_.Feols.predict.llms.md` | `reference/estimation.models.feols_.Feols.resid.llms.md`, `reference/estimation.models.feols_.Feols.fixef.llms.md` |
+| Hypothesis tests, decomposition | `reference/estimation.models.feols_.Feols.wald_test.llms.md` | `how-to/regression_decomposition.llms.md` |
+| Multiple-hypothesis corrections | `reference/estimation.post_estimation.multcomp.rwolf.llms.md` | `reference/estimation.post_estimation.multcomp.wyoung.llms.md`, `reference/estimation.post_estimation.multcomp.bonferroni.llms.md` |
+| Anytime-valid / sequential inference | `how-to/anytime-valid-inference.llms.md` | `reference/estimation.models.feols_.Feols.evalue.llms.md`, `reference/estimation.models.feols_.Feols.pvalue_savi.llms.md` |
+| Marginal effects | `how-to/marginaleffects.llms.md` | `reference/index.llms.md` |
+| AB tests with panel data | `how-to/panel_variance_reduction.llms.md` | `tutorials/difference-in-differences.llms.md` |
+| Slow or failing fixed-effects fits | `explanation/difficult-fixed-effects.llms.md` | `how-to/demeaner-backends.llms.md` |
+| Translate from R or Stata | `explanation/compare-fixest-pyfixest.llms.md` | `how-to/stata-2-pyfixest.llms.md` |
+| Exact signatures | `reference/index.llms.md` | `llms.txt` |
+
+## Core facts
+
+```python
+import pyfixest as pf
+data = pf.get_data().dropna()
+# fixed effects follow the first |, : interacts them (`^` is deprecated)
+pf.feols("Y ~ X1 + X2 | f1 + f2", data=data)
+pf.feols("Y ~ X1 | f1:f2", data=data)
+# three-part IV: depvar ~ exogenous | fixed effects | endogenous ~ instruments
+pf.feols("Y ~ X2 | f1 | X1 ~ Z1", data=data)  # newer spelling: Y ~ X2 + [X1 ~ Z1] | f1
+# i(cat) expands a categorical, ref drops a level, i(cat, x) gives slopes on x
+pf.feols("Y ~ i(f1, ref=1.0) + i(f1, X2)", data=data)
+# vcov spellings; NW and DK additionally need vcov_kwargs with time metadata
+pf.feols("Y ~ X1", data=data, vcov="iid")
+pf.feols("Y ~ X1", data=data, vcov="hetero")
+pf.feols("Y ~ X1", data=data, vcov="HC3")
+pf.feols("Y ~ X1", data=data, vcov={"CRV1": "f1"})
+pf.feols("Y ~ X1", data=data, vcov={"CRV3": "f1"})
+# two-way clustering
+pf.feols("Y ~ X1", data=data, vcov={"CRV1": "f1 + f2"})
+pf.etable([pf.feols("Y ~ X1 | f1", data=data)], type="md", keep="X1")
+```
+
+## Workflow
+
+1. Choose the closest task in the table above and open its narrative
+   documentation.
+2. Before choosing `vcov`, check the support-limits table in
+   `tutorials/standard-errors.llms.md`; before writing a formula, check
+   `tutorials/formula-syntax.llms.md`.
+3. Check the installed API reference or function signature before writing code.
+4. Search `llms.txt` only when the table above does not identify a suitable
+   page.
+5. Prefer public `pyfixest` functions and result methods; do not depend on
+   underscore-prefixed state.
+6. State unsupported combinations instead of silently substituting another
+   estimator or inference method.

--- a/skills/pyfixest/SKILL.md
+++ b/skills/pyfixest/SKILL.md
@@ -5,14 +5,17 @@ description: Routes coding agents into PyFixest's bundled, version-matched docum
 
 # PyFixest
 
-The installed package ships its own documentation. Locate it once:
+The installed package ships its own documentation. Locate it and check that it
+is present:
 
-    python -c "import importlib.resources as r; print(r.files('pyfixest') / 'docs')"
+    python -c "import importlib.resources as r; p = r.files('pyfixest') / 'docs'; print(p, (p / 'llms.txt').is_file())"
 
-Read `cheatsheet.llms.md` in that directory first (one page: syntax, standard
-errors, methods, and the table below). `llms.txt` lists every page. If
-`pyfixest` is not importable, use https://pyfixest.org/cheatsheet.html and
-https://pyfixest.org/skills.html instead.
+If it prints `True`, read `cheatsheet.llms.md` in that directory first (one
+page: syntax, standard errors, methods, and the table below); `llms.txt`
+lists every page and describes each. If it prints `False`, this is a source
+checkout or a release older than the bundled docs: in a checkout read
+`docs/` and `AGENTS.md`; otherwise use https://pyfixest.org/cheatsheet.html,
+which may describe a different version than the one installed.
 
 ## Where to go for each task
 

--- a/skills/pyfixest/SKILL.md
+++ b/skills/pyfixest/SKILL.md
@@ -10,34 +10,12 @@ is present:
 
     python -c "import importlib.resources as r; p = r.files('pyfixest') / 'docs'; print(p, (p / 'llms.txt').is_file())"
 
-If it prints `True`, read `cheatsheet.llms.md` in that directory first (one
-page: syntax, standard errors, methods, and the table below); `llms.txt`
-lists every page and describes each. If it prints `False`, this is a source
-checkout or a release older than the bundled docs: in a checkout read
-`docs/` and `AGENTS.md`; otherwise use https://pyfixest.org/cheatsheet.html,
+If it prints `True`, open `cheatsheet.llms.md` in that directory and use its
+"Where to go for each task" table to choose the relevant documentation.
+`llms.txt` lists every page and describes each. If it prints `False`, this is a
+source checkout or a release older than the bundled docs: in a checkout start
+with `docs/cheatsheet.qmd`; otherwise use https://pyfixest.org/cheatsheet.html,
 which may describe a different version than the one installed.
-
-## Where to go for each task
-
-| Task | Start here | Then |
-|---|---|---|
-| Fit a first model | `getting-started.llms.md` | `tutorials/ols-fixed-effects.llms.md` |
-| Formulas, fixed effects, interactions, multiple estimation | `tutorials/formula-syntax.llms.md` | `reference/estimation.api.feols.feols.llms.md` |
-| Instrumental variables | `tutorials/instrumental-variables.llms.md` | `reference/estimation.api.feols.feols.llms.md` |
-| Poisson or GLM | `tutorials/poisson-glm.llms.md` | `reference/estimation.api.fepois.fepois.llms.md`, `reference/estimation.api.feglm.feglm.llms.md` |
-| Quantile regression | `tutorials/quantile-regression.llms.md` | `reference/estimation.api.quantreg.quantreg.llms.md` |
-| Choose or change standard errors | `tutorials/standard-errors.llms.md` | `reference/estimation.models.feols_.Feols.vcov.llms.md` |
-| Tables, summaries, coefficient plots | `tutorials/regression-tables.llms.md` | `reference/index.llms.md` |
-| Difference-in-differences, event studies | `tutorials/difference-in-differences.llms.md` | `reference/index.llms.md#difference-in-differences` |
-| Predictions, residuals, fixed-effect estimates | `reference/estimation.models.feols_.Feols.predict.llms.md` | `reference/estimation.models.feols_.Feols.resid.llms.md`, `reference/estimation.models.feols_.Feols.fixef.llms.md` |
-| Hypothesis tests, decomposition | `reference/estimation.models.feols_.Feols.wald_test.llms.md` | `how-to/regression_decomposition.llms.md` |
-| Multiple-hypothesis corrections | `reference/estimation.post_estimation.multcomp.rwolf.llms.md` | `reference/estimation.post_estimation.multcomp.wyoung.llms.md`, `reference/estimation.post_estimation.multcomp.bonferroni.llms.md` |
-| Anytime-valid / sequential inference | `how-to/anytime-valid-inference.llms.md` | `reference/estimation.models.feols_.Feols.evalue.llms.md`, `reference/estimation.models.feols_.Feols.pvalue_savi.llms.md` |
-| Marginal effects | `how-to/marginaleffects.llms.md` | `reference/index.llms.md` |
-| AB tests with panel data | `how-to/panel_variance_reduction.llms.md` | `tutorials/difference-in-differences.llms.md` |
-| Slow or failing fixed-effects fits | `explanation/difficult-fixed-effects.llms.md` | `how-to/demeaner-backends.llms.md` |
-| Translate from R or Stata | `explanation/compare-fixest-pyfixest.llms.md` | `how-to/stata-2-pyfixest.llms.md` |
-| Exact signatures | `reference/index.llms.md` | `llms.txt` |
 
 ## Core facts
 
@@ -65,13 +43,13 @@ pf.etable([pf.feols("Y ~ X1 | f1", data=data)], type="md", keep="X1")
 
 ## Workflow
 
-1. Choose the closest task in the table above and open its narrative
+1. Choose the closest task in the cheat sheet's task table and open its narrative
    documentation.
 2. Before choosing `vcov`, check the support-limits table in
    `tutorials/standard-errors.llms.md`; before writing a formula, check
    `tutorials/formula-syntax.llms.md`.
 3. Check the installed API reference or function signature before writing code.
-4. Search `llms.txt` only when the table above does not identify a suitable
+4. Search `llms.txt` only when the cheat sheet does not identify a suitable
    page.
 5. Prefer public `pyfixest` functions and result methods; do not depend on
    underscore-prefixed state.

--- a/tests/test_agent_breadcrumbs.py
+++ b/tests/test_agent_breadcrumbs.py
@@ -1,0 +1,25 @@
+"""Check the breadcrumbs an agent reads out of `help(pyfixest)`.
+
+An agent that only has the installed package points itself at the documentation
+and the skill through the package docstring, so the three breadcrumb lines are a
+contract rather than prose.
+"""
+
+from __future__ import annotations
+
+import pyfixest as pf
+
+
+def test_docstring_points_at_the_bundled_documentation():
+    assert pf.__doc__ is not None
+    assert 'importlib.resources.files("pyfixest") / "docs"' in pf.__doc__
+    assert "https://pyfixest.org/llms.txt" in pf.__doc__
+
+
+def test_docstring_points_at_the_source_repository():
+    assert "https://github.com/py-econometrics/pyfixest" in pf.__doc__
+
+
+def test_docstring_points_at_the_installable_skill():
+    assert "skills/pyfixest/SKILL.md" in pf.__doc__
+    assert "https://pyfixest.org/skills.html" in pf.__doc__

--- a/tests/test_agent_skill.py
+++ b/tests/test_agent_skill.py
@@ -2,8 +2,8 @@
 
 The skill file is what a coding agent loads before it writes PyFixest code, so
 its frontmatter must satisfy the Agent Skills specification, its references must
-stay inside the skill directory, its task table must not drift from the cheat
-sheet, and its code examples must actually run.
+stay inside the skill directory, its routing table must not drift from the cheat
+sheet in either task or destination, and its code examples must actually run.
 """
 
 from __future__ import annotations
@@ -39,8 +39,44 @@ def _frontmatter_value(frontmatter: str, key: str) -> str:
     raise AssertionError(f"SKILL.md frontmatter has no `{key}` entry")
 
 
-def _first_table_tasks(text: str) -> list[str]:
-    """Return the first column of the first Markdown table, header row dropped."""
+TableRow = tuple[str, list[str], list[str]]
+
+LINK_TARGET = re.compile(r"\[[^\]]*\]\(([^)]+)\)")
+BACKTICKED = re.compile(r"`([^`]+)`")
+
+
+def _normalise_target(target: str) -> str:
+    """Rewrite a cheat-sheet link target as the bundled documentation page.
+
+    The rendered site links to `.qmd`/`.md` sources; the wheel ships the same
+    pages as `.llms.md`. Any `#fragment` survives, and non-page targets such as
+    `llms.txt` pass through unchanged.
+    """
+    path, separator, fragment = target.partition("#")
+    for suffix in (".qmd", ".md"):
+        if path.endswith(suffix):
+            path = f"{path[: -len(suffix)]}.llms.md"
+            break
+    return path + separator + fragment
+
+
+def _cell_targets(cell: str, *, normalise: bool) -> list[str]:
+    """Return the destinations a routing-table cell points at, in order.
+
+    The cheat sheet writes destinations as Markdown links and needs
+    `normalise=True`; the skill writes them as backticked paths that are already
+    bundled-documentation names.
+    """
+    if normalise:
+        return [_normalise_target(target) for target in LINK_TARGET.findall(cell)]
+    return BACKTICKED.findall(cell)
+
+
+def _first_table_rows(text: str, *, normalise: bool) -> list[TableRow]:
+    """Return the body rows of the first Markdown table as routing entries.
+
+    Each entry is `(task_label, start_here_targets, then_targets)`.
+    """
     rows: list[str] = []
     in_table = False
     for line in text.splitlines():
@@ -51,9 +87,21 @@ def _first_table_tasks(text: str) -> list[str]:
         elif in_table:
             break
     assert rows, "no Markdown table found"
-    first_column = [row.strip("|").split("|")[0].strip() for row in rows]
+
+    entries: list[TableRow] = []
     # drop the header row and the `|---|` separator
-    return first_column[2:]
+    for row in rows[2:]:
+        cells = [cell.strip() for cell in row.strip("|").split("|")]
+        assert len(cells) == 3, f"routing-table row is not three columns: {row}"
+        task, start_here, then = cells
+        entries.append(
+            (
+                task,
+                _cell_targets(start_here, normalise=normalise),
+                _cell_targets(then, normalise=normalise),
+            )
+        )
+    return entries
 
 
 @pytest.fixture(scope="module")
@@ -100,6 +148,17 @@ def test_code_examples_run(skill_body: str):
 
 
 def test_task_table_matches_the_cheat_sheet(skill_body: str):
-    assert _first_table_tasks(skill_body) == _first_table_tasks(
-        CHEATSHEET_PATH.read_text(encoding="utf-8")
+    skill_rows = _first_table_rows(skill_body, normalise=False)
+    cheatsheet_rows = _first_table_rows(
+        CHEATSHEET_PATH.read_text(encoding="utf-8"), normalise=True
     )
+
+    assert [row[0] for row in skill_rows] == [row[0] for row in cheatsheet_rows], (
+        "the skill's routing tasks drifted from `docs/cheatsheet.qmd`"
+    )
+    for skill_row, cheatsheet_row in zip(skill_rows, cheatsheet_rows, strict=True):
+        assert skill_row == cheatsheet_row, (
+            f"the skill routes the {skill_row[0]!r} task to "
+            f"{skill_row[1:]}, but `docs/cheatsheet.qmd` routes it to "
+            f"{cheatsheet_row[1:]}"
+        )

--- a/tests/test_agent_skill.py
+++ b/tests/test_agent_skill.py
@@ -1,0 +1,105 @@
+"""Contract tests for the installable agent skill in `skills/pyfixest/`.
+
+The skill file is what a coding agent loads before it writes PyFixest code, so
+its frontmatter must satisfy the Agent Skills specification, its references must
+stay inside the skill directory, its task table must not drift from the cheat
+sheet, and its code examples must actually run.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SKILL_PATH = REPO_ROOT / "skills" / "pyfixest" / "SKILL.md"
+CHEATSHEET_PATH = REPO_ROOT / "docs" / "cheatsheet.qmd"
+
+MAX_BODY_LINES = 80
+MAX_CODE_LINES = 20
+
+
+def _split_frontmatter(text: str) -> tuple[str, str]:
+    """Split a Markdown file into its YAML frontmatter and its body."""
+    assert text.startswith("---\n"), "SKILL.md must open with a `---` frontmatter fence"
+    closing = text.find("\n---\n", len("---\n") - 1)
+    assert closing != -1, "SKILL.md frontmatter is not closed by a `---` line"
+    frontmatter = text[len("---\n") : closing + 1]
+    body = text[closing + len("\n---\n") :]
+    return frontmatter, body
+
+
+def _frontmatter_value(frontmatter: str, key: str) -> str:
+    """Read a single-line `key: value` entry without a YAML dependency."""
+    for line in frontmatter.splitlines():
+        if line.startswith(f"{key}:"):
+            return line[len(key) + 1 :].strip()
+    raise AssertionError(f"SKILL.md frontmatter has no `{key}` entry")
+
+
+def _first_table_tasks(text: str) -> list[str]:
+    """Return the first column of the first Markdown table, header row dropped."""
+    rows: list[str] = []
+    in_table = False
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("|"):
+            in_table = True
+            rows.append(stripped)
+        elif in_table:
+            break
+    assert rows, "no Markdown table found"
+    first_column = [row.strip("|").split("|")[0].strip() for row in rows]
+    # drop the header row and the `|---|` separator
+    return first_column[2:]
+
+
+@pytest.fixture(scope="module")
+def skill_text() -> str:
+    return SKILL_PATH.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def skill_body(skill_text: str) -> str:
+    return _split_frontmatter(skill_text)[1]
+
+
+def test_frontmatter_follows_the_agent_skills_spec(skill_text: str):
+    frontmatter = _split_frontmatter(skill_text)[0]
+
+    name = _frontmatter_value(frontmatter, "name")
+    assert name == SKILL_PATH.parent.name, (
+        "the skill `name` must equal its directory name so agent runtimes can "
+        "resolve it"
+    )
+
+    description = _frontmatter_value(frontmatter, "description")
+    assert 1 <= len(description) <= 1024
+    assert "pyfixest" in description.lower()
+
+
+def test_body_is_short_and_self_contained(skill_body: str):
+    assert len(skill_body.strip().splitlines()) <= MAX_BODY_LINES
+    # skill references resolve against the skill root, so `../` never resolves
+    assert "../" not in skill_body
+    # the skill must locate the bundled documentation at runtime
+    assert "importlib.resources" in skill_body
+
+
+def test_code_examples_run(skill_body: str):
+    fences = re.findall(r"```python\n(.*?)```", skill_body, flags=re.DOTALL)
+    assert fences, "SKILL.md has no ```python example"
+
+    code = "".join(fences)
+    assert len(code.strip().splitlines()) <= MAX_CODE_LINES
+
+    compiled = compile(code, str(SKILL_PATH), "exec")
+    exec(compiled, {})
+
+
+def test_task_table_matches_the_cheat_sheet(skill_body: str):
+    assert _first_table_tasks(skill_body) == _first_table_tasks(
+        CHEATSHEET_PATH.read_text(encoding="utf-8")
+    )

--- a/tests/test_agent_skill.py
+++ b/tests/test_agent_skill.py
@@ -1,9 +1,9 @@
 """Contract tests for the installable agent skill in `skills/pyfixest/`.
 
 The skill file is what a coding agent loads before it writes PyFixest code, so
-its frontmatter must satisfy the Agent Skills specification, its references must
-stay inside the skill directory, its routing table must not drift from the cheat
-sheet in either task or destination, and its code examples must actually run.
+its frontmatter must satisfy the Agent Skills specification, it must locate the
+bundled documentation independently of its install location, and its code
+examples must actually run.
 """
 
 from __future__ import annotations
@@ -15,7 +15,6 @@ import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SKILL_PATH = REPO_ROOT / "skills" / "pyfixest" / "SKILL.md"
-CHEATSHEET_PATH = REPO_ROOT / "docs" / "cheatsheet.qmd"
 
 MAX_BODY_LINES = 80
 MAX_CODE_LINES = 20
@@ -37,71 +36,6 @@ def _frontmatter_value(frontmatter: str, key: str) -> str:
         if line.startswith(f"{key}:"):
             return line[len(key) + 1 :].strip()
     raise AssertionError(f"SKILL.md frontmatter has no `{key}` entry")
-
-
-TableRow = tuple[str, list[str], list[str]]
-
-LINK_TARGET = re.compile(r"\[[^\]]*\]\(([^)]+)\)")
-BACKTICKED = re.compile(r"`([^`]+)`")
-
-
-def _normalise_target(target: str) -> str:
-    """Rewrite a cheat-sheet link target as the bundled documentation page.
-
-    The rendered site links to `.qmd`/`.md` sources; the wheel ships the same
-    pages as `.llms.md`. Any `#fragment` survives, and non-page targets such as
-    `llms.txt` pass through unchanged.
-    """
-    path, separator, fragment = target.partition("#")
-    for suffix in (".qmd", ".md"):
-        if path.endswith(suffix):
-            path = f"{path[: -len(suffix)]}.llms.md"
-            break
-    return path + separator + fragment
-
-
-def _cell_targets(cell: str, *, normalise: bool) -> list[str]:
-    """Return the destinations a routing-table cell points at, in order.
-
-    The cheat sheet writes destinations as Markdown links and needs
-    `normalise=True`; the skill writes them as backticked paths that are already
-    bundled-documentation names.
-    """
-    if normalise:
-        return [_normalise_target(target) for target in LINK_TARGET.findall(cell)]
-    return BACKTICKED.findall(cell)
-
-
-def _first_table_rows(text: str, *, normalise: bool) -> list[TableRow]:
-    """Return the body rows of the first Markdown table as routing entries.
-
-    Each entry is `(task_label, start_here_targets, then_targets)`.
-    """
-    rows: list[str] = []
-    in_table = False
-    for line in text.splitlines():
-        stripped = line.strip()
-        if stripped.startswith("|"):
-            in_table = True
-            rows.append(stripped)
-        elif in_table:
-            break
-    assert rows, "no Markdown table found"
-
-    entries: list[TableRow] = []
-    # drop the header row and the `|---|` separator
-    for row in rows[2:]:
-        cells = [cell.strip() for cell in row.strip("|").split("|")]
-        assert len(cells) == 3, f"routing-table row is not three columns: {row}"
-        task, start_here, then = cells
-        entries.append(
-            (
-                task,
-                _cell_targets(start_here, normalise=normalise),
-                _cell_targets(then, normalise=normalise),
-            )
-        )
-    return entries
 
 
 @pytest.fixture(scope="module")
@@ -145,20 +79,3 @@ def test_code_examples_run(skill_body: str):
 
     compiled = compile(code, str(SKILL_PATH), "exec")
     exec(compiled, {})
-
-
-def test_task_table_matches_the_cheat_sheet(skill_body: str):
-    skill_rows = _first_table_rows(skill_body, normalise=False)
-    cheatsheet_rows = _first_table_rows(
-        CHEATSHEET_PATH.read_text(encoding="utf-8"), normalise=True
-    )
-
-    assert [row[0] for row in skill_rows] == [row[0] for row in cheatsheet_rows], (
-        "the skill's routing tasks drifted from `docs/cheatsheet.qmd`"
-    )
-    for skill_row, cheatsheet_row in zip(skill_rows, cheatsheet_rows, strict=True):
-        assert skill_row == cheatsheet_row, (
-            f"the skill routes the {skill_row[0]!r} task to "
-            f"{skill_row[1:]}, but `docs/cheatsheet.qmd` routes it to "
-            f"{cheatsheet_row[1:]}"
-        )


### PR DESCRIPTION
## Summary

Ships an installable Agent Skill that helps coding agents use PyFixest's version-matched documentation. The skill locates the bundled docs, routes readers to the cheat sheet's task table, and provides executable core API examples and workflow guidance. The comprehensive task table is maintained only in `docs/cheatsheet.qmd`; the skill has no duplicate table or table-synchronization parser/test.

The skill ships in wheels and sdists, the package docstring points to it, and the AI agent guide explains installation and the bundled-docs, source-checkout, and online fallbacks. Based on #1508 for the cheat sheet; documentation bundling and release integration are supplied by #1472/#1510.

## Verification

For the task-table simplification, using existing Pixi environments:

- `python -m pytest tests/test_agent_skill.py tests/test_agent_breadcrumbs.py --no-cov -q -p no:cacheprovider`: 6 passed in 2.07s; existing singleton warning.
- Changed-file `prek run ruff-check` and `ruff-format`: passed (under 1s combined).
- Skill `quick_validate.py`: passed (under 1s).
- `quarto render docs/skills.md`: passed; updated text and cheat-sheet link inspected. Partial render warns about the unbuilt `reference/index.qmd` navigation target.
- `git diff --check`: passed.

All Python, lint, and render commands ran through `pixi run --as-is`. Full-site rendering and packaging were not rerun for this focused edit.
