### PR TITLE
build(test): persist Matplotlib cache

### DIFF
--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -28,6 +28,8 @@ fit3 = pf.feols("Y ~ X1 + X2 | f1", data = df)
   `feols`, `fepois`, and `feglm` with R `fixest`, and `quantreg` with R
   `quantreg`. The existing estimator-specific R suites remain the authoritative
   reference coverage.
+- Pixi tasks now share a writable project-local Matplotlib configuration
+  directory, avoiding repeated font-cache rebuilds across fresh test processes.
 
 ### Inference Types
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -211,6 +211,9 @@ wildboottest = ">=0.3.2"
 maturin-import-hook = ">=0.2.0"
 maturin = ">=1.8"
 
+[tool.pixi.activation.env]
+MPLCONFIGDIR = "$PIXI_PROJECT_ROOT/.pixi/matplotlib"
+
 [tool.pixi.tasks]
 test-py = { cmd = 'pytest tests -n auto -m "not (extended or against_r_core or against_r_extended or plots or hac)" --cov=pyfixest --cov-report=xml', depends-on = ["_setup"], description = "Quick Python tests (no R, extended, plots, or HAC)" }
 test-py-extended = { cmd = 'pytest tests -n auto -m "extended" --cov=pyfixest --cov-report=xml', depends-on = ["_setup"], description = "Extended Python tests" }


### PR DESCRIPTION
## Summary

Sets `MPLCONFIGDIR` to `$PIXI_PROJECT_ROOT/.pixi/matplotlib` for every Pixi-activated command. Fresh Python and pytest processes in the same checkout now share a writable Matplotlib font cache instead of rebuilding it in temporary directories.

This is independent of #1483: that PR avoids importing plotting libraries on non-plotting paths, while this PR makes the unavoidable first plotting import reusable across later processes.

## Verification

- `pixi run -e lint prek run check-toml --files pyproject.toml`: passed.
- Pixi expanded `MPLCONFIGDIR` to the current worktree's `.pixi/matplotlib` directory exactly.
- The directory was created writable and is ignored by Git.
- Two fresh Python processes importing Matplotlib pyplot: 26.332s while creating the cache, then 0.335s while reusing it.
- `git diff --check`: passed.
- Exact-head CI: pending.

## Compatibility / risks

No dependency, Python API, estimator, inference, test selection, or numerical behavior changes. The cache is local to each checkout under the already ignored `.pixi` directory. A checkout still pays the initial font-cache build once; subsequent Pixi processes reuse it.
