### PR TITLE
Account for fixed-effect uncertainty in predictions

### DIFF
--- a/pyfixest/estimation/models/feols_.py
+++ b/pyfixest/estimation/models/feols_.py
@@ -28,6 +28,7 @@ from pyfixest.estimation.internals.collinearity import drop_multicollinear_varia
 from pyfixest.estimation.internals.demean_ import DemeanCache
 from pyfixest.estimation.internals.families import T_DIST, InferenceDist
 from pyfixest.estimation.internals.fit_ import fit_ols
+from pyfixest.estimation.internals.jla import LinearOperator
 from pyfixest.estimation.internals.literals import (
     PredictionErrorOptions,
     PredictionType,
@@ -1888,6 +1889,194 @@ class Feols(ResultAccessorMixin):
         return jla.influence(
             residuals=np.asarray(self.resid(), dtype=np.float64),
             leverage=leverage,
+        )
+
+    def predictions(
+        self,
+        type: PredictionType = "link",
+        average: bool | tuple[str, ...] = False,
+        number_probes: int = 100,
+        seed: int = 1234,
+    ) -> jla.PredictionResult:
+        """Calculate in-sample OLS predictions and their standard errors.
+
+        For models with absorbed fixed effects, prediction variances include
+        uncertainty from both the reported coefficients and the fixed effects.
+        They are approximated from the complete regression projection using the
+        Johnson--Lindenstrauss construction of [Kline, Saggio, and Sølvsten
+        (2020)](https://doi.org/10.3982/ECTA16410). The reported Monte Carlo
+        standard errors describe approximation error in the variance estimates,
+        not sampling uncertainty.
+
+        Parameters
+        ----------
+        type : PredictionType, optional
+            Prediction scale. ``"link"`` and ``"response"`` are identical for
+            OLS. Defaults to ``"link"``.
+        average : bool | tuple[str, ...], optional
+            Whether to average predictions before calculating uncertainty.
+            ``True`` returns the overall average. A non-empty tuple of column
+            names returns averages for each observed group. Defaults to
+            ``False``.
+        number_probes : int, optional
+            Number of independent Rademacher probes. More probes reduce Monte
+            Carlo error but increase runtime and memory use. Defaults to ``100``.
+        seed : int, optional
+            Seed used to construct the random-number generator. Defaults to
+            ``1234``.
+
+        Returns
+        -------
+        PredictionResult
+            In-sample predictions, their statistical standard errors, and
+            variance-level Monte Carlo standard errors for randomized results.
+
+        Raises
+        ------
+        ValueError
+            If the model is lean, ``type`` or ``average`` is invalid, grouped
+            averages are requested without stored data, or grouping columns
+            contain missing values.
+        NotImplementedError
+            If the model is weighted, instrumental-variables, fixed-effect-only,
+            not OLS, or was fitted with an inference method other than IID or
+            one-way CRV1.
+
+        Examples
+        --------
+        ```{python}
+        import pyfixest as pf
+
+        fit = pf.feols("Y ~ X1 | f1 + f2", pf.get_data())
+        result = fit.predictions(number_probes=100, seed=1234)
+        result.estimate[:5]
+        result.standard_error[:5]
+        ```
+        """
+        if self._lean:
+            raise ValueError(
+                "predictions() is unavailable for lean models. "
+                "Re-estimate with lean=False."
+            )
+        if self._is_iv:
+            raise NotImplementedError("predictions() is not implemented for IV models.")
+        if self._method != "feols":
+            raise NotImplementedError(
+                "predictions() is currently implemented only for OLS models."
+            )
+        if self._has_weights:
+            raise NotImplementedError(
+                "predictions() does not currently support regression weights."
+            )
+        if self._X_is_empty:
+            raise NotImplementedError(
+                "predictions() does not currently support models without "
+                "estimated covariate coefficients."
+            )
+        if self._vcov_type not in {"iid", "CRV"} or (
+            self._vcov_type == "CRV" and self._vcov_type_detail != "CRV1"
+        ):
+            raise NotImplementedError(
+                "predictions() currently supports only IID and CRV1 inference."
+            )
+        if self._vcov_type == "CRV" and self._cluster_df.shape[1] != 1:
+            raise NotImplementedError(
+                "predictions() currently supports only one-way CRV1 inference."
+            )
+        _validate_literal_argument(type, PredictionType)
+
+        group_keys: tuple[tuple[object, ...], ...] | None = None
+        if average is False:
+            prediction_to_quantity: LinearOperator = jla.IdentityOperator(
+                size=self._N_rows
+            )
+        elif average is True:
+            prediction_to_quantity = jla.PredictionAveragingOperator(
+                group_indices=np.zeros(self._N_rows, dtype=np.intp),
+            )
+        elif (
+            isinstance(average, tuple)
+            and average
+            and all(isinstance(column, str) for column in average)
+        ):
+            if not self._store_data:
+                raise ValueError(
+                    "Grouped prediction averages require stored data. "
+                    "Re-estimate with store_data=True."
+                )
+            missing_columns = [
+                column for column in average if column not in self._data.columns
+            ]
+            if missing_columns:
+                raise ValueError(
+                    f"Grouping columns not found in stored data: {missing_columns}."
+                )
+            if len(set(average)) != len(average):
+                raise ValueError(f"Grouping columns must be unique: {average}")
+            group_data = self._data.loc[:, list(average)]
+            if group_data.isna().to_numpy().any():
+                raise ValueError("Grouping columns must not contain missing values.")
+            group_indices, unique_groups = pd.factorize(
+                pd.MultiIndex.from_frame(group_data), sort=False
+            )
+            group_keys = tuple(tuple(key) for key in unique_groups.tolist())
+            prediction_to_quantity = jla.PredictionAveragingOperator(
+                group_indices=np.asarray(group_indices, dtype=np.intp),
+            )
+        else:
+            raise ValueError(
+                "average must be False, True, or a non-empty tuple of column names."
+            )
+
+        fitted_values = np.asarray(self._Y_hat_link, dtype=np.float64)
+        fitted_values = prediction_to_quantity.apply(fitted_values[:, None]).reshape(-1)
+        regression_projection = jla.RegressionProjectionOperator(
+            fixed_effect_residual_projection=(
+                jla.FixedEffectResidualProjection(
+                    fixed_effects=np.asarray(self._fe, dtype=np.int32),
+                    weights=np.asarray(self._weights, dtype=np.float64).reshape(-1),
+                    demeaner=self._demeaner,
+                    preconditioner=self.preconditioner,
+                )
+                if self._has_fixef
+                else None
+            ),
+            covariates=np.asarray(self._X, dtype=np.float64),
+            gramian=(
+                np.asarray(self._hessian, dtype=np.float64)
+                if self._X.shape[1] > 0
+                else np.empty((0, 0), dtype=np.float64)
+            ),
+        )
+        residuals = np.asarray(self._u_hat, dtype=np.float64).reshape(-1)
+        ssc = np.asarray(self._ssc, dtype=np.float64).reshape(-1)
+        score_covariance_factor: LinearOperator
+        if self._vcov_type == "iid":
+            residual_variance = float(ssc[0] * np.sum(residuals**2) / (self._N - 1))
+            score_covariance_factor = jla.DiagonalScoreCovarianceFactor(
+                number_observations=self._N,
+                scale=np.sqrt(residual_variance),
+            )
+        else:
+            cluster_indices = np.asarray(
+                pd.factorize(self._cluster_df.iloc[:, 0])[0],
+                dtype=np.intp,
+            )
+            score_covariance_factor = jla.ClusterScoreCovarianceFactor(
+                score_scale=np.sqrt(float(ssc[0])) * residuals,
+                cluster_indices=cluster_indices,
+                number_clusters=int(self._cluster_df.iloc[:, 0].nunique()),
+            )
+        return jla.prediction_uncertainty(
+            fitted_values=fitted_values,
+            prediction_jacobian=jla.PredictionJacobian(
+                score_covariance_factor=score_covariance_factor,
+                score_to_prediction=regression_projection,
+                prediction_to_quantity=prediction_to_quantity,
+            ),
+            number_probes=number_probes,
+            random_number_generator=_create_rng(seed),
+            group_keys=group_keys,
         )
 
     def predict(

--- a/pyfixest/estimation/post_estimation/jla.py
+++ b/pyfixest/estimation/post_estimation/jla.py
@@ -108,6 +108,311 @@ class RegressionProjectionOperator:
         return right_hand_side - residualised
 
 
+@dataclass(frozen=True, slots=True)
+class DiagonalScoreCovarianceFactor:
+    """Apply a diagonal score covariance factor."""
+
+    number_observations: int
+    scale: float | NDArray[np.float64] = 1.0
+
+    def __post_init__(self) -> None:
+        scale = np.asarray(self.scale)
+        if scale.ndim > 0 and scale.shape != (self.number_observations,):
+            raise ValueError(
+                f"scale must be a scalar or have shape ({self.number_observations},)."
+            )
+
+    @property
+    def shape(self) -> tuple[int, int]:
+        """Operator dimensions as ``(number_observations, number_scores)``."""
+        return (self.number_observations, self.number_observations)
+
+    def apply(self, right_hand_side: NDArray[np.float64]) -> NDArray[np.float64]:
+        """Scale observation-level score perturbations.
+
+        Parameters
+        ----------
+        right_hand_side : NDArray[np.float64]
+            Probe vectors with shape ``(number_observations, number_vectors)``.
+
+        Returns
+        -------
+        NDArray[np.float64]
+            Scaled score perturbations.
+        """
+        scale = np.asarray(self.scale, dtype=np.float64)
+        return (
+            float(scale) * right_hand_side
+            if scale.ndim == 0
+            else scale[:, None] * right_hand_side
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ClusterScoreCovarianceFactor:
+    """Expand cluster-level perturbations into observation-level scores."""
+
+    score_scale: NDArray[np.float64]
+    cluster_indices: NDArray[np.intp]
+    number_clusters: int
+
+    def __post_init__(self) -> None:
+        if self.score_scale.ndim != 1:
+            raise ValueError("score_scale must be one-dimensional.")
+        number_observations = self.score_scale.shape[0]
+        if self.cluster_indices.shape != (number_observations,):
+            raise ValueError(
+                "cluster_indices must have the same length as score_scale."
+            )
+        if self.number_clusters < 1:
+            raise ValueError("number_clusters must be positive.")
+        if np.any(self.cluster_indices < 0) or np.any(
+            self.cluster_indices >= self.number_clusters
+        ):
+            raise ValueError(
+                "cluster_indices must be between zero and number_clusters - 1."
+            )
+
+    @property
+    def shape(self) -> tuple[int, int]:
+        """Operator dimensions as ``(number_observations, number_clusters)``."""
+        return (self.score_scale.shape[0], self.number_clusters)
+
+    def apply(self, right_hand_side: NDArray[np.float64]) -> NDArray[np.float64]:
+        """Map cluster-level probes to scaled observation-level scores.
+
+        Parameters
+        ----------
+        right_hand_side : NDArray[np.float64]
+            Probe vectors with shape ``(number_clusters, number_vectors)``.
+
+        Returns
+        -------
+        NDArray[np.float64]
+            Scaled score perturbations with one row per observation.
+        """
+        return self.score_scale[:, None] * right_hand_side[self.cluster_indices]
+
+
+@dataclass(frozen=True, slots=True)
+class IdentityOperator:
+    """Return vectors without transforming them."""
+
+    size: int
+
+    def __post_init__(self) -> None:
+        if self.size < 0:
+            raise ValueError("size must be non-negative.")
+
+    @property
+    def shape(self) -> tuple[int, int]:
+        """Operator dimensions as ``(size, size)``."""
+        return (self.size, self.size)
+
+    def apply(self, right_hand_side: NDArray[np.float64]) -> NDArray[np.float64]:
+        """Return one or more column vectors unchanged.
+
+        Parameters
+        ----------
+        right_hand_side : NDArray[np.float64]
+            Column vectors with shape ``(size, number_vectors)``.
+
+        Returns
+        -------
+        NDArray[np.float64]
+            The input column vectors.
+        """
+        return right_hand_side
+
+
+@dataclass(frozen=True, slots=True)
+class PredictionAveragingOperator:
+    """Average observation-level quantities within groups."""
+
+    group_indices: NDArray[np.intp]
+
+    def __post_init__(self) -> None:
+        if self.group_indices.ndim != 1:
+            raise ValueError("group_indices must be one-dimensional.")
+        if self.group_indices.size == 0:
+            raise ValueError("group_indices must contain at least one observation.")
+        if not np.issubdtype(self.group_indices.dtype, np.integer):
+            raise ValueError("group_indices must contain integers.")
+        if np.any(self.group_indices < 0):
+            raise ValueError("group_indices must be non-negative.")
+        if np.unique(self.group_indices).shape[0] != self.number_groups:
+            raise ValueError("group_indices must be contiguous and zero-based.")
+
+    @property
+    def number_groups(self) -> int:
+        """Number of groups."""
+        return int(self.group_indices.max()) + 1
+
+    @property
+    def shape(self) -> tuple[int, int]:
+        """Operator dimensions as ``(number_groups, number_observations)``."""
+        return (self.number_groups, self.group_indices.shape[0])
+
+    def apply(self, right_hand_side: NDArray[np.float64]) -> NDArray[np.float64]:
+        """Average rows of one or more column vectors within groups.
+
+        Parameters
+        ----------
+        right_hand_side : NDArray[np.float64]
+            Observation-level vectors with shape
+            ``(number_observations, number_vectors)``.
+
+        Returns
+        -------
+        NDArray[np.float64]
+            Group averages with shape ``(number_groups, number_vectors)``.
+        """
+        group_sums = np.zeros(
+            (self.number_groups, right_hand_side.shape[1]), dtype=np.float64
+        )
+        np.add.at(group_sums, self.group_indices, right_hand_side)
+        group_counts = np.bincount(
+            self.group_indices, minlength=self.number_groups
+        ).astype(np.float64)
+        return group_sums / group_counts[:, None]
+
+
+@dataclass(frozen=True, slots=True)
+class PredictionJacobian:
+    """Compose the operators defining a prediction-derived quantity.
+
+    The represented operator is ``prediction_to_quantity @``
+    ``score_to_prediction @ score_covariance_factor``.
+    """
+
+    score_covariance_factor: LinearOperator
+    score_to_prediction: LinearOperator
+    prediction_to_quantity: LinearOperator
+
+    def __post_init__(self) -> None:
+        if self.score_to_prediction.shape[1] != self.score_covariance_factor.shape[0]:
+            raise ValueError(
+                "score_to_prediction input size must equal "
+                "score_covariance_factor output size."
+            )
+        if self.prediction_to_quantity.shape[1] != self.score_to_prediction.shape[0]:
+            raise ValueError(
+                "prediction_to_quantity input size must equal "
+                "score_to_prediction output size."
+            )
+
+    @property
+    def shape(self) -> tuple[int, int]:
+        """Operator dimensions as ``(number_predictions, number_scores)``."""
+        return (
+            self.prediction_to_quantity.shape[0],
+            self.score_covariance_factor.shape[1],
+        )
+
+    def apply(self, right_hand_side: NDArray[np.float64]) -> NDArray[np.float64]:
+        """Map score perturbations to perturbations of fitted values.
+
+        Parameters
+        ----------
+        right_hand_side : NDArray[np.float64]
+            Probe vectors with shape ``(number_scores, number_vectors)``.
+
+        Returns
+        -------
+        NDArray[np.float64]
+            Perturbations of the in-sample fitted values.
+        """
+        score_perturbations = self.score_covariance_factor.apply(right_hand_side)
+        prediction_perturbations = self.score_to_prediction.apply(score_perturbations)
+        return self.prediction_to_quantity.apply(prediction_perturbations)
+
+
+@dataclass(frozen=True, slots=True)
+class PredictionResult:
+    """In-sample prediction estimates and statistical uncertainty.
+
+    Attributes
+    ----------
+    estimate : NDArray[np.float64]
+        Fitted values with shape ``(number_observations,)``.
+    variance : RandomizedDiagonalResult
+        JLA prediction-variance approximation and its numerical uncertainty.
+    group_keys : tuple[tuple[object, ...], ...] | None
+        Group keys corresponding to aggregated estimates. ``None`` for
+        observation-level or overall-average predictions.
+    """
+
+    estimate: NDArray[np.float64]
+    variance: RandomizedDiagonalResult
+    group_keys: tuple[tuple[object, ...], ...] | None = None
+
+    @property
+    def standard_error(self) -> NDArray[np.float64]:
+        """Calculate statistical standard errors of the predictions.
+
+        Returns
+        -------
+        NDArray[np.float64]
+            Prediction standard errors.
+        """
+        return np.sqrt(self.variance.estimate)
+
+
+def prediction_uncertainty(
+    *,
+    fitted_values: NDArray[np.float64],
+    prediction_jacobian: PredictionJacobian,
+    number_probes: int,
+    random_number_generator: np.random.Generator,
+    group_keys: tuple[tuple[object, ...], ...] | None = None,
+) -> PredictionResult:
+    """Approximate prediction uncertainty from a prediction Jacobian.
+
+    For a covariance-scaled prediction Jacobian ``J``, the prediction
+    variances are ``diag(J @ J.T)``.
+
+    Parameters
+    ----------
+    fitted_values : NDArray[np.float64]
+        Prediction estimates.
+    prediction_jacobian : PredictionJacobian
+        Operator mapping standardized score perturbations to prediction
+        perturbations.
+    number_probes : int
+        Number of independent Rademacher probes.
+    random_number_generator : np.random.Generator
+        Random-number generator used to construct the probes.
+    group_keys : tuple[tuple[object, ...], ...] | None, optional
+        Group keys corresponding to aggregated predictions.
+
+    Returns
+    -------
+    PredictionResult
+        Prediction estimates and their JLA variance approximation.
+
+    Raises
+    ------
+    ValueError
+        If fewer than two probes are requested or the Jacobian output size
+        differs from the number of predictions.
+    """
+    if prediction_jacobian.shape[0] != fitted_values.shape[0]:
+        raise ValueError(
+            "prediction_jacobian output size must equal the number of predictions."
+        )
+    variance_approximation = approximate_diagonal(
+        left=prediction_jacobian,
+        number_probes=number_probes,
+        random_number_generator=random_number_generator,
+        compute_monte_carlo_standard_errors=True,
+    )
+    return PredictionResult(
+        estimate=fitted_values,
+        variance=variance_approximation,
+        group_keys=group_keys,
+    )
+
+
 def leverage(
     *,
     regression_projection: RegressionProjectionOperator,

--- a/tests/test_post_estimation_jla.py
+++ b/tests/test_post_estimation_jla.py
@@ -10,10 +10,17 @@ from pyfixest.demeaners import LsmrDemeaner, MapDemeaner
 from pyfixest.estimation.internals.jla import RandomizedDiagonalResult
 from pyfixest.estimation.post_estimation import jla
 from pyfixest.estimation.post_estimation.jla import (
+    ClusterScoreCovarianceFactor,
+    DiagonalScoreCovarianceFactor,
     FixedEffectResidualProjection,
+    IdentityOperator,
+    PredictionAveragingOperator,
+    PredictionJacobian,
+    PredictionResult,
     RegressionProjectionOperator,
     influence,
     leverage,
+    prediction_uncertainty,
 )
 
 FixedEffectDesign = tuple[
@@ -21,6 +28,26 @@ FixedEffectDesign = tuple[
     NDArray[np.float64],
     NDArray[np.float64],
 ]
+
+
+def _averaging_matrix(
+    data: pd.DataFrame,
+    average: bool | tuple[str, ...],
+) -> tuple[NDArray[np.float64], tuple[tuple[object, ...], ...] | None]:
+    number_observations = data.shape[0]
+    if average is False:
+        return np.eye(number_observations), None
+    if average is True:
+        return np.full((1, number_observations), 1 / number_observations), None
+
+    group_index = pd.MultiIndex.from_frame(data.loc[:, list(average)])
+    group_indices, unique_groups = pd.factorize(group_index, sort=False)
+    group_membership = (
+        group_indices[None, :] == np.arange(len(unique_groups))[:, None]
+    ).astype(np.float64)
+    averaging_matrix = group_membership / group_membership.sum(axis=1, keepdims=True)
+    group_keys = tuple(tuple(key) for key in unique_groups.tolist())
+    return averaging_matrix, group_keys
 
 
 def _regression_projection(
@@ -168,6 +195,260 @@ def test_leverage_approximates_dense_weighted_projection_diagonal(
     )
 
 
+def test_prediction_uncertainty_approximates_dense_projection_variance(
+    fixed_effect_design: FixedEffectDesign,
+) -> None:
+    projection, weighted_design_matrix = _regression_projection(fixed_effect_design)
+    fitted_values = np.linspace(-1.0, 1.0, projection.shape[0])
+    residual_variance = 2.5
+
+    result = prediction_uncertainty(
+        fitted_values=fitted_values,
+        prediction_jacobian=PredictionJacobian(
+            score_covariance_factor=DiagonalScoreCovarianceFactor(
+                number_observations=projection.shape[1],
+                scale=np.sqrt(residual_variance),
+            ),
+            score_to_prediction=projection,
+            prediction_to_quantity=IdentityOperator(size=projection.shape[0]),
+        ),
+        number_probes=10_000,
+        random_number_generator=np.random.default_rng(741),
+    )
+
+    dense_projection = weighted_design_matrix @ np.linalg.pinv(weighted_design_matrix)
+    expected_variance = residual_variance * np.diag(dense_projection)
+    assert isinstance(result, PredictionResult)
+    assert result.variance.number_probes == 10_000
+    assert result.variance.monte_carlo_standard_errors is not None
+    np.testing.assert_array_equal(result.estimate, fitted_values)
+    np.testing.assert_array_less(
+        np.abs(result.standard_error**2 - expected_variance),
+        5 * result.variance.monte_carlo_standard_errors + 1e-10,
+        err_msg=("Prediction variance error exceeds five Monte Carlo standard errors."),
+    )
+
+
+def test_prediction_jacobian_composes_score_covariance_factor(
+    fixed_effect_design: FixedEffectDesign,
+) -> None:
+    projection, _ = _regression_projection(fixed_effect_design)
+    score_scale = np.linspace(0.5, 1.5, projection.shape[1])
+    right_hand_side = np.arange(projection.shape[1] * 2, dtype=np.float64).reshape(
+        projection.shape[1], 2
+    )
+    jacobian = PredictionJacobian(
+        score_covariance_factor=DiagonalScoreCovarianceFactor(
+            number_observations=projection.shape[1],
+            scale=score_scale,
+        ),
+        score_to_prediction=projection,
+        prediction_to_quantity=IdentityOperator(size=projection.shape[0]),
+    )
+
+    expected = projection.apply(score_scale[:, None] * right_hand_side)
+    np.testing.assert_allclose(jacobian.apply(right_hand_side), expected)
+
+
+def test_identity_operator_returns_vectors_unchanged() -> None:
+    right_hand_side = np.arange(8, dtype=np.float64).reshape(4, 2)
+    identity = IdentityOperator(size=4)
+
+    assert identity.shape == (4, 4)
+    assert identity.apply(right_hand_side) is right_hand_side
+
+    with pytest.raises(ValueError, match="size must be non-negative"):
+        IdentityOperator(size=-1)
+
+
+def test_prediction_jacobian_applies_averaging_operator(
+    fixed_effect_design: FixedEffectDesign,
+) -> None:
+    projection, _ = _regression_projection(fixed_effect_design)
+    group_indices = np.arange(projection.shape[0], dtype=np.intp) % 3
+    averaging = PredictionAveragingOperator(
+        group_indices=group_indices,
+    )
+    jacobian = PredictionJacobian(
+        score_covariance_factor=DiagonalScoreCovarianceFactor(
+            number_observations=projection.shape[1],
+        ),
+        score_to_prediction=projection,
+        prediction_to_quantity=averaging,
+    )
+    right_hand_side = np.arange(projection.shape[1] * 2, dtype=np.float64).reshape(
+        projection.shape[1], 2
+    )
+
+    expected = averaging.apply(projection.apply(right_hand_side))
+    np.testing.assert_allclose(jacobian.apply(right_hand_side), expected)
+    assert jacobian.shape == (3, projection.shape[1])
+
+
+@pytest.mark.parametrize(
+    ("group_indices", "message"),
+    [
+        pytest.param(
+            np.ones((3, 1), dtype=np.intp),
+            "group_indices must be one-dimensional",
+            id="dimensions",
+        ),
+        pytest.param(
+            np.array([], dtype=np.intp),
+            "group_indices must contain at least one observation",
+            id="empty",
+        ),
+        pytest.param(
+            np.array([0.0, 1.0]),
+            "group_indices must contain integers",
+            id="dtype",
+        ),
+        pytest.param(
+            np.array([-1, 0], dtype=np.intp),
+            "group_indices must be non-negative",
+            id="negative",
+        ),
+        pytest.param(
+            np.array([0, 2, 2], dtype=np.intp),
+            "group_indices must be contiguous and zero-based",
+            id="noncontiguous",
+        ),
+    ],
+)
+def test_prediction_averaging_operator_rejects_invalid_inputs(
+    group_indices: NDArray[np.intp] | NDArray[np.float64],
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        PredictionAveragingOperator(
+            group_indices=group_indices,
+        )
+
+
+def test_cluster_score_covariance_factor_expands_cluster_probes(
+    fixed_effect_design: FixedEffectDesign,
+) -> None:
+    projection, _ = _regression_projection(fixed_effect_design)
+    number_observations = projection.shape[1]
+    cluster_indices = np.arange(number_observations, dtype=np.intp) % 3
+    score_scale = np.linspace(-1.0, 1.0, number_observations)
+    factor = ClusterScoreCovarianceFactor(
+        score_scale=score_scale,
+        cluster_indices=cluster_indices,
+        number_clusters=3,
+    )
+    jacobian = PredictionJacobian(
+        score_covariance_factor=factor,
+        score_to_prediction=projection,
+        prediction_to_quantity=IdentityOperator(size=projection.shape[0]),
+    )
+    cluster_probes = np.arange(6, dtype=np.float64).reshape(3, 2)
+
+    expected_scores = score_scale[:, None] * cluster_probes[cluster_indices]
+    np.testing.assert_array_equal(factor.apply(cluster_probes), expected_scores)
+    np.testing.assert_allclose(
+        jacobian.apply(cluster_probes), projection.apply(expected_scores)
+    )
+
+
+@pytest.mark.parametrize(
+    ("score_scale", "cluster_indices", "number_clusters", "message"),
+    [
+        pytest.param(
+            np.ones((3, 1)),
+            np.arange(3, dtype=np.intp),
+            3,
+            "score_scale must be one-dimensional",
+            id="score_scale",
+        ),
+        pytest.param(
+            np.ones(3),
+            np.arange(2, dtype=np.intp),
+            3,
+            "same length as score_scale",
+            id="cluster_length",
+        ),
+        pytest.param(
+            np.ones(3),
+            np.zeros(3, dtype=np.intp),
+            0,
+            "number_clusters must be positive",
+            id="number_clusters",
+        ),
+        pytest.param(
+            np.ones(3),
+            np.array([0, 1, 3], dtype=np.intp),
+            3,
+            "between zero and number_clusters - 1",
+            id="cluster_range",
+        ),
+    ],
+)
+def test_cluster_score_covariance_factor_rejects_invalid_inputs(
+    score_scale: NDArray[np.float64],
+    cluster_indices: NDArray[np.intp],
+    number_clusters: int,
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        ClusterScoreCovarianceFactor(
+            score_scale=score_scale,
+            cluster_indices=cluster_indices,
+            number_clusters=number_clusters,
+        )
+
+
+def test_prediction_jacobian_rejects_incompatible_operator_dimensions(
+    fixed_effect_design: FixedEffectDesign,
+) -> None:
+    projection, _ = _regression_projection(fixed_effect_design)
+
+    with pytest.raises(ValueError, match="scale must be a scalar or have shape"):
+        DiagonalScoreCovarianceFactor(
+            number_observations=projection.shape[1],
+            scale=np.ones(2),
+        )
+    with pytest.raises(ValueError, match="input size must equal"):
+        PredictionJacobian(
+            score_covariance_factor=DiagonalScoreCovarianceFactor(
+                number_observations=projection.shape[1] + 1,
+            ),
+            score_to_prediction=projection,
+            prediction_to_quantity=IdentityOperator(size=projection.shape[0]),
+        )
+    with pytest.raises(ValueError, match="prediction_to_quantity input size"):
+        PredictionJacobian(
+            score_covariance_factor=DiagonalScoreCovarianceFactor(
+                number_observations=projection.shape[1],
+            ),
+            score_to_prediction=projection,
+            prediction_to_quantity=PredictionAveragingOperator(
+                group_indices=np.zeros(projection.shape[0] - 1, dtype=np.intp),
+            ),
+        )
+
+
+def test_prediction_uncertainty_rejects_invalid_jacobian(
+    fixed_effect_design: FixedEffectDesign,
+) -> None:
+    projection, _ = _regression_projection(fixed_effect_design)
+    prediction_jacobian = PredictionJacobian(
+        score_covariance_factor=DiagonalScoreCovarianceFactor(
+            number_observations=projection.shape[1],
+        ),
+        score_to_prediction=projection,
+        prediction_to_quantity=IdentityOperator(size=projection.shape[0]),
+    )
+
+    with pytest.raises(ValueError, match="output size"):
+        prediction_uncertainty(
+            fitted_values=np.ones(projection.shape[0] - 1),
+            prediction_jacobian=prediction_jacobian,
+            number_probes=2,
+            random_number_generator=np.random.default_rng(1),
+        )
+
+
 def test_influence_transforms_leverage_and_uncertainty() -> None:
     residuals = np.array([2.0, -1.0, 0.5])
     leverage_result = RandomizedDiagonalResult(
@@ -252,6 +533,226 @@ def test_feols_leverage_matches_dense_projection_across_designs(
         np.abs(result.estimate - expected),
         5 * result.monte_carlo_standard_errors + 1e-10,
         err_msg=("Feols leverage error exceeds five Monte Carlo standard errors."),
+    )
+
+
+@pytest.mark.parametrize(
+    ("formula", "fixed_effect_columns", "include_covariate", "average"),
+    [
+        pytest.param("y ~ x | f1", ["f1"], True, False, id="one_fixed_effect"),
+        pytest.param(
+            "y ~ x | f1 + f2",
+            ["f1", "f2"],
+            True,
+            False,
+            id="two_fixed_effects",
+        ),
+        pytest.param(
+            "y ~ x | f1 + f2",
+            ["f1", "f2"],
+            True,
+            True,
+            id="overall_average",
+        ),
+        pytest.param(
+            "y ~ x | f1 + f2",
+            ["f1", "f2"],
+            True,
+            ("f1", "f2"),
+            id="group_averages",
+        ),
+    ],
+)
+def test_feols_predictions_matches_dense_dummy_covariance(
+    fixed_effect_design: FixedEffectDesign,
+    formula: str,
+    fixed_effect_columns: list[str],
+    include_covariate: bool,
+    average: bool | tuple[str, ...],
+) -> None:
+    fixed_effects, _, _ = fixed_effect_design
+    number_observations = fixed_effects.shape[0]
+    covariate = np.linspace(-1.0, 2.0, number_observations)
+    data = pd.DataFrame(
+        {
+            "y": 0.5 * covariate + np.sin(np.arange(number_observations)),
+            "x": covariate,
+            "f1": fixed_effects[:, 0],
+            "f2": fixed_effects[:, 1],
+        }
+    )
+    fit = pf.feols(formula, data=data, vcov="iid")
+
+    result = fit.predictions(average=average, number_probes=20_000, seed=7721)
+
+    design_blocks = [
+        (data[column].to_numpy()[:, None] == np.unique(data[column])).astype(np.float64)
+        for column in fixed_effect_columns
+    ]
+    if include_covariate:
+        design_blocks.append(covariate[:, None])
+    design_matrix = np.column_stack(design_blocks)
+    dense_projection = design_matrix @ np.linalg.pinv(design_matrix)
+    averaging_matrix, expected_group_keys = _averaging_matrix(data, average)
+    ssc = float(fit._ssc[0])
+    residual_variance = ssc * np.sum(fit._u_hat**2) / (fit._N - 1)
+    expected_variance = residual_variance * np.diag(
+        averaging_matrix @ dense_projection @ averaging_matrix.T
+    )
+    expected_estimate = averaging_matrix @ fit.predict()
+
+    assert result.variance.monte_carlo_standard_errors is not None
+    assert result.group_keys == expected_group_keys
+    np.testing.assert_allclose(result.estimate, expected_estimate, rtol=0, atol=1e-14)
+    np.testing.assert_array_less(
+        np.abs(result.standard_error**2 - expected_variance),
+        5 * result.variance.monte_carlo_standard_errors + 1e-10,
+        err_msg=(
+            "Feols prediction variance error exceeds five Monte Carlo standard errors."
+        ),
+    )
+
+
+def test_feols_predictions_without_fixed_effects_uses_jla() -> None:
+    data = pf.get_data().dropna()
+    fit = pf.feols("Y ~ X1 + X2", data=data, vcov="iid")
+
+    link = fit.predictions(type="link", number_probes=20_000, seed=99)
+    response = fit.predictions(type="response", number_probes=20_000, seed=99)
+    expected_variance = np.einsum("ij,jk,ik->i", fit._X, fit._vcov, fit._X)
+
+    np.testing.assert_array_equal(link.estimate, fit.predict())
+    np.testing.assert_array_equal(response.estimate, link.estimate)
+    np.testing.assert_array_equal(response.standard_error, link.standard_error)
+    assert link.variance.monte_carlo_standard_errors is not None
+    assert link.variance.number_probes == 20_000
+    np.testing.assert_array_less(
+        np.abs(link.standard_error**2 - expected_variance),
+        5 * link.variance.monte_carlo_standard_errors + 1e-10,
+        err_msg=("Prediction variance error exceeds five Monte Carlo standard errors."),
+    )
+
+
+@pytest.mark.parametrize(
+    "average",
+    [
+        pytest.param(False, id="unit"),
+        pytest.param(True, id="overall_average"),
+        pytest.param(("f1",), id="group_averages"),
+    ],
+)
+def test_feols_crv1_predictions_match_dense_dummy_covariance(
+    average: bool | tuple[str, ...],
+) -> None:
+    number_observations = 72
+    observation = np.arange(number_observations)
+    data = pd.DataFrame(
+        {
+            "y": np.cos(observation / 5) + observation / 100,
+            "x": np.sin(observation / 7) + observation / 50,
+            "f1": observation % 4,
+            "f2": (observation // 4) % 6,
+            "g1": (observation // 3) % 8,
+        }
+    )
+    fit = pf.feols(
+        "y ~ x | f1 + f2",
+        data=data,
+        vcov={"CRV1": "g1"},
+    )
+
+    result = fit.predictions(average=average, number_probes=20_000, seed=2871)
+
+    design_matrix = np.column_stack(
+        [
+            (data["f1"].to_numpy()[:, None] == np.unique(data["f1"])).astype(
+                np.float64
+            ),
+            (data["f2"].to_numpy()[:, None] == np.unique(data["f2"])).astype(
+                np.float64
+            ),
+            data["x"].to_numpy(),
+        ]
+    )
+    dense_projection = design_matrix @ np.linalg.pinv(design_matrix)
+    averaging_matrix, expected_group_keys = _averaging_matrix(data, average)
+    cluster_values = data["g1"].to_numpy()
+    cluster_membership = (cluster_values[:, None] == np.unique(cluster_values)).astype(
+        np.float64
+    )
+    component_jacobian = (
+        averaging_matrix @ dense_projection @ (fit._u_hat[:, None] * cluster_membership)
+    )
+    expected_variance = float(np.asarray(fit._ssc).reshape(-1)[0]) * np.sum(
+        component_jacobian**2, axis=1
+    )
+    expected_estimate = averaging_matrix @ fit.predict()
+
+    assert result.variance.monte_carlo_standard_errors is not None
+    assert result.group_keys == expected_group_keys
+    np.testing.assert_allclose(result.estimate, expected_estimate, rtol=0, atol=1e-14)
+    np.testing.assert_array_less(
+        np.abs(result.variance.estimate - expected_variance),
+        5 * result.variance.monte_carlo_standard_errors + 1e-10,
+        err_msg=(
+            "CRV1 prediction variance error exceeds five Monte Carlo standard errors."
+        ),
+    )
+
+
+def test_feols_predictions_supports_store_data_false_and_cached_preconditioner(
+    fixed_effect_design: FixedEffectDesign,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixed_effects, _, _ = fixed_effect_design
+    observation = np.arange(fixed_effects.shape[0])
+    data = pd.DataFrame(
+        {
+            "y": np.cos(observation / 3),
+            "x": np.sin(observation / 4),
+            "f1": fixed_effects[:, 0],
+            "f2": fixed_effects[:, 1],
+        }
+    )
+    fit = pf.feols(
+        "y ~ x | f1 + f2",
+        data=data,
+        vcov={"CRV1": "f1"},
+        store_data=False,
+        demeaner=LsmrDemeaner(
+            fixef_atol=1e-12,
+            fixef_btol=1e-12,
+            preconditioner="additive",
+        ),
+    )
+    captured_jacobians: list[PredictionJacobian] = []
+    original_prediction_uncertainty = jla.prediction_uncertainty
+
+    def capture_projection(**kwargs):
+        captured_jacobians.append(kwargs["prediction_jacobian"])
+        return original_prediction_uncertainty(**kwargs)
+
+    monkeypatch.setattr(jla, "prediction_uncertainty", capture_projection)
+    first = fit.predictions(number_probes=100, seed=823)
+    second = fit.predictions(number_probes=100, seed=823)
+    averaged = fit.predictions(average=True, number_probes=100, seed=823)
+
+    score_to_prediction = captured_jacobians[0].score_to_prediction
+    assert isinstance(score_to_prediction, RegressionProjectionOperator)
+    fixed_effect_projection = score_to_prediction.fixed_effect_residual_projection
+    assert isinstance(fixed_effect_projection, FixedEffectResidualProjection)
+    assert fixed_effect_projection.preconditioner is fit.preconditioner
+    assert isinstance(captured_jacobians[0].prediction_to_quantity, IdentityOperator)
+    assert isinstance(
+        captured_jacobians[2].prediction_to_quantity,
+        PredictionAveragingOperator,
+    )
+    np.testing.assert_array_equal(first.estimate, second.estimate)
+    np.testing.assert_allclose(averaged.estimate, [np.mean(first.estimate)])
+    np.testing.assert_array_equal(first.standard_error, second.standard_error)
+    np.testing.assert_array_equal(
+        first.variance.monte_carlo_standard_errors,
+        second.variance.monte_carlo_standard_errors,
     )
 
 
@@ -406,6 +907,66 @@ def test_feols_leverage_rejects_unsupported_models_and_inputs() -> None:
         lean_fit.influence(number_probes=2)
 
 
+def test_feols_predictions_rejects_unsupported_models_and_inputs() -> None:
+    data = pf.get_data().dropna()
+    lean_fit = pf.feols("Y ~ X1 | f1", data=data, lean=True)
+    iv_fit = pf.feols("Y ~ 1 + [X1 ~ Z1] | f1", data=data)
+    glm_fit = pf.feglm("Y ~ X1", data=data, family="gaussian")
+    weighted_fit = pf.feols(
+        "Y ~ X1 | f1",
+        data=data.assign(regression_weights=2.0),
+        weights="regression_weights",
+    )
+    hetero_fit = pf.feols("Y ~ X1 | f1", data=data, vcov="hetero")
+    crv3_fit = pf.feols("Y ~ X1", data=data, vcov={"CRV3": "f1"})
+    multiway_crv1_fit = pf.feols("Y ~ X1", data=data, vcov={"CRV1": "f1 + f2"})
+    iid_fit = pf.feols("Y ~ X1 | f1", data=data, vcov="iid")
+    no_data_fit = pf.feols("Y ~ X1 | f1", data=data, vcov="iid", store_data=False)
+    missing_group_fit = pf.feols(
+        "Y ~ X1 | f1",
+        data=data.assign(
+            group_with_missing=np.where(np.arange(len(data)) == 0, np.nan, 1.0)
+        ),
+        vcov="iid",
+    )
+    fixed_effect_only_fit = pf.feols("Y ~ 1 | f1", data=data, vcov="iid")
+
+    with pytest.raises(ValueError, match="unavailable for lean models"):
+        lean_fit.predictions(number_probes=2)
+    with pytest.raises(NotImplementedError, match="not implemented for IV models"):
+        iv_fit.predictions(number_probes=2)
+    with pytest.raises(NotImplementedError, match="only for OLS models"):
+        glm_fit.predictions(number_probes=2)
+    with pytest.raises(NotImplementedError, match="regression weights"):
+        weighted_fit.predictions(number_probes=2)
+    with pytest.raises(NotImplementedError, match="only IID and CRV1 inference"):
+        hetero_fit.predictions(number_probes=2)
+    with pytest.raises(NotImplementedError, match="only IID and CRV1 inference"):
+        crv3_fit.predictions(number_probes=2)
+    with pytest.raises(NotImplementedError, match="only one-way CRV1 inference"):
+        multiway_crv1_fit.predictions(number_probes=2)
+    with pytest.raises(
+        NotImplementedError, match="without estimated covariate coefficients"
+    ):
+        fixed_effect_only_fit.predictions(number_probes=2)
+    with pytest.raises(ValueError, match="Invalid argument"):
+        iid_fit.predictions(type="invalid", number_probes=2)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="number_probes must be greater than one"):
+        iid_fit.predictions(number_probes=1)
+    with pytest.raises(ValueError, match="non-empty tuple of column names"):
+        iid_fit.predictions(average=(), number_probes=2)
+    with pytest.raises(ValueError, match="non-empty tuple of column names"):
+        iid_fit.predictions(average="f1", number_probes=2)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="Grouping columns must be unique"):
+        iid_fit.predictions(average=("f1", "f1"), number_probes=2)
+    with pytest.raises(ValueError, match="require stored data"):
+        no_data_fit.predictions(average=("f1",), number_probes=2)
+    with pytest.raises(ValueError, match="Grouping columns not found"):
+        iid_fit.predictions(average=("unknown",), number_probes=2)
+    with pytest.raises(ValueError, match="must not contain missing values"):
+        missing_group_fit.predictions(average=("group_with_missing",), number_probes=2)
+
+
 def test_influence_rejects_unit_leverage() -> None:
     leverage_result = RandomizedDiagonalResult(
         estimate=np.array([0.5, 1.0]),
@@ -432,9 +993,11 @@ def test_leverage_is_available_on_fetched_multiple_estimation_model() -> None:
 
     result = fit.leverage(number_probes=16)
     influence_result = fit.influence(number_probes=16)
+    prediction_result = fit.predictions(number_probes=16)
 
     assert result.estimate.shape == (fit._N_rows,)
     assert influence_result.estimate.shape == (fit._N_rows,)
+    assert prediction_result.estimate.shape == (fit._N_rows,)
 
 
 def test_fixed_effect_residual_projection_raises_on_nonconvergence() -> None:

--- a/tests/test_vs_fixest.py
+++ b/tests/test_vs_fixest.py
@@ -4,6 +4,7 @@ import numpy as np
 import pandas as pd
 import pytest
 import rpy2.robjects as ro
+from numpy.typing import NDArray
 
 # rpy2 imports
 from rpy2.robjects.packages import importr
@@ -1705,6 +1706,165 @@ def test_influence_against_fixest_refits():
         err_msg=(
             "JLA leave-one-out influence error exceeds five Monte Carlo standard "
             "errors relative to R fixest refits."
+        ),
+    )
+
+
+def _prediction_averaging_matrix(
+    data: pd.DataFrame,
+    average: bool | tuple[str, ...],
+) -> NDArray[np.float64]:
+    number_observations = data.shape[0]
+    if average is False:
+        return np.eye(number_observations)
+    if average is True:
+        return np.full((1, number_observations), 1 / number_observations)
+
+    group_index = pd.MultiIndex.from_frame(data.loc[:, list(average)])
+    group_indices, unique_groups = pd.factorize(group_index, sort=False)
+    group_membership = (
+        group_indices[None, :] == np.arange(len(unique_groups))[:, None]
+    ).astype(np.float64)
+    return group_membership / group_membership.sum(axis=1, keepdims=True)
+
+
+@pytest.mark.against_r_core
+@pytest.mark.parametrize(
+    "average",
+    [
+        pytest.param(False, id="unit"),
+        pytest.param(True, id="overall_average"),
+        pytest.param(("f1",), id="group_averages"),
+    ],
+)
+def test_prediction_uncertainty_against_r_lm_explicit_fixed_effects(
+    average: bool | tuple[str, ...],
+):
+    """Compare HDFE prediction uncertainty with an explicit-factor R lm."""
+    number_observations = 96
+    observation = np.arange(number_observations)
+    data = pd.DataFrame(
+        {
+            "y": np.cos(observation / 5) + observation / 100,
+            "x": np.sin(observation / 7) + observation / 50,
+            "f1": observation % 4,
+            "f2": (observation // 4) % 6,
+        }
+    )
+
+    fit_py = pf.feols(
+        "y ~ x | f1 + f2",
+        data=data,
+        vcov="iid",
+        demeaner=pf.LsmrDemeaner(
+            fixef_atol=1e-12,
+            fixef_btol=1e-12,
+            preconditioner="additive",
+        ),
+    )
+    fit_r = stats.lm(ro.Formula("y ~ x + factor(f1) + factor(f2)"), data=data)
+
+    result = fit_py.predictions(average=average, number_probes=20_000, seed=4981)
+    design_r = np.asarray(stats.model_matrix(fit_r), dtype=np.float64)
+    covariance_r = np.asarray(stats.vcov(fit_r), dtype=np.float64)
+    prediction_covariance_r = design_r @ covariance_r @ design_r.T
+    averaging_matrix = _prediction_averaging_matrix(data, average)
+    variance_r = np.diag(
+        averaging_matrix @ prediction_covariance_r @ averaging_matrix.T
+    )
+    fitted_r = averaging_matrix @ np.asarray(stats.fitted(fit_r), dtype=np.float64)
+
+    assert result.variance.monte_carlo_standard_errors is not None
+    np.testing.assert_allclose(
+        result.estimate,
+        fitted_r,
+        rtol=1e-10,
+        atol=1e-10,
+        err_msg="PyFixest and R lm fitted values differ.",
+    )
+    np.testing.assert_allclose(
+        result.standard_error,
+        np.sqrt(variance_r),
+        rtol=0.06,
+        atol=0.005,
+        err_msg="JLA prediction standard errors differ from R lm.",
+    )
+    np.testing.assert_array_less(
+        np.abs(result.standard_error**2 - variance_r),
+        5 * result.variance.monte_carlo_standard_errors + 1e-10,
+        err_msg=(
+            "JLA prediction variance error exceeds five Monte Carlo standard "
+            "errors relative to R lm."
+        ),
+    )
+
+
+@pytest.mark.against_r_core
+@pytest.mark.parametrize(
+    "average",
+    [
+        pytest.param(False, id="unit"),
+        pytest.param(True, id="overall_average"),
+        pytest.param(("f1",), id="group_averages"),
+    ],
+)
+def test_crv1_prediction_uncertainty_against_r_fixest_explicit_fixed_effects(
+    average: bool | tuple[str, ...],
+):
+    """Compare HDFE CRV1 prediction variance with explicit-factor R fixest."""
+    number_observations = 96
+    observation = np.arange(number_observations)
+    data = pd.DataFrame(
+        {
+            "y": np.cos(observation / 5) + observation / 100,
+            "x": np.sin(observation / 7) + observation / 50,
+            "f1": observation % 4,
+            "f2": (observation // 4) % 6,
+            "g1": (observation // 3) % 8,
+        }
+    )
+    fit_py = pf.feols(
+        "y ~ x | f1 + f2",
+        data=data,
+        vcov={"CRV1": "g1"},
+        ssc=pf.ssc(k_adj=False, k_fixef="none", G_adj=False),
+        demeaner=pf.LsmrDemeaner(
+            fixef_atol=1e-12,
+            fixef_btol=1e-12,
+            preconditioner="additive",
+        ),
+    )
+    fit_r = fixest.feols(
+        ro.Formula("y ~ x + factor(f1) + factor(f2)"),
+        data=data,
+        cluster=ro.Formula("~g1"),
+        ssc=fixest.ssc(False, "none", False, False, "conventional", "min"),
+    )
+
+    result = fit_py.predictions(average=average, number_probes=20_000, seed=6741)
+    design_r = np.asarray(stats.model_matrix(fit_r), dtype=np.float64)
+    covariance_r = np.asarray(stats.vcov(fit_r), dtype=np.float64)
+    prediction_covariance_r = design_r @ covariance_r @ design_r.T
+    averaging_matrix = _prediction_averaging_matrix(data, average)
+    variance_r = np.diag(
+        averaging_matrix @ prediction_covariance_r @ averaging_matrix.T
+    )
+    fitted_r = averaging_matrix @ np.asarray(stats.fitted(fit_r), dtype=np.float64)
+
+    assert result.variance.monte_carlo_standard_errors is not None
+    np.testing.assert_allclose(
+        result.estimate,
+        fitted_r,
+        rtol=1e-10,
+        atol=1e-10,
+        err_msg="PyFixest and R fixest fitted values differ.",
+    )
+    np.testing.assert_array_less(
+        np.abs(result.variance.estimate - variance_r),
+        5 * result.variance.monte_carlo_standard_errors + 1e-10,
+        err_msg=(
+            "JLA CRV1 prediction variance error exceeds five Monte Carlo "
+            "standard errors relative to R fixest."
         ),
     )
 


### PR DESCRIPTION
Adds `Feols.predictions` for in-sample predictions with prediction uncertainty estimated via the Johnson-Lindenstrauss approximation.

I've deliberately kept the method separate from the existing `Feols.predict` for now. We may want to add the functionality `Feols.predictions` to `Feols.predict` at some point.

Using `Feols.predictions(average=True)` enables us to get average predictions that (approximately) correctly account for absorbed fixed effects:
```python
import marginaleffects
import numpy as np
import statsmodels.formula.api as smf
from statsmodels.datasets import get_rdataset

import pyfixest

data = get_rdataset("airquality", package="datasets", cache=True).data
data["Month"] = data["Month"].astype("string").astype("category")

# explicit factors using statsmodels
fit_factor = smf.ols("Ozone ~ Wind + C(Month)", data=data).fit()
prediction_factor = marginaleffects.avg_predictions(fit_factor)

# fixed-effect regression using pyfixest
number_probes = 100_000
fit_fixed_effects = pyfixest.feols("Ozone ~ Wind | Month", data=data, vcov="iid")
prediction_fixed_effects = fit_fixed_effects.predictions(
    average=True,
    number_probes=number_probes,
)

# compare marginaleffects.avg_predictions against pyfixest's `Feols.predictions(average=True)`
prediction_factor.select("estimate", "std_error").to_numpy().flatten() # array([42.12931034,  2.3163823 ])
np.array([prediction_fixed_effects.estimate, prediction_fixed_effects.standard_error]).flatten()  # array([42.12931034,  2.31629323])
```

See this discussion in the `marginaleffects` package for further context: https://github.com/vincentarelbundock/marginaleffects/issues/1487

