### PR TITLE
Add leverage and leave-one-out influence

### DIFF
--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -17,6 +17,14 @@ fit3 = pf.feols("Y ~ X1 + X2 | f1", data = df)
 
 ## PyFixest 0.70.0 (In Development)
 
+### Post-Estimation
+
+- `Feols.leverage()` computes approximate leverage values for OLS models with
+  high-dimensional fixed effects using Johnson--Lindenstrauss approximation.
+- `Feols.influence()` calculates the leave-one-out influence values for OLS
+  models with high-dimensional fixed effects using the Johnson--Lindenstrauss
+  approximation.
+
 ### Contributor Workflow
 
 - Repository-local skills and developer guides now define architecture,

--- a/pyfixest/estimation/models/feols_.py
+++ b/pyfixest/estimation/models/feols_.py
@@ -47,6 +47,7 @@ from pyfixest.estimation.internals.vcov_utils import (
     run_crv_loop,
 )
 from pyfixest.estimation.models._result_accessor_mixin import ResultAccessorMixin
+from pyfixest.estimation.post_estimation import jla
 from pyfixest.estimation.post_estimation.decomposition import (
     GelbachDecomposition,
     _decompose_arg_check,
@@ -72,6 +73,7 @@ from pyfixest.estimation.post_estimation.ritest import (
 from pyfixest.estimation.post_estimation.wald import _wald_statistic
 from pyfixest.utils.dev_utils import (
     DataFrameType,
+    _create_rng,
     _narwhals_to_pandas,
 )
 from pyfixest.utils.utils import (
@@ -1747,6 +1749,146 @@ class Feols(ResultAccessorMixin):
         self._sumFE = D2.dot(alpha)
 
         return fixed_effects_to_frame(self._fixef_coefficients)
+
+    def leverage(
+        self,
+        number_probes: int = 100,
+        seed: int = 1234,
+        compute_monte_carlo_standard_errors: bool = False,
+    ) -> jla.RandomizedDiagonalResult:
+        """Approximate regression leverage values using random projections.
+
+        This method applies the leverage approximation of [Kline, Saggio, and
+        Sølvsten (2020)](https://doi.org/10.3982/ECTA16410) to the complete
+        regression projection, including absorbed fixed effects. Its
+        Rademacher random projections follow [Achlioptas
+        (2003)](https://doi.org/10.1016/S0022-0000(03)00025-4).
+
+        Parameters
+        ----------
+        number_probes : int, optional
+            Number of independent Rademacher probes. More probes reduce the
+            Monte Carlo error but increase runtime and memory use. Defaults to
+            ``100``.
+        seed : int, optional
+            Seed used to construct the random-number generator. Defaults to
+            ``1234``.
+        compute_monte_carlo_standard_errors : bool, optional
+            Whether to estimate Monte Carlo standard errors. Defaults to
+            ``False``.
+
+        Returns
+        -------
+        RandomizedDiagonalResult
+            Approximate leverage values and optional Monte Carlo standard
+            errors.
+
+        Examples
+        --------
+        ```{python}
+        import pyfixest as pf
+
+        fit = pf.feols("Y ~ X1 | f1 + f2", pf.get_data())
+        result = fit.leverage(number_probes=100, seed=1234)
+        result.estimate[:5]
+        ```
+        """
+        if self._lean:
+            raise ValueError(
+                "leverage() is unavailable for lean models. "
+                "Re-estimate with lean=False."
+            )
+        if self._is_iv:
+            raise NotImplementedError("leverage() is not implemented for IV models.")
+        if self._method != "feols":
+            raise NotImplementedError(
+                "leverage() is currently implemented only for OLS models."
+            )
+        if self._has_weights and self._weights_type == "fweights":
+            raise NotImplementedError(
+                "leverage() does not currently support frequency weights."
+            )
+        regression_projection = jla.RegressionProjectionOperator(
+            fixed_effect_residual_projection=(
+                jla.FixedEffectResidualProjection(
+                    fixed_effects=np.asarray(self._fe, dtype=np.int32),
+                    weights=np.asarray(self._weights, dtype=np.float64).reshape(-1),
+                    demeaner=self._demeaner,
+                    preconditioner=self.preconditioner,
+                )
+                if self._has_fixef
+                else None
+            ),
+            covariates=np.asarray(self._X, dtype=np.float64),
+            gramian=(
+                np.asarray(self._hessian, dtype=np.float64)
+                if self._X.shape[1] > 0
+                else np.empty((0, 0), dtype=np.float64)
+            ),
+        )
+        return jla.leverage(
+            regression_projection=regression_projection,
+            number_probes=number_probes,
+            random_number_generator=_create_rng(seed),
+            compute_monte_carlo_standard_errors=compute_monte_carlo_standard_errors,
+        )
+
+    def influence(
+        self,
+        number_probes: int = 100,
+        seed: int = 1234,
+        compute_monte_carlo_standard_errors: bool = False,
+    ) -> jla.RandomizedDiagonalResult:
+        """Calculate leave-one-out influence values for an OLS model.
+
+        The influence of observation ``i`` is the change in its own fitted
+        value when it is deleted from the estimation sample:
+
+        ``fitted_i - fitted_i_without_i = leverage_i * residual_i / (1 - leverage_i)``.
+
+        Leverage is approximated for the complete regression projection,
+        including absorbed fixed effects, using the Johnson--Lindenstrauss
+        approximation described by [Kline, Saggio, and Sølvsten
+        (2020)](https://doi.org/10.3982/ECTA16410).
+
+        Parameters
+        ----------
+        number_probes : int, optional
+            Number of independent Rademacher probes used to approximate
+            leverage. More probes reduce Monte Carlo error but increase runtime
+            and memory use. Defaults to ``100``.
+        seed : int, optional
+            Seed used to construct the random-number generator. Defaults to
+            ``1234``.
+        compute_monte_carlo_standard_errors : bool, optional
+            Whether to propagate leverage's Monte Carlo standard errors to the
+            influence values. Defaults to ``False``.
+
+        Returns
+        -------
+        RandomizedDiagonalResult
+            Approximate leave-one-out influence values and optional Monte Carlo
+            standard errors.
+
+        Examples
+        --------
+        ```{python}
+        import pyfixest as pf
+
+        fit = pf.feols("Y ~ X1 | f1 + f2", pf.get_data())
+        result = fit.influence(number_probes=100, seed=1234)
+        result.estimate[:5]
+        ```
+        """
+        leverage = self.leverage(
+            number_probes=number_probes,
+            seed=seed,
+            compute_monte_carlo_standard_errors=compute_monte_carlo_standard_errors,
+        )
+        return jla.influence(
+            residuals=np.asarray(self.resid(), dtype=np.float64),
+            leverage=leverage,
+        )
 
     def predict(
         self,

--- a/pyfixest/estimation/post_estimation/jla.py
+++ b/pyfixest/estimation/post_estimation/jla.py
@@ -1,0 +1,211 @@
+"""Regression-specific post-estimation quantities calculated using the Johnson-Lindenstrauss approximation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+from numpy.typing import NDArray
+
+from pyfixest.core import Preconditioner
+from pyfixest.demeaners import AnyDemeaner
+from pyfixest.estimation.internals.jla import (
+    LinearOperator,
+    RandomizedDiagonalResult,
+    approximate_diagonal,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class FixedEffectResidualProjection:
+    """Apply the fixed-effect residual maker M_D."""
+
+    fixed_effects: NDArray[np.int32]
+    weights: NDArray[np.float64]
+    demeaner: AnyDemeaner
+    preconditioner: Preconditioner | None
+
+    @property
+    def shape(self) -> tuple[int, int]:
+        """Operator dimensions as ``(number_observations, number_observations)``."""
+        number_observations = self.fixed_effects.shape[0]
+        return (number_observations, number_observations)
+
+    def apply(self, right_hand_side: NDArray[np.float64]) -> NDArray[np.float64]:
+        """Apply the fixed-effect residual projection in working coordinates.
+
+        Parameters
+        ----------
+        right_hand_side : NDArray[np.float64]
+            Column vectors in weighted working coordinates, with shape
+            ``(number_observations, number_vectors)``.
+
+        Returns
+        -------
+        NDArray[np.float64]
+            Fixed-effect residualised column vectors in weighted working
+            coordinates.
+
+        Raises
+        ------
+        ValueError
+            If the fixed-effect residualization does not converge.
+        """
+        square_root_weights = np.sqrt(self.weights)[:, None]
+        residualised, converged, _ = self.demeaner.demean(
+            x=right_hand_side / square_root_weights,
+            flist=self.fixed_effects,
+            weights=self.weights,
+            cached_preconditioner=self.preconditioner,
+        )
+        if not converged:
+            raise ValueError(
+                f"Fixed-effect residualisation failed after {self.demeaner.fixef_maxiter} iterations"
+            )
+        return square_root_weights * residualised
+
+
+@dataclass(frozen=True, slots=True)
+class RegressionProjectionOperator:
+    """Apply the complete regression projection in working coordinates."""
+
+    fixed_effect_residual_projection: LinearOperator | None
+    covariates: NDArray[np.float64]
+    gramian: NDArray[np.float64]
+
+    @property
+    def shape(self) -> tuple[int, int]:
+        """Operator dimensions as ``(number_observations, number_observations)``."""
+        number_observations = self.covariates.shape[0]
+        return (number_observations, number_observations)
+
+    def apply(self, right_hand_side: NDArray[np.float64]) -> NDArray[np.float64]:
+        """Apply the complete regression projection in working coordinates.
+
+        Parameters
+        ----------
+        right_hand_side : NDArray[np.float64]
+            Column vectors in weighted working coordinates, with shape
+            ``(number_observations, number_vectors)``.
+
+        Returns
+        -------
+        NDArray[np.float64]
+            Projection of the column vectors onto the combined fixed-effect
+            and covariate column space.
+        """
+        residualised = (
+            right_hand_side
+            if self.fixed_effect_residual_projection is None
+            else self.fixed_effect_residual_projection.apply(right_hand_side)
+        )
+        if self.covariates.shape[1] > 0:
+            coefficients = np.linalg.solve(
+                self.gramian, self.covariates.T @ residualised
+            )
+            residualised = residualised - self.covariates @ coefficients
+
+        return right_hand_side - residualised
+
+
+def leverage(
+    *,
+    regression_projection: RegressionProjectionOperator,
+    number_probes: int,
+    random_number_generator: np.random.Generator,
+    compute_monte_carlo_standard_errors: bool = False,
+) -> RandomizedDiagonalResult:
+    """Approximate regression leverage values using random projections.
+
+    For an orthogonal regression projection ``H``,
+
+    ``diag(H) = diag(H @ H.T)``.
+
+    Therefore, leverage values can be estimated from the squared row norms of
+    random embeddings of ``H``. This is the leverage approximation used by
+    [Kline, Saggio, and Sølvsten
+    (2020)](https://doi.org/10.3982/ECTA16410), based on the Rademacher
+    random-projection construction of [Achlioptas
+    (2003)](https://doi.org/10.1016/S0022-0000(03)00025-4).
+
+    Parameters
+    ----------
+    regression_projection : RegressionProjectionOperator
+        Operator applying the complete regression projection in weighted
+        working coordinates.
+    number_probes : int
+        Number of independent Rademacher probes.
+    random_number_generator : np.random.Generator
+        Random-number generator used to construct the probes.
+    compute_monte_carlo_standard_errors : bool, optional
+        Whether to estimate Monte Carlo standard errors.
+
+    Returns
+    -------
+    RandomizedDiagonalResult
+        Approximate leverage values and optional Monte Carlo standard errors.
+    """
+    return approximate_diagonal(
+        left=regression_projection,
+        number_probes=number_probes,
+        random_number_generator=random_number_generator,
+        compute_monte_carlo_standard_errors=compute_monte_carlo_standard_errors,
+    )
+
+
+def influence(
+    *,
+    residuals: NDArray[np.float64],
+    leverage: RandomizedDiagonalResult,
+) -> RandomizedDiagonalResult:
+    """Calculate each observation's leave-one-out influence in an OLS model.
+
+    For observation ``i``, the returned value is
+
+    ``fitted_i - fitted_i_without_i = leverage_i * residual_i / (1 - leverage_i)``.
+
+    The Monte Carlo standard errors use a first-order propagation of the
+    algorithmic uncertainty in the randomized leverage approximation. They do
+    not describe sampling uncertainty. See [Belsley, Kuh, and Welsch
+    (1980)](https://doi.org/10.1002/0471725153) for regression deletion
+    diagnostics.
+
+    Parameters
+    ----------
+    residuals : NDArray[np.float64]
+        OLS residuals on the scale of the dependent variable, with shape
+        ``(number_observations,)``.
+    leverage : RandomizedDiagonalResult
+        Leverage estimates and optional Monte Carlo standard errors.
+
+    Returns
+    -------
+    RandomizedDiagonalResult
+        Leave-one-out influence values and optional Monte Carlo standard
+        errors.
+
+    Raises
+    ------
+    ValueError
+        If any estimated leverage is greater than or equal to one, in which
+        case deleting the corresponding observation does not yield a defined
+        fitted value.
+    """
+    denominator = 1 - leverage.estimate
+    if np.any(denominator <= 0):
+        raise ValueError(
+            "Leave-one-out influence is undefined for observations with "
+            "leverage greater than or equal to one."
+        )
+
+    estimate = residuals * leverage.estimate / denominator
+    monte_carlo_standard_errors = (
+        None
+        if leverage.monte_carlo_standard_errors is None
+        else np.abs(residuals) * leverage.monte_carlo_standard_errors / denominator**2
+    )
+    return RandomizedDiagonalResult(
+        estimate=estimate,
+        monte_carlo_standard_errors=monte_carlo_standard_errors,
+        number_probes=leverage.number_probes,
+    )

--- a/tests/test_post_estimation_jla.py
+++ b/tests/test_post_estimation_jla.py
@@ -1,0 +1,460 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+from numpy.typing import NDArray
+
+import pyfixest as pf
+from pyfixest.demeaners import LsmrDemeaner, MapDemeaner
+from pyfixest.estimation.internals.jla import RandomizedDiagonalResult
+from pyfixest.estimation.post_estimation import jla
+from pyfixest.estimation.post_estimation.jla import (
+    FixedEffectResidualProjection,
+    RegressionProjectionOperator,
+    influence,
+    leverage,
+)
+
+FixedEffectDesign = tuple[
+    NDArray[np.int32],
+    NDArray[np.float64],
+    NDArray[np.float64],
+]
+
+
+def _regression_projection(
+    fixed_effect_design: FixedEffectDesign,
+) -> tuple[RegressionProjectionOperator, NDArray[np.float64]]:
+    fixed_effects, weights, dummy_matrix = fixed_effect_design
+    square_root_weights = np.sqrt(weights)
+    raw_covariates = np.column_stack(
+        [
+            np.linspace(-1.0, 2.0, fixed_effects.shape[0]),
+            np.array([0.0, 1.0, 4.0, 2.0, 5.0, 3.0, 8.0, 6.0, 7.0, 11.0, 9.0, 10.0]),
+        ]
+    )
+    fixed_effect_projection = FixedEffectResidualProjection(
+        fixed_effects=fixed_effects,
+        weights=weights,
+        demeaner=MapDemeaner(fixef_tol=1e-12),
+        preconditioner=None,
+    )
+    transformed_covariates = fixed_effect_projection.apply(
+        square_root_weights[:, None] * raw_covariates
+    )
+    projection = RegressionProjectionOperator(
+        fixed_effect_residual_projection=fixed_effect_projection,
+        covariates=transformed_covariates,
+        gramian=transformed_covariates.T @ transformed_covariates,
+    )
+    weighted_design_matrix = square_root_weights[:, None] * np.column_stack(
+        [dummy_matrix, raw_covariates]
+    )
+    return projection, weighted_design_matrix
+
+
+@pytest.fixture
+def fixed_effect_design() -> FixedEffectDesign:
+    fixed_effects = np.array(
+        [
+            [0, 0],
+            [0, 1],
+            [0, 2],
+            [0, 0],
+            [1, 1],
+            [1, 2],
+            [1, 0],
+            [1, 1],
+            [2, 2],
+            [2, 0],
+            [2, 1],
+            [2, 2],
+        ],
+        dtype=np.int32,
+    )
+    weights = np.array([1.0, 2.0, 0.5, 1.5, 3.0, 0.75, 2.5, 1.25, 0.8, 1.8, 2.2, 1.1])
+    dummy_matrix = np.column_stack(
+        [
+            fixed_effects[:, factor][:, None] == np.arange(3)
+            for factor in range(fixed_effects.shape[1])
+        ]
+    ).astype(np.float64)
+    return fixed_effects, weights, dummy_matrix
+
+
+def test_fixed_effect_residual_projection_matches_weighted_dummy_projection(
+    fixed_effect_design: FixedEffectDesign,
+) -> None:
+    fixed_effects, weights, dummy_matrix = fixed_effect_design
+    right_hand_side = np.arange(36, dtype=np.float64).reshape(12, 3) / 7
+    square_root_weights = np.sqrt(weights)
+    weighted_dummy_matrix = square_root_weights[:, None] * dummy_matrix
+
+    projection = FixedEffectResidualProjection(
+        fixed_effects=fixed_effects,
+        weights=weights,
+        demeaner=MapDemeaner(fixef_tol=1e-12),
+        preconditioner=None,
+    )
+
+    actual = projection.apply(right_hand_side)
+    expected = (
+        right_hand_side
+        - weighted_dummy_matrix
+        @ np.linalg.pinv(weighted_dummy_matrix)
+        @ right_hand_side
+    )
+
+    np.testing.assert_allclose(
+        actual,
+        expected,
+        rtol=1e-10,
+        atol=1e-10,
+        err_msg="Fixed-effect residual projection differs from dense reference.",
+    )
+    assert projection.shape == (12, 12)
+
+
+def test_regression_projection_matches_weighted_design_projection(
+    fixed_effect_design: FixedEffectDesign,
+) -> None:
+    projection, weighted_design_matrix = _regression_projection(fixed_effect_design)
+    right_hand_side = np.column_stack(
+        [
+            np.linspace(-2.0, 1.0, projection.shape[0]),
+            np.cos(np.arange(projection.shape[0])),
+        ]
+    )
+
+    actual = projection.apply(right_hand_side)
+    expected = (
+        weighted_design_matrix
+        @ np.linalg.pinv(weighted_design_matrix)
+        @ right_hand_side
+    )
+
+    np.testing.assert_allclose(
+        actual,
+        expected,
+        rtol=1e-10,
+        atol=1e-10,
+        err_msg="Regression projection differs from dense weighted-design reference.",
+    )
+    assert projection.shape == (12, 12)
+
+
+def test_leverage_approximates_dense_weighted_projection_diagonal(
+    fixed_effect_design: FixedEffectDesign,
+) -> None:
+    projection, weighted_design_matrix = _regression_projection(fixed_effect_design)
+
+    result = leverage(
+        regression_projection=projection,
+        number_probes=10_000,
+        random_number_generator=np.random.default_rng(921),
+        compute_monte_carlo_standard_errors=True,
+    )
+
+    dense_projection = weighted_design_matrix @ np.linalg.pinv(weighted_design_matrix)
+    expected = np.diag(dense_projection)
+    assert result.monte_carlo_standard_errors is not None
+    assert result.monte_carlo_standard_errors.shape == expected.shape
+    assert result.number_probes == 10_000
+    np.testing.assert_array_less(
+        np.abs(result.estimate - expected),
+        5 * result.monte_carlo_standard_errors + 1e-10,
+        err_msg=("Randomized leverage error exceeds five Monte Carlo standard errors."),
+    )
+
+
+def test_influence_transforms_leverage_and_uncertainty() -> None:
+    residuals = np.array([2.0, -1.0, 0.5])
+    leverage_result = RandomizedDiagonalResult(
+        estimate=np.array([0.2, 0.5, 0.8]),
+        monte_carlo_standard_errors=np.array([0.01, 0.02, 0.03]),
+        number_probes=250,
+    )
+
+    result = influence(
+        residuals=residuals,
+        leverage=leverage_result,
+    )
+
+    denominator = 1 - leverage_result.estimate
+    expected = residuals * leverage_result.estimate / denominator
+    expected_standard_errors = (
+        np.abs(residuals) * leverage_result.monte_carlo_standard_errors / denominator**2
+    )
+    assert isinstance(result, RandomizedDiagonalResult)
+    assert result.number_probes == 250
+    np.testing.assert_allclose(result.estimate, expected)
+    np.testing.assert_allclose(
+        result.monte_carlo_standard_errors,
+        expected_standard_errors,
+    )
+
+
+@pytest.mark.parametrize(
+    ("formula", "fixed_effect_columns", "include_covariate"),
+    [
+        pytest.param("y ~ x", [], True, id="no_fixed_effects"),
+        pytest.param("y ~ x | f1", ["f1"], True, id="one_fixed_effect"),
+        pytest.param(
+            "y ~ 1 | f1 + f2",
+            ["f1", "f2"],
+            False,
+            id="fixed_effects_only",
+        ),
+    ],
+)
+def test_feols_leverage_matches_dense_projection_across_designs(
+    fixed_effect_design: FixedEffectDesign,
+    formula: str,
+    fixed_effect_columns: list[str],
+    include_covariate: bool,
+) -> None:
+    fixed_effects, _, _ = fixed_effect_design
+    number_observations = fixed_effects.shape[0]
+    covariate = np.linspace(-1.0, 2.0, number_observations)
+    data = pd.DataFrame(
+        {
+            "y": 0.5 * covariate + np.sin(np.arange(number_observations)),
+            "x": covariate,
+            "f1": fixed_effects[:, 0],
+            "f2": fixed_effects[:, 1],
+        }
+    )
+    fit = pf.feols(formula, data=data)
+
+    result = fit.leverage(
+        number_probes=10_000,
+        seed=8192,
+        compute_monte_carlo_standard_errors=True,
+    )
+
+    design_blocks = []
+    if fixed_effect_columns:
+        for column in fixed_effect_columns:
+            levels = np.unique(data[column])
+            design_blocks.append(
+                (data[column].to_numpy()[:, None] == levels).astype(np.float64)
+            )
+    else:
+        design_blocks.append(np.ones((number_observations, 1)))
+    if include_covariate:
+        design_blocks.append(covariate[:, None])
+    design_matrix = np.column_stack(design_blocks)
+    dense_projection = design_matrix @ np.linalg.pinv(design_matrix)
+    expected = np.diag(dense_projection)
+    assert result.monte_carlo_standard_errors is not None
+    np.testing.assert_array_less(
+        np.abs(result.estimate - expected),
+        5 * result.monte_carlo_standard_errors + 1e-10,
+        err_msg=("Feols leverage error exceeds five Monte Carlo standard errors."),
+    )
+
+
+@pytest.mark.parametrize("preconditioner", ["additive", "diagonal"])
+def test_feols_leverage_uses_fitted_projection_and_cached_preconditioner(
+    fixed_effect_design: FixedEffectDesign,
+    monkeypatch: pytest.MonkeyPatch,
+    preconditioner: str,
+) -> None:
+    fixed_effects, weights, dummy_matrix = fixed_effect_design
+    number_observations = fixed_effects.shape[0]
+    covariate = np.linspace(-1.0, 2.0, number_observations)
+    data = pd.DataFrame(
+        {
+            "y": 0.5 * covariate + np.sin(np.arange(number_observations)),
+            "x": covariate,
+            "f1": fixed_effects[:, 0],
+            "f2": fixed_effects[:, 1],
+            "weights": weights,
+        }
+    )
+    fit = pf.feols(
+        "y ~ x | f1 + f2",
+        data=data,
+        weights="weights",
+        store_data=False,
+        demeaner=LsmrDemeaner(
+            fixef_atol=1e-12,
+            fixef_btol=1e-12,
+            preconditioner=preconditioner,  # type: ignore[arg-type]
+        ),
+    )
+
+    captured_projections: list[RegressionProjectionOperator] = []
+    original_leverage = jla.leverage
+
+    def capture_projection(**kwargs):
+        captured_projections.append(kwargs["regression_projection"])
+        return original_leverage(**kwargs)
+
+    monkeypatch.setattr(jla, "leverage", capture_projection)
+    result = fit.leverage(
+        number_probes=10_000,
+        seed=128,
+        compute_monte_carlo_standard_errors=True,
+    )
+
+    projection = captured_projections[0]
+    assert isinstance(
+        projection.fixed_effect_residual_projection,
+        FixedEffectResidualProjection,
+    )
+    assert (
+        projection.fixed_effect_residual_projection.preconditioner is fit.preconditioner
+    )
+
+    square_root_weights = np.sqrt(weights)
+    weighted_design_matrix = square_root_weights[:, None] * np.column_stack(
+        [dummy_matrix, covariate]
+    )
+    dense_projection = weighted_design_matrix @ np.linalg.pinv(weighted_design_matrix)
+    expected = np.diag(dense_projection)
+    assert result.monte_carlo_standard_errors is not None
+    assert result.monte_carlo_standard_errors.shape == expected.shape
+    assert result.number_probes == 10_000
+    np.testing.assert_array_less(
+        np.abs(result.estimate - expected),
+        5 * result.monte_carlo_standard_errors + 1e-10,
+        err_msg=("Feols leverage error exceeds five Monte Carlo standard errors."),
+    )
+    first = fit.leverage()
+    second = fit.leverage()
+    assert first.monte_carlo_standard_errors is None
+    assert first.number_probes == 100
+    np.testing.assert_array_equal(first.estimate, second.estimate)
+
+
+def test_feols_influence_matches_deleted_refits(
+    fixed_effect_design: FixedEffectDesign,
+) -> None:
+    fixed_effects, weights, _ = fixed_effect_design
+    number_observations = fixed_effects.shape[0]
+    covariate = np.linspace(-1.0, 2.0, number_observations)
+    data = pd.DataFrame(
+        {
+            "y": 0.5 * covariate + np.sin(np.arange(number_observations)),
+            "x": covariate,
+            "f1": fixed_effects[:, 0],
+            "f2": fixed_effects[:, 1],
+            "weights": weights,
+        }
+    )
+    fit = pf.feols(
+        "y ~ x | f1 + f2",
+        data=data,
+        weights="weights",
+    )
+
+    result = fit.influence(
+        number_probes=20_000,
+        seed=114,
+        compute_monte_carlo_standard_errors=True,
+    )
+
+    fitted = fit.predict()
+    expected = np.empty(number_observations)
+    for observation in range(number_observations):
+        leave_one_out_fit = pf.feols(
+            "y ~ x | f1 + f2",
+            data=data.drop(index=observation),
+            weights="weights",
+        )
+        leave_one_out_prediction = leave_one_out_fit.predict(
+            newdata=data.iloc[[observation]]
+        )[0]
+        expected[observation] = fitted[observation] - leave_one_out_prediction
+
+    assert result.monte_carlo_standard_errors is not None
+    np.testing.assert_array_less(
+        np.abs(result.estimate - expected),
+        5 * result.monte_carlo_standard_errors + 1e-10,
+        err_msg=(
+            "Randomized leave-one-out influence error exceeds five Monte Carlo "
+            "standard errors."
+        ),
+    )
+
+
+def test_feols_leverage_rejects_unsupported_models_and_inputs() -> None:
+    data = pf.get_data().dropna()
+    ols_fit = pf.feols("Y ~ X1", data=data)
+    lean_fit = pf.feols("Y ~ X1 | f1", data=data, lean=True)
+    iv_fit = pf.feols("Y ~ 1 + [X1 ~ Z1] | f1", data=data)
+    glm_fit = pf.feglm("Y ~ X1", data=data, family="gaussian")
+    frequency_weight_fit = pf.feols(
+        "Y ~ X1",
+        data=data.assign(frequency_weights=2),
+        weights="frequency_weights",
+        weights_type="fweights",
+    )
+    with pytest.raises(ValueError, match="unavailable for lean models"):
+        lean_fit.leverage(number_probes=2)
+    with pytest.raises(NotImplementedError, match="not implemented for IV models"):
+        iv_fit.leverage(number_probes=2)
+    with pytest.raises(NotImplementedError, match="only for OLS models"):
+        glm_fit.leverage(number_probes=2)
+    with pytest.raises(NotImplementedError, match="frequency weights"):
+        frequency_weight_fit.leverage(number_probes=2)
+    with pytest.raises(ValueError, match="number_probes must be greater than one"):
+        ols_fit.leverage(number_probes=1)
+    with pytest.raises(ValueError, match="unavailable for lean models"):
+        lean_fit.influence(number_probes=2)
+
+
+def test_influence_rejects_unit_leverage() -> None:
+    leverage_result = RandomizedDiagonalResult(
+        estimate=np.array([0.5, 1.0]),
+        monte_carlo_standard_errors=None,
+        number_probes=100,
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="leverage greater than or equal to one",
+    ):
+        influence(
+            residuals=np.array([1.0, 1.0]),
+            leverage=leverage_result,
+        )
+
+
+def test_leverage_is_available_on_fetched_multiple_estimation_model() -> None:
+    multiple_fit = pf.feols(
+        "Y ~ sw(X1, X2) | f1",
+        data=pf.get_data().dropna(),
+    )
+    fit = multiple_fit.fetch_model(0, print_fml=False)
+
+    result = fit.leverage(number_probes=16)
+    influence_result = fit.influence(number_probes=16)
+
+    assert result.estimate.shape == (fit._N_rows,)
+    assert influence_result.estimate.shape == (fit._N_rows,)
+
+
+def test_fixed_effect_residual_projection_raises_on_nonconvergence() -> None:
+    random_number_generator = np.random.default_rng(42)
+    number_observations = 100
+    fixed_effects = random_number_generator.integers(
+        0,
+        10,
+        size=(number_observations, 2),
+        dtype=np.int32,
+    )
+    projection = FixedEffectResidualProjection(
+        fixed_effects=fixed_effects,
+        weights=np.ones(number_observations),
+        demeaner=MapDemeaner(fixef_maxiter=1),
+        preconditioner=None,
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="Fixed-effect residualisation failed after 1 iterations",
+    ):
+        projection.apply(random_number_generator.normal(size=(number_observations, 2)))

--- a/tests/test_vs_fixest.py
+++ b/tests/test_vs_fixest.py
@@ -1584,6 +1584,131 @@ def test_wls_na():
     )
 
 
+@pytest.mark.against_r_core
+def test_jla_leverage_against_fixest():
+    """Compare randomized leverage with exact R fixest hat values."""
+    number_observations = 96
+    observation = np.arange(number_observations)
+    component = observation // 48
+    within_component = observation % 48
+    data = pd.DataFrame(
+        {
+            "y": np.cos(observation / 5) + observation / 100,
+            "x": np.sin(observation / 7) + observation / 50,
+            "f1": 3 * component + within_component % 3,
+            "f2": 4 * component + (within_component // 3) % 4,
+            "weights": 0.5 + (observation % 7) / 3,
+        }
+    )
+
+    fit_py = pf.feols(
+        "y ~ x | f1 + f2",
+        data=data,
+        weights="weights",
+        demeaner=pf.LsmrDemeaner(
+            fixef_atol=1e-12,
+            fixef_btol=1e-12,
+            preconditioner="additive",
+        ),
+    )
+    fit_r = fixest.feols(
+        ro.Formula("y ~ x | f1 + f2"),
+        data=data,
+        weights=ro.Formula("~ weights"),
+    )
+
+    result = fit_py.leverage(
+        number_probes=10_000,
+        seed=8712,
+        compute_monte_carlo_standard_errors=True,
+    )
+    leverage_r = np.asarray(stats.hatvalues(fit_r, exact=True), dtype=np.float64)
+
+    assert result.monte_carlo_standard_errors is not None
+    # These tolerances cover finite-probe Monte Carlo error; the deterministic
+    # projection tests separately exercise solver accuracy at tighter tolerances.
+    np.testing.assert_allclose(
+        result.estimate,
+        leverage_r,
+        rtol=0.06,
+        atol=0.005,
+        err_msg="JLA leverage differs from exact R fixest hat values.",
+    )
+    np.testing.assert_array_less(
+        np.abs(result.estimate - leverage_r),
+        5 * result.monte_carlo_standard_errors + 1e-10,
+        err_msg="JLA leverage error exceeds five Monte Carlo standard errors.",
+    )
+
+
+@pytest.mark.against_r_core
+def test_influence_against_fixest_refits():
+    """Compare OLS influence with direct deleted-observation R fixest refits."""
+    number_observations = 36
+    observation = np.arange(number_observations)
+    data = pd.DataFrame(
+        {
+            "y": np.cos(observation / 5) + observation / 100,
+            "x": np.sin(observation / 7) + observation / 50,
+            "f1": observation % 3,
+            "f2": (observation // 3) % 4,
+            "weights": 0.5 + (observation % 7) / 3,
+        }
+    )
+
+    fit_py = pf.feols(
+        "y ~ x | f1 + f2",
+        data=data,
+        weights="weights",
+        demeaner=pf.LsmrDemeaner(
+            fixef_atol=1e-12,
+            fixef_btol=1e-12,
+            preconditioner="additive",
+        ),
+    )
+    fit_r = fixest.feols(
+        ro.Formula("y ~ x | f1 + f2"),
+        data=data,
+        weights=ro.Formula("~ weights"),
+    )
+
+    result = fit_py.influence(
+        number_probes=20_000,
+        seed=9817,
+        compute_monte_carlo_standard_errors=True,
+    )
+    fitted_r = np.asarray(stats.fitted(fit_r), dtype=np.float64)
+    influence_r = np.empty(number_observations)
+    for index in range(number_observations):
+        leave_one_out_fit_r = fixest.feols(
+            ro.Formula("y ~ x | f1 + f2"),
+            data=data.drop(index=index),
+            weights=ro.Formula("~ weights"),
+        )
+        leave_one_out_prediction_r = np.asarray(
+            stats.predict(leave_one_out_fit_r, newdata=data.iloc[[index]]),
+            dtype=np.float64,
+        )[0]
+        influence_r[index] = fitted_r[index] - leave_one_out_prediction_r
+
+    assert result.monte_carlo_standard_errors is not None
+    np.testing.assert_allclose(
+        result.estimate,
+        influence_r,
+        rtol=0.08,
+        atol=0.005,
+        err_msg="JLA leave-one-out influence differs from direct R fixest refits.",
+    )
+    np.testing.assert_array_less(
+        np.abs(result.estimate - influence_r),
+        5 * result.monte_carlo_standard_errors + 1e-10,
+        err_msg=(
+            "JLA leave-one-out influence error exceeds five Monte Carlo standard "
+            "errors relative to R fixest refits."
+        ),
+    )
+
+
 def _py_fml_to_r_fml(py_fml):
     """
     Covernt pyfixest formula.


### PR DESCRIPTION
Uses the Johnson-Lindenstrauss approximation introduced in #1478 to efficiently compute leverage and leave-one-out influence values of OLS regressions with high-dimensional fixed effects.

### Description
Observation $i$'s leverage is $i$-th diagonal element of the regression projection matrix $H = X(X^\top X)^{-1}X$. Forming $H$ becomes computationally infeasible with high-dimensional fixed effects which may have millions of levels.

Because the projection matrix $H$ is symmetric and idempotent, the leverage value $`h_i = H_{ii} = (HH^\top)_{ii}`$ can be approximated using the Johnson-Lindenstrauss approximation [(Achlioptas, 2003)](https://www.sciencedirect.com/science/article/pii/S0022000003000254):

The Johnson-Lindenstrauss approximation (JLA) constructs an estimate of $`h_i`$ using $`p`$ [Rademacher random probes](https://en.wikipedia.org/wiki/Rademacher_distribution) $`z_1,\dots, z_p\in\{\pm1\}^N`$. The leverage value can be estimated as

```math
\hat{h}_i = \frac{1}{p}\sum_{\alpha=1}^p (H z_\alpha)_i^2.
```

This works because $`\mathbb{E}[z_\alpha z_\alpha^\top] = I_N`$ by construction, so that
```math
\mathbb{E}[(Hz_\alpha)_i^2] = e_i^\top H\mathbb{E}[z_\alpha z_\alpha^\top] H^\top e_i = (HH^\top)_{ii} = h_i.
```

For each random probe $z_\alpha$, we can absorb the fixed effects using the Frisch-Waugh Lovell theorem so we don't have to ever form the full projection matrix $H$. The main cost in calculating the leverage values then becomes demeaning $p$ random probes.


### Example
It looks like JLA scales reasonably well to large(ish) datasets: `feols.influence()` takes around 257 ms for 1 million observations using 100 random probes. (Still need to investigate how to determine the "right" number of probes.)

```python
import pyfixest

from benchmarks.modular.dgp_functions import base_dgp
from pyfixest.demeaners import LsmrDemeaner

data = base_dgp(n=1_000_000)
fit = pyfixest.feols(fml="y ~ x1 | indiv_id:firm_id + year", data=data, demeaner=LsmrDemeaner())
fit.influence()  # 257 ms ± 2.74 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

### Next steps

I think this opens up a few additional post estimation utilities that so far aren't really available in fixed-effect regression libraries. For example,
- fixed-effect prediction uncertainty (see, e.g., https://github.com/lrberge/fixest/issues/22 and https://github.com/vincentarelbundock/marginaleffects/issues/1487)
- generic "variance components" and bias-correction à la [KSS (2020)](https://onlinelibrary.wiley.com/doi/abs/10.3982/ECTA16410) (Julia has an [implementation]( https://github.com/HighDimensionalEconLab/VarianceComponentsHDFE.jl) for two fixed effects; the `within` backend should scale reasonably well to three fixed effects)
- fixed-effect covariance https://github.com/py-econometrics/pyfixest/discussions/1330 

----
FYI @schroedk and @s3alfisc (since I've mentioned this idea to both of you in the past). Would be happy to hear your feedback/comment/ideas.
