### PR TITLE
perf(imports): defer plotting dependencies

### DIFF
--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -178,6 +178,9 @@ We also removed:
 
 ### Bug Fixes
 
+- Fitted `Feols` models no longer import randomization-inference helpers
+  eagerly. `ritest()` loads its numerical helpers on use, while `plot_ritest()`
+  loads Matplotlib, Seaborn, or Lets-Plot only when plotting.
 - CCV auxiliary fits now retain the original demeaner configuration.
 - IR separation checks now use the configured demeaner backend.
 - Fixes `confint()` when `keep` or `drop` requests coefficients in an order

--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -178,9 +178,9 @@ We also removed:
 
 ### Bug Fixes
 
-- Fitted `Feols` models no longer import randomization-inference helpers
-  eagerly. `ritest()` loads its numerical helpers on use, while `plot_ritest()`
-  loads Matplotlib, Seaborn, or Lets-Plot only when plotting.
+- Fitted models and non-plotting DiD and reporting paths no longer import
+  plotting dependencies eagerly. `ritest()` loads its numerical helpers on use,
+  while Matplotlib, Seaborn, and Lets-Plot load only when plotting.
 - CCV auxiliary fits now retain the original demeaner configuration.
 - IR separation checks now use the configured demeaner backend.
 - Fixes `confint()` when `keep` or `drop` requests coefficients in an order

--- a/pyfixest/did/saturated_twfe.py
+++ b/pyfixest/did/saturated_twfe.py
@@ -1,7 +1,6 @@
 import re
 import warnings
 
-import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 from scipy.stats import norm
@@ -137,6 +136,8 @@ class SaturatedEventStudy(DID):
 
     def iplot(self):
         """Plot DID estimates."""
+        import matplotlib.pyplot as plt
+
         cmp = plt.get_cmap("Set1")
 
         _, ax = plt.subplots(figsize=(10, 6))
@@ -283,6 +284,8 @@ class SaturatedEventStudy(DID):
         -------
         None
         """
+        import matplotlib.pyplot as plt
+
         df_agg = self.aggregate(agg=agg, weighting=weighting)
 
         time = np.array(df_agg.index, dtype=float).astype(float)

--- a/pyfixest/did/visualize.py
+++ b/pyfixest/did/visualize.py
@@ -1,5 +1,11 @@
-import matplotlib.pyplot as plt
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import pandas as pd
+
+if TYPE_CHECKING:
+    import matplotlib.pyplot as plt
 
 
 def panelview(
@@ -251,6 +257,8 @@ def _plot_panelview_output_plot(
     ylim: tuple[float, float] | None = None,
     figsize: tuple | None = (11, 3),
 ) -> plt.Axes:
+    import matplotlib.pyplot as plt
+
     if not ax:
         _, ax = plt.subplots(figsize=figsize)
     for unit_id in data_pivot.index:
@@ -350,6 +358,8 @@ def _plot_panelview(
     noticks: bool | None = False,
     title: str | None = None,
 ) -> plt.Axes:
+    import matplotlib.pyplot as plt
+
     if not ax:
         _, ax = plt.subplots(figsize=figsize)
     cax = ax.matshow(treatment_quilt, cmap="viridis", aspect="auto")

--- a/pyfixest/estimation/models/feols_.py
+++ b/pyfixest/estimation/models/feols_.py
@@ -61,14 +61,6 @@ from pyfixest.estimation.post_estimation.fixed_effects import (
     warn_on_unseen_fixed_effect_levels,
 )
 from pyfixest.estimation.post_estimation.prediction import _compute_prediction_error
-from pyfixest.estimation.post_estimation.ritest import (
-    _HAS_NUMBA,
-    _decode_resampvar,
-    _get_ritest_pvalue,
-    _get_ritest_stats_fast,
-    _get_ritest_stats_slow,
-    _plot_ritest_pvalue,
-)
 from pyfixest.estimation.post_estimation.wald import _wald_statistic
 from pyfixest.utils.dev_utils import (
     DataFrameType,
@@ -2003,6 +1995,14 @@ class Feols(ResultAccessorMixin):
         fit.ritest("X1", reps=1000, store_ritest_statistics=True)
         ```
         """
+        from pyfixest.estimation.post_estimation.ritest import (
+            _HAS_NUMBA,
+            _decode_resampvar,
+            _get_ritest_pvalue,
+            _get_ritest_stats_fast,
+            _get_ritest_stats_slow,
+        )
+
         resampvar = resampvar.replace(" ", "")
         resampvar_, h0_value, hypothesis, test_type = _decode_resampvar(resampvar)
 
@@ -2159,6 +2159,8 @@ class Feols(ResultAccessorMixin):
         A lets_plot or matplotlib figure with the distribution of the Randomization
         Inference Statistics.
         """
+        from pyfixest.estimation.post_estimation.ritest import _plot_ritest_pvalue
+
         if not hasattr(self, "_ritest_statistics"):
             raise ValueError(
                 """

--- a/pyfixest/estimation/post_estimation/ritest.py
+++ b/pyfixest/estimation/post_estimation/ritest.py
@@ -1,28 +1,7 @@
 from importlib import import_module
 
-import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-import seaborn as sns
-
-# Make lets-plot an optional dependency
-try:
-    from lets_plot import (
-        LetsPlot,
-        aes,
-        geom_density,
-        geom_vline,
-        ggplot,
-        ggtitle,
-        theme_bw,
-        xlab,
-        ylab,
-    )
-
-    _HAS_LETS_PLOT = True
-except ImportError:
-    _HAS_LETS_PLOT = False
-
 from scipy.stats import norm
 from tqdm import tqdm
 
@@ -46,10 +25,6 @@ _NUMBA_RITEST_ERROR = (
     "Install it with `pip install pyfixest[numba]`, or pass "
     "`choose_algorithm='slow'`."
 )
-
-# Only setup lets-plot if it's available
-if _HAS_LETS_PLOT:
-    LetsPlot.setup_html()
 
 
 def _get_ritest_stats_slow(
@@ -406,10 +381,23 @@ def _plot_ritest_pvalue(
     y_lab = "Density"
 
     if plot_backend == "lets_plot":
-        if not _HAS_LETS_PLOT:
+        try:
+            from lets_plot import (
+                LetsPlot,
+                aes,
+                geom_density,
+                geom_vline,
+                ggplot,
+                ggtitle,
+                theme_bw,
+                xlab,
+                ylab,
+            )
+        except ImportError:
             print("lets-plot is not installed. Falling back to matplotlib.")
             plot_backend = "matplotlib"
         else:
+            LetsPlot.setup_html()
             plot = (
                 ggplot(df, aes(x="ri_stats"))
                 + geom_density(fill="blue", alpha=0.5)
@@ -419,10 +407,12 @@ def _plot_ritest_pvalue(
                 + xlab(x_lab)
                 + ylab(y_lab)
             )
+            return plot.show()
 
-        return plot.show()
+    if plot_backend == "matplotlib":
+        import matplotlib.pyplot as plt
+        import seaborn as sns
 
-    elif plot_backend == "matplotlib":
         plt.figure(figsize=(10, 6))
         sns.kdeplot(data=df, x="ri_stats", fill=True, color="blue", alpha=0.5)
         plt.axvline(x=sample_stat, color="red", linestyle="--")
@@ -431,8 +421,9 @@ def _plot_ritest_pvalue(
         plt.ylabel(y_lab)
         plt.show()
 
-    else:
-        raise ValueError(f"Unsupported plot backend: {plot_backend}")
+        return None
+
+    raise ValueError(f"Unsupported plot backend: {plot_backend}")
 
 
 def _decode_resampvar(resampvar: str) -> tuple[str, float, str, str]:

--- a/pyfixest/report/visualize.py
+++ b/pyfixest/report/visualize.py
@@ -1,31 +1,11 @@
-import math
+from __future__ import annotations
 
-import matplotlib.pyplot as plt
+import math
+from importlib.util import find_spec
+from typing import TYPE_CHECKING
+
 import numpy as np
 import pandas as pd
-
-# Make lets-plot an optional dependency
-try:
-    from lets_plot import (
-        LetsPlot,
-        aes,
-        coord_flip,
-        element_text,
-        geom_errorbar,
-        geom_hline,
-        geom_point,
-        geom_vline,
-        ggplot,
-        ggsize,
-        ggtitle,
-        position_dodge,
-        theme,
-        ylab,
-    )
-
-    _HAS_LETS_PLOT = True
-except ImportError:
-    _HAS_LETS_PLOT = False
 
 from pyfixest.estimation.FixestMulti_ import FixestMulti
 from pyfixest.estimation.models.feiv_ import Feiv
@@ -39,11 +19,12 @@ from pyfixest.report.utils import (
 )
 from pyfixest.utils.dev_utils import _select_order_coefs
 
-ModelInputType = FixestMulti | Feols | Fepois | Feiv | list[Feols | Fepois | Feiv]
+if TYPE_CHECKING:
+    import matplotlib.pyplot as plt
 
-# Only setup lets-plot if it's available
-if _HAS_LETS_PLOT:
-    LetsPlot.setup_html()
+_HAS_LETS_PLOT = find_spec("lets_plot") is not None
+
+ModelInputType = FixestMulti | Feols | Fepois | Feiv | list[Feols | Fepois | Feiv]
 
 
 def set_figsize(figsize: tuple[int, int] | None, plot_backend: str) -> tuple[int, int]:
@@ -575,6 +556,25 @@ def _coefplot_lets_plot(
     object
         A lets-plot figure.
     """
+    from lets_plot import (
+        LetsPlot,
+        aes,
+        coord_flip,
+        element_text,
+        geom_errorbar,
+        geom_hline,
+        geom_point,
+        geom_vline,
+        ggplot,
+        ggsize,
+        ggtitle,
+        position_dodge,
+        theme,
+        ylab,
+    )
+
+    LetsPlot.setup_html()
+
     df.reset_index(inplace=True)
     df.rename(columns={"fml": "Model"}, inplace=True)
     ub, lb = 1 - alpha / 2, alpha / 2
@@ -673,6 +673,8 @@ def _coefplot_matplotlib(
     matplotlib.figure.Figure
         A matplotlib Figure object.
     """
+    import matplotlib.pyplot as plt
+
     labels_dict = {} if labels is None else labels
 
     if not labels_dict or cat_template is not None:
@@ -798,6 +800,8 @@ def _qplot(
     (Figure, ndarray[Axes])
         Handle to the created figure and axes.
     """
+    import matplotlib.pyplot as plt
+
     if nrow is None and ncol is None:
         nrow = 1
     if (nrow is not None) and (ncol is not None):


### PR DESCRIPTION
## Summary

Keeps optional plotting dependencies out of ordinary estimation and reporting paths. Matplotlib, Seaborn, and Lets-Plot now load only when the plotting operation that needs them is called, including coefficient plots, quantile plots, panel views, saturated DiD plots, and randomization-inference plots.

Randomization-inference numerical helpers also remain deferred until `Feols.ritest()` or `Feols.plot_ritest()` uses them. Public plotting APIs, backend defaults, estimator behavior, and numerical results are unchanged.

With the same persistent Matplotlib cache, a fresh import plus `feols()` fit fell from 4.71s to 2.98s. The eager baseline loaded Matplotlib, Matplotlib pyplot, Seaborn, and Lets-Plot; the new path loaded none of them.

## Verification

- `pixi run test-py`: 804 passed, 13 skipped, 1 xfailed in 58.61s. The first attempt was interrupted by an xdist worker crash while Pandas was partially initialized; the unchanged retry passed.
- `pixi run -e py312-r pytest tests/test_visualize.py tests/test_plots.py -q --no-cov`: 789 passed in 184.46s.
- Existing targeted randomization-inference success/error cases: 4 passed; Matplotlib and Lets-Plot randomization-inference backends exercised manually.
- Both saturated DiD plotting methods exercised headlessly against a fitted event-study model.
- Ruff format/check, mypy, and `git diff --check`: passed.
- Exact-head CI, including canonical R comparisons: in progress.

## Compatibility / risks

No public API, dependency declaration, estimator result, inference result, tolerance, or stored reference changes. Lets-Plot availability is detected without importing it so the existing default-backend selection is preserved.
