### PR TITLE
test: accelerate fixest feedback

### DIFF
--- a/.agents/skills/change-verification/SKILL.md
+++ b/.agents/skills/change-verification/SKILL.md
@@ -13,13 +13,15 @@ Resolve and record the actual PR base and merge base as described in
 `docs/developer/git-and-pr-style.md`; do not assume local `master` is current.
 Inspect every changed path against that base and classify the change using the
 selection matrix in `docs/developer/testing.md`. Start with targeted tests and
-changed-file format/lint/type checks, then run the PR baseline and affected
-domain suites.
+changed-file format/lint/type checks. Once the implementation stabilizes, run
+the selected broader baseline once and assign each required long check to a
+local run or exact-head CI.
 
 - Numerical/API changes require the relevant public integration tests and
   external-reference suite. `test-py` is a Python-only regression baseline and
   never substitutes for an external numerical comparison. Use the fast R suite
-  for edit feedback before the applicable canonical R suite.
+  for edit feedback; produce canonical evidence after stabilization, locally or
+  in exact-head CI.
 - HAC changes require the single-threaded HAC suite.
 - Rust changes require kernel/reference tests and platform CI.
 - Performance-sensitive changes require before/after evidence.
@@ -43,6 +45,12 @@ Unknown paths require the conservative PR baseline. For a stack, repeat the
 selection for each layer against its immediate parent, then inspect the
 cumulative top against the trunk.
 
+Complete the required edit and handoff checks locally. A long check listed as
+merge evidence may be deferred to exact-head CI when a local run would add no
+diagnostic value. Defer only after the targeted checks pass, and identify the
+check, destination, and head under test. Never defer a failing check or a
+targeted check needed to understand unresolved risk.
+
 ## Report truthfully
 
 For every applicable check record:
@@ -53,8 +61,9 @@ For every applicable check record:
 - reason and destination for a deferred check.
 
 Run long domain suites after the design stabilizes. A deferred or CI-only check
-is not a pass. Do not claim completion while a mandatory local check is
-unreported or failing.
+is not a pass. Do not claim implementation handoff while required local checks
+are unreported or failing, and do not claim merge readiness until all required
+exact-head evidence has passed.
 
 Write this report directly in the handoff or PR body. Do not introduce a
 generated verification artifact unless the task specifically requires one.

--- a/.agents/skills/numerical-validation/SKILL.md
+++ b/.agents/skills/numerical-validation/SKILL.md
@@ -47,13 +47,13 @@ estimator-specific tolerance, and extend the nearest permanent matrix before
 adding a new test function or file.
 
 Keep the permanent test parametrized through the public API where possible and
-keep its runtime suitable for regular use. Live R comparisons must run through
-rpy2 inside pytest. Register every rpy2-importing test file in
+keep its runtime suitable for regular CI use. Live R comparisons must run
+through rpy2 inside pytest. Register every rpy2-importing test file in
 `tests/conftest.py` and use the strict R marker matching dependency
-availability. If the external implementation is too slow or cannot run
-reliably in the test environment, store a small deterministic result (for
-example, CSV) and commit the code that generates it plus the exact software
-version.
+availability. Do not replace an available live reference merely to shorten the
+edit loop; first select affected live cases or use the fast matrix. Follow the
+stored-reference criteria in `docs/developer/testing.md` when live execution is
+unavailable, unreliable, or impractical.
 
 Use R `fixest` as the default reference for `feols`, `fepois`, and `feglm`.
 Use R `quantreg` for `quantreg`. The fast direct matrix is available as:
@@ -62,5 +62,7 @@ Use R `quantreg` for `quantreg`. The fast direct matrix is available as:
 pixi run -e py312-r test-r-fixest-fast
 ```
 
-Use the fast suite while editing. It does not replace or establish permanent
-estimator-specific coverage.
+Use the fast suite while editing. After the implementation stabilizes, produce
+the affected canonical evidence locally or in exact-head CI. The fast suite
+does not replace or establish permanent estimator-specific coverage and is not
+complete merge evidence.

--- a/.agents/skills/pr-draft-summary/SKILL.md
+++ b/.agents/skills/pr-draft-summary/SKILL.md
@@ -5,8 +5,10 @@ description: Prepare reviewer-ready pyfixest single or stacked draft PRs after h
 
 # Prepare the review handoff
 
-Use this skill only after implementation, history curation, and required local
-verification are complete. Read `docs/developer/git-and-pr-style.md`.
+Use this skill only after implementation is stable, any required history
+curation is complete, and required edit or handoff verification is complete.
+Required long checks may still be running in exact-head CI when clearly
+reported. Read `docs/developer/git-and-pr-style.md`.
 
 ## Choose the delivery shape
 
@@ -42,8 +44,10 @@ For a stack, identify the immediate parent only when it is not obvious from the
 PR base. Do not force estimator-specific boilerplate into documentation, CI, or
 maintenance PRs.
 
-Submit new PRs as drafts. Mark a layer ready only when required checks pass or
-clearly identified long checks are running in CI. Require human-maintainer
-approval on every layer.
+Submit new PRs as drafts. A draft may be handed off while clearly identified
+long checks run in exact-head CI. Mark a layer ready for review only when
+required checks pass or those long checks are visibly running. Do not describe
+the change as merge-ready until every required exact-head check passes. Require
+human-maintainer approval on every layer.
 
 Stop at handoff. Do not merge the PR or invoke `gh stack merge`.

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -52,7 +52,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test-task: [test-r-core, test-r-extended, test-r-fixest, test-r-hac]
+        test-task: [test-r-core-other, test-r-extended, test-r-fixest, test-r-hac]
     steps:
       - uses: actions/checkout@v7
 
@@ -63,6 +63,10 @@ jobs:
           cache-write: ${{ github.event_name == 'push' && github.ref_name == 'master' }}
           frozen: true
           environments: py312-r
+
+      - name: Run fast R preflight
+        if: matrix.test-task == 'test-r-fixest'
+        run: pixi run -e py312-r test-r-fixest-fast
 
       - name: Run ${{ matrix.test-task }}
         run: pixi run -e py312-r ${{ matrix.test-task }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,21 +147,20 @@ fixture boundary.
 Use `pixi run` for every Python, pytest, lint, docs, and R command. Bare tools
 may miss dependencies or the compiled extension.
 
-- Edit loop: targeted tests with `-x -q --no-cov` and changed-file lint/type
-  checks.
-- PR baseline: `pixi run test-py` plus relevant lint/type checks. This is a
-  Python-only regression suite; it does not establish numerical agreement with
-  R or other external software.
-- Domain suites: R, HAC, no-JIT, docs, plots, Rust, or extended tests selected
-  by the changed subsystem. Estimation and inference changes require the
-  applicable external-reference suite in addition to `test-py`.
-- Full available suite: `test-all`; exhaustive evidence also requires the
-  CRAN-only R dependencies, applicable platform CI, and relevant benchmarks.
+- Edit feedback: targeted tests with `-x -q --no-cov`, changed-file lint/type
+  checks, and targeted or fast live-R cases for numerical work.
+- Stabilized implementation: run the selected broader baseline once.
+  `test-py` remains Python-only and does not establish numerical agreement.
+- Merge evidence: affected R, HAC, no-JIT, docs, plots, Rust, extended, and
+  platform checks must pass on the exact PR head. A long check may be deferred
+  to exact-head CI at handoff, but deferred is not passed or merge-ready.
+- Exhaustive or release evidence: `test-all` plus the CRAN-only R dependencies,
+  applicable platform CI, and relevant benchmarks.
 
-Long suites can take tens of minutes or more. Run narrow checks while editing,
-then required domain suites once the change stabilizes. Report every applicable
-check as passed, failed, deferred, or not run; never imply that a deferred check
-passed.
+Long suites can take tens of minutes or more. Do not repeatedly run
+`test-r-fixest`, `test-r-core`, or `test-all` while editing. Report every
+applicable check as passed, failed, deferred, or not run; never imply that a
+deferred check passed.
 
 Always update `docs/changelog.qmd`. Documentation ships with the feature. New
 public functions/classes require quartodoc registration; user workflows usually
@@ -205,10 +204,10 @@ qualitative and depends on hardware and caches; report the actual elapsed time.
 | Command | Purpose | Typical scale |
 |---|---|---|
 | `pixi run -e py312-r pytest tests/test_<feature>.py -x -q --no-cov` | Test the changed seam without the repository coverage report | Seconds to a few minutes |
-| `pixi run -e py312-r test-r-fixest-fast` | Compare representative `feols`, `fepois`, and `feglm` cases with R `fixest`, and `quantreg` with R `quantreg` | Seconds to a few minutes |
+| `pixi run -e py312-r test-r-fixest-fast` | Get edit feedback from representative `feols`, `fepois`, and `feglm` comparisons with R `fixest`, and `quantreg` with R `quantreg` | Seconds to a few minutes |
 | `pixi run test-py` | Run the broad Python-only regression suite; this is not an external numerical comparison | Minutes |
-| `pixi run -e py312-r test-r-fixest` | Run the canonical `tests/test_vs_fixest.py` comparison matrix | Minutes to tens of minutes |
-| `pixi run -e py312-r test-r-core` | Run all canonical comparisons with conda-forge R packages | May take tens of minutes |
+| `pixi run -e py312-r test-r-fixest` | Produce canonical `tests/test_vs_fixest.py` merge evidence | Minutes to tens of minutes |
+| `pixi run -e py312-r test-r-core` | Produce aggregate canonical comparison evidence with conda-forge R packages | May take tens of minutes |
 | `pixi run -e py312-r test-r-hac` | Run single-threaded HAC comparisons against R | May take tens of minutes |
 | `pixi run -e py312-r test-r-extended` | Run CRAN-only reference tests after installing their dependencies | May take tens of minutes or longer |
 | `pixi run -e py312-r test-all` | Run every test supported by the current Python and R environment | Potentially substantially longer |

--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -28,6 +28,10 @@ fit3 = pf.feols("Y ~ X1 + X2 | f1", data = df)
   `feols`, `fepois`, and `feglm` with R `fixest`, and `quantreg` with R
   `quantreg`. The existing estimator-specific R suites remain the authoritative
   reference coverage.
+- R CI now runs disjoint canonical shards with the fast live-R matrix as a
+  preflight. Contributor guidance separates repeatable edit feedback from
+  exact-head merge evidence, so long suites can run once after stabilization or
+  in CI without weakening the merge gate.
 
 ### Inference Types
 

--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -28,14 +28,10 @@ fit3 = pf.feols("Y ~ X1 + X2 | f1", data = df)
   `feols`, `fepois`, and `feglm` with R `fixest`, and `quantreg` with R
   `quantreg`. The existing estimator-specific R suites remain the authoritative
   reference coverage.
-- R CI now runs disjoint canonical shards with the fast live-R matrix as a
-  preflight. Contributor guidance separates repeatable edit feedback from
-  exact-head merge evidence, so long suites can run once after stabilization or
-  in CI without weakening the merge gate.
-- `feols` backend parity now runs as an exhaustive Python-only matrix over
-  formulas, factor representations, weights, missing-data modes, and inference
-  types. The canonical live-R matrix exercises the reference backend directly,
-  avoiding redundant R fits while preserving fit-time inference validation.
+- We reorganize the tests against `fixest` for faster test feedback. By
+  default, we test only the default demeaner backend against `fixest` through
+  an integration test. All other demeaner backends are tested in a separate
+  workflow.
 
 ### Inference Types
 

--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -32,6 +32,10 @@ fit3 = pf.feols("Y ~ X1 + X2 | f1", data = df)
   preflight. Contributor guidance separates repeatable edit feedback from
   exact-head merge evidence, so long suites can run once after stabilization or
   in CI without weakening the merge gate.
+- `feols` backend parity now runs as an exhaustive Python-only matrix over
+  formulas, factor representations, weights, missing-data modes, and inference
+  types. The canonical live-R matrix exercises the reference backend directly,
+  avoiding redundant R fits while preserving fit-time inference validation.
 
 ### Inference Types
 

--- a/docs/developer/testing.md
+++ b/docs/developer/testing.md
@@ -1,26 +1,29 @@
 # Testing and verification
 
-Pyfixest testing is risk-based: run the narrowest useful checks while editing,
-then the affected long-running suites after the change stabilizes. Always use
-`pixi run`; bare Python or pytest may not have the compiled extension or the
-right optional dependencies.
+Pyfixest testing is risk-based: use fast checks while editing, broaden the
+evidence once the implementation stabilizes, and require the affected
+long-running suites before merge. Always use `pixi run`; bare Python or pytest
+may not have the compiled extension or the right optional dependencies.
 
 ## Runtime tiers
 
 Runtime labels are qualitative because machine, compiler cache, and test
 selection affect wall time.
 
-| Tier | Purpose | Typical scale | Examples |
+| Stage | Purpose | Typical scale | Examples |
 |---|---|---|---|
-| Edit | Fast feedback on the changed seam | Seconds to a few minutes | targeted pytest, changed-file Ruff/mypy |
-| PR baseline | Broad Python regression check | Minutes | `pixi run test-py` |
-| Domain/special | Validate an affected environment or reference | May take tens of minutes | R, HAC, no-JIT, docs, plots, Rust |
-| Full available suite | All tests supported by the current environment | Potentially substantially longer | `test-all`, platform CI, benchmarks |
+| Edit feedback | Exercise the changed seam repeatedly | Seconds to a few minutes | targeted pytest, targeted or fast live-R checks, changed-file Ruff/mypy |
+| Stabilized implementation | Broaden local confidence once | Minutes | selected subsystem checks, `pixi run test-py` when required |
+| Merge evidence | Validate the exact PR head in affected environments | May take tens of minutes | canonical R, HAC, no-JIT, docs, plots, Rust, platform CI |
+| Exhaustive or release | Exercise everything available | Potentially substantially longer | `test-all`, CRAN-only dependencies, platform CI, benchmarks |
 
-Run edit checks repeatedly. Run required domain checks once the design is
-stable. A verification report records actual elapsed time and reports every
-applicable check as passed, failed, deferred, or not run. Deferred is never
-equivalent to passed.
+Run edit checks repeatedly, but do not repeatedly launch `test-r-fixest`,
+`test-r-core`, or `test-all` while iterating. Use a targeted test or
+`test-r-fixest-fast` instead. Once the design is stable, run the selected
+baseline once. A required long check may be deferred to exact-head CI at
+implementation handoff when the report names the check and destination.
+Deferred is never equivalent to passed, and the change is not merge-ready
+until all required merge evidence is green.
 
 `test-py` is the broad Python-only regression baseline. It does not compare
 results with R or another external implementation, so it cannot establish
@@ -39,13 +42,16 @@ platform CI and benchmarks.
 # Targeted, without the repository-wide coverage report
 pixi run -e py312-r pytest tests/test_<feature>.py -x -q --no-cov
 
+# Targeted live-R edit feedback
+pixi run -e py312-r pytest -q tests/test_vs_r_fast.py --no-cov -k feols
+pixi run -e py312-r test-r-fixest-fast
+
 # Python baseline
 pixi run test-py
 
-# External references
+# Canonical external-reference evidence
 pixi run -e py312-r test-r-core
 pixi run -e py312-r test-r-fixest
-pixi run -e py312-r test-r-fixest-fast
 pixi run -e py312-r test-r-hac
 pixi run -e py312-r test-r-extended
 
@@ -66,9 +72,15 @@ pixi run docs-build
 pixi run docs-render
 ```
 
+`test-r-core` remains the convenient local aggregate for all canonical
+conda-forge R comparisons. CI partitions that population into
+`test-r-fixest` and the internal `test-r-core-other` shard so
+`tests/test_vs_fixest.py` is not executed twice. The fast suite runs once as a
+preflight in the canonical `fixest` job.
+
 ## Selection matrix
 
-| Change | Required local evidence | Long or CI evidence |
+| Change | Required edit or handoff evidence | Merge or long evidence |
 |---|---|---|
 | Public docstrings or API-reference configuration | `git diff --check`; execute changed examples; `docs-build` | affected reference-page render when applicable |
 | Content under `docs/` | `git diff --check`; execute changed examples; render the affected page when practical | `docs-render` only for site-wide configuration, navigation, templates, or cross-page changes |
@@ -95,14 +107,14 @@ For prose under `docs/`, prefer an affected-page render. Reserve the full
 
 Every new estimator requires a permanent comparison with existing software.
 Prefer live R `fixest`, another established R package, or a well-established
-Python package. Use
-`against_r_core` when the reference is available on conda-forge and
-`against_r_extended` for CRAN-only dependencies. Stored Stata or other
-verified output is acceptable when its generator script and software version
-are committed. Keep reference tests fast enough for regular use. If the
-external implementation is too slow or cannot run reliably in the test
-environment, store a small deterministic result and commit the code that
-generates it plus the exact software version.
+Python package. Use `against_r_core` when the reference is available on
+conda-forge and `against_r_extended` for CRAN-only dependencies. Do not replace
+an available live reference merely to avoid running the complete canonical
+suite while editing; first select the affected live cases or use the fast
+matrix. Store a small deterministic result only when the external
+implementation is unavailable or unreliable in the test environment, or when
+measured per-case runtime makes regular execution impractical. Commit its
+generator and exact software version with the stored output.
 
 Any test file importing rpy2 must be listed in `_rpy2_test_files` in
 `tests/conftest.py` so non-R environments skip it safely. HAC tests use
@@ -119,8 +131,8 @@ directly against R `fixest` for `feols`, `fepois`, and `feglm`, and R
 `quantreg` for `quantreg`. To select one entry point while editing, run, for
 example,
 `pixi run -e py312-r pytest -q tests/test_vs_r_fast.py --no-cov -k feols`.
-This is an edit check, not a second permanent reference framework; extend the
-canonical suites when a change needs new coverage.
+This is edit feedback, not a second permanent reference framework or complete
+merge evidence; extend the canonical suites when a change needs new coverage.
 
 The compact matrix covers the main comparison axes at least once:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -267,17 +267,18 @@ outputs = ["tests/data/ritest_results.csv"]
 env = { RETICULATE_PYTHON = "$CONDA_PREFIX/bin/python" }
 
 [tool.pixi.feature.r.tasks.test-r-hac]
-cmd = "pytest tests -v -n auto -m hac"
+cmd = "pytest tests -v -n auto -m hac --durations=20 --durations-min=0.25"
 depends-on = ["_setup"]
 description = "HAC standard error tests vs R"
 env = { OMP_NUM_THREADS = "1", OPENBLAS_NUM_THREADS = "1", MKL_NUM_THREADS = "1", VECLIB_MAXIMUM_THREADS = "1", NUMEXPR_NUM_THREADS = "1" }
 
 [tool.pixi.feature.r.tasks]
 test-all = { cmd = "pytest -rs -n auto --cov-report=term tests", depends-on = ["_setup"], description = "Run all tests available in the current Python + R environment" }
-test-r-core = { cmd = 'pytest -rs -n auto tests -m "against_r_core and not fast_r" --cov=pyfixest --cov-report=xml', depends-on = ["_setup"], description = "Canonical tests against R packages available on conda-forge" }
-test-r-extended = { cmd = 'pytest -rs -n auto tests -m "against_r_extended" --cov=pyfixest --cov-report=xml', depends-on = ["_setup"], description = "Tests against R (requires manual Rscript r_test_requirements.R)" }
-test-r-fixest = { cmd = "pytest -rs -n auto tests/test_vs_fixest.py --cov=pyfixest --cov-report=xml", depends-on = ["_setup"], description = "Run test_vs_fixest.py" }
-test-r-fixest-fast = { cmd = "pytest -rs -q tests/test_vs_r_fast.py --no-cov", depends-on = ["_setup"], description = "Fast direct comparisons with R fixest and quantreg" }
+test-r-core = { cmd = 'pytest -rs -n auto tests -m "against_r_core and not fast_r" --cov=pyfixest --cov-report=xml --durations=20 --durations-min=0.25', depends-on = ["_setup"], description = "Canonical tests against R packages available on conda-forge" }
+test-r-core-other = { cmd = 'pytest -rs -n auto tests --ignore=tests/test_vs_fixest.py -m "against_r_core and not fast_r" --cov=pyfixest --cov-report=xml --durations=20 --durations-min=0.25', depends-on = ["_setup"], description = "CI shard for canonical conda-forge R tests outside test_vs_fixest.py" }
+test-r-extended = { cmd = 'pytest -rs -n auto tests -m "against_r_extended" --cov=pyfixest --cov-report=xml --durations=20 --durations-min=0.25', depends-on = ["_setup"], description = "Tests against R (requires manual Rscript r_test_requirements.R)" }
+test-r-fixest = { cmd = "pytest -rs -n auto tests/test_vs_fixest.py --cov=pyfixest --cov-report=xml --durations=20 --durations-min=0.25", depends-on = ["_setup"], description = "Run test_vs_fixest.py" }
+test-r-fixest-fast = { cmd = "pytest -rs -q tests/test_vs_r_fast.py --no-cov --durations=20 --durations-min=0.05", depends-on = ["_setup"], description = "Fast direct comparisons with R fixest and quantreg" }
 
 # -- docs feature ----------------------------------------------------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -267,18 +267,18 @@ outputs = ["tests/data/ritest_results.csv"]
 env = { RETICULATE_PYTHON = "$CONDA_PREFIX/bin/python" }
 
 [tool.pixi.feature.r.tasks.test-r-hac]
-cmd = "pytest tests -v -n auto -m hac --durations=20 --durations-min=0.25"
+cmd = "pytest tests -v -n auto -m hac"
 depends-on = ["_setup"]
 description = "HAC standard error tests vs R"
 env = { OMP_NUM_THREADS = "1", OPENBLAS_NUM_THREADS = "1", MKL_NUM_THREADS = "1", VECLIB_MAXIMUM_THREADS = "1", NUMEXPR_NUM_THREADS = "1" }
 
 [tool.pixi.feature.r.tasks]
 test-all = { cmd = "pytest -rs -n auto --cov-report=term tests", depends-on = ["_setup"], description = "Run all tests available in the current Python + R environment" }
-test-r-core = { cmd = 'pytest -rs -n auto tests -m "against_r_core and not fast_r" --cov=pyfixest --cov-report=xml --durations=20 --durations-min=0.25', depends-on = ["_setup"], description = "Canonical tests against R packages available on conda-forge" }
-test-r-core-other = { cmd = 'pytest -rs -n auto tests --ignore=tests/test_vs_fixest.py -m "against_r_core and not fast_r" --cov=pyfixest --cov-report=xml --durations=20 --durations-min=0.25', depends-on = ["_setup"], description = "CI shard for canonical conda-forge R tests outside test_vs_fixest.py" }
-test-r-extended = { cmd = 'pytest -rs -n auto tests -m "against_r_extended" --cov=pyfixest --cov-report=xml --durations=20 --durations-min=0.25', depends-on = ["_setup"], description = "Tests against R (requires manual Rscript r_test_requirements.R)" }
-test-r-fixest = { cmd = "pytest -rs -n auto tests/test_vs_fixest.py --cov=pyfixest --cov-report=xml --durations=20 --durations-min=0.25", depends-on = ["_setup"], description = "Run test_vs_fixest.py" }
-test-r-fixest-fast = { cmd = "pytest -rs -q tests/test_vs_r_fast.py --no-cov --durations=20 --durations-min=0.05", depends-on = ["_setup"], description = "Fast direct comparisons with R fixest and quantreg" }
+test-r-core = { cmd = 'pytest -rs -n auto tests -m "against_r_core and not fast_r" --cov=pyfixest --cov-report=xml', depends-on = ["_setup"], description = "Canonical tests against R packages available on conda-forge" }
+test-r-core-other = { cmd = 'pytest -rs -n auto tests --ignore=tests/test_vs_fixest.py -m "against_r_core and not fast_r" --cov=pyfixest --cov-report=xml', depends-on = ["_setup"], description = "CI shard for canonical conda-forge R tests outside test_vs_fixest.py" }
+test-r-extended = { cmd = 'pytest -rs -n auto tests -m "against_r_extended" --cov=pyfixest --cov-report=xml', depends-on = ["_setup"], description = "Tests against R (requires manual Rscript r_test_requirements.R)" }
+test-r-fixest = { cmd = "pytest -rs -n auto tests/test_vs_fixest.py --cov=pyfixest --cov-report=xml", depends-on = ["_setup"], description = "Run test_vs_fixest.py" }
+test-r-fixest-fast = { cmd = "pytest -rs -q tests/test_vs_r_fast.py --no-cov", depends-on = ["_setup"], description = "Fast direct comparisons with R fixest and quantreg" }
 
 # -- docs feature ----------------------------------------------------------------------
 

--- a/tests/_feols_test_cases.py
+++ b/tests/_feols_test_cases.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+ols_fmls = (
+    "Y~X1",
+    "Y~X1+X2",
+    "Y~X1|f2",
+    "Y~X1|f2+f3",
+    "Y ~ X1 + exp(X2)",
+    "Y ~ X1 + C(f1)",
+    "Y ~ X1 + i(f1, ref = 1)",
+    "Y ~ X1 + i(f2, ref = 2.0)",
+    "Y ~ X1 + C(f1) + C(f2)",
+    "Y ~ X1 + C(f1) | f2",
+    "Y ~ X1 + i(f1, ref = 3.0) | f2",
+    "Y ~ X1 + C(f1) | f2 + f3",
+    "Y ~ X1 + i(f1, ref = 1) | f2 + f3",
+    "Y ~ X1 + i(f1) + i(f2)",
+    "Y ~ X1 + i(f1, ref = 1) + i(f2, ref = 2)",
+    # C():C() translation is not implemented yet.
+    # "Y ~ X1 + C(f1):C(fe2)",
+    # "Y ~ X1 + C(f1):C(fe2) | f3",
+    "Y ~ X1 + X2:f1",
+    "Y ~ X1 + X2:f1 | f3",
+    "Y ~ X1 + X2:f1 | f3 + f1",
+    # These currently make fepois prohibitively slow.
+    # "log(Y) ~ X1:X2 | f3 + f1",
+    # "log(Y) ~ log(X1):X2 | f3 + f1",
+    # "Y ~  X2 + exp(X1) | f3 + f1",
+    "Y ~ X1 + i(f1,X2)",
+    "Y ~ X1 + i(f1,X2) + i(f2, X2)",
+    "Y ~ X1 + i(f1,X2, ref =1) + i(f2)",
+    "Y ~ X1 + i(f1,X2, ref =1) + i(f2, X1, ref =2)",
+    "Y ~ X1 + i(f2,X2)",
+    "Y ~ X1 + i(f1,X2) | f2",
+    "Y ~ X1 + i(f1,X2) | f2 + f3",
+    "Y ~ X1 + i(f1,X2, ref=1.0)",
+    "Y ~ X1 + i(f2,X2, ref=2.0)",
+    "Y ~ X1 + i(f1,X2, ref=3.0) | f2",
+    "Y ~ X1 + i(f1,X2, ref=4.0) | f2 + f3",
+    # C():X and C():C() translation are not implemented yet.
+    # "Y ~ C(f1):X2",
+    # "Y ~ C(f1):C(f2)",
+    "Y ~ X1 + I(X2 ** 2)",
+    "Y ~ X1 + I(X1 ** 2) + I(X2**4)",
+    "Y ~ X1*X2",
+    "Y ~ X1*X2 | f1+f2",
+    # Formulaic does not implement the former X1/X2 translation yet.
+    # "Y ~ X1/X2",
+    # "Y ~ X1/X2 | f1+f2",
+    "Y ~ X1 + poly(X2, 2) | f1",
+)
+
+
+ols_but_not_poisson_fml = (
+    "log(Y) ~ X1",
+    "Y~X1|f2:f3",
+    "Y~X1|f1 + f2:f3",
+    "Y~X1|f2:f3:f1",
+)
+
+
+ALL_F3_TYPES = ("str", "object", "int", "categorical", "float")
+
+
+def _deduplicate(items: tuple[str, ...]) -> tuple[str, ...]:
+    return tuple(dict.fromkeys(items))
+
+
+FEOLS_FORMULAS = _deduplicate(ols_fmls + ols_but_not_poisson_fml)
+
+# Every formula uses the historical string representation. Formulas involving f3
+# additionally exercise every supported pandas representation without collecting
+# irrelevant combinations that would immediately skip.
+FEOLS_FORMULA_F3_CASES = (
+    *((fml, "str") for fml in FEOLS_FORMULAS),
+    *(
+        (fml, f3_type)
+        for fml in FEOLS_FORMULAS
+        if "f3" in fml
+        for f3_type in ALL_F3_TYPES[1:]
+    ),
+)
+
+
+def convert_f3(data: pd.DataFrame, f3_type: str) -> pd.DataFrame:
+    """Convert f3 to the requested representation."""
+    if f3_type == "categorical":
+        data["f3"] = pd.Categorical(data["f3"])
+    elif f3_type == "int":
+        data["f3"] = data["f3"].astype(float).astype(np.int32)
+    elif f3_type == "str":
+        data["f3"] = data["f3"].astype(str)
+    elif f3_type == "object":
+        data["f3"] = data["f3"].astype(object)
+    elif f3_type == "float":
+        data["f3"] = data["f3"].astype(float)
+    else:  # pragma: no cover - the case matrix is closed above
+        raise ValueError(f"Unsupported f3_type: {f3_type}")
+    return data

--- a/tests/_feols_test_cases.py
+++ b/tests/_feols_test_cases.py
@@ -100,3 +100,16 @@ def convert_f3(data: pd.DataFrame, f3_type: str) -> pd.DataFrame:
     else:  # pragma: no cover - the case matrix is closed above
         raise ValueError(f"Unsupported f3_type: {f3_type}")
     return data
+
+
+def build_feols_data_variants(
+    base: pd.DataFrame,
+) -> dict[tuple[bool, str], pd.DataFrame]:
+    """Build the missing-data and factor-type inputs shared by parity suites."""
+    variants = {}
+    for dropna in (False, True):
+        for f3_type in ALL_F3_TYPES:
+            data = base.dropna() if dropna else base.copy()
+            data.where(data != "nan", np.nan, inplace=True)
+            variants[(dropna, f3_type)] = convert_f3(data, f3_type)
+    return variants

--- a/tests/test_demeaner_backends.py
+++ b/tests/test_demeaner_backends.py
@@ -1,0 +1,281 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import pyfixest as pf
+from tests._feols_test_cases import FEOLS_FORMULA_F3_CASES, convert_f3
+from tests._torch_test_utils import torch_param
+
+pytestmark = [
+    pytest.mark.filterwarnings(
+        "ignore:The torch LSMR demeaner backend is experimental:UserWarning"
+    ),
+    pytest.mark.filterwarnings(
+        "ignore:No GPU available .* torch demeaning will run on CPU:UserWarning"
+    ),
+    pytest.mark.filterwarnings(
+        "ignore:Sparse CSR tensor support is in beta state:UserWarning"
+    ),
+]
+
+
+@dataclass(frozen=True)
+class BackendCase:
+    name: str
+    demeaner: pf.MapDemeaner | pf.LsmrDemeaner
+    coef_tol: float
+    predict_tol: float
+    resid_tol: float
+    inference_tol: float
+    tstat_tol: float
+
+
+REFERENCE_DEMEANER = pf.MapDemeaner(backend="rust")
+
+BACKEND_CASES = [
+    pytest.param(
+        BackendCase(
+            name="numba",
+            demeaner=pf.MapDemeaner(backend="numba"),
+            coef_tol=1e-8,
+            predict_tol=1e-6,
+            resid_tol=1e-6,
+            inference_tol=1e-7,
+            tstat_tol=1e-6,
+        ),
+        id="numba",
+    ),
+    pytest.param(
+        BackendCase(
+            name="within_additive",
+            demeaner=pf.LsmrDemeaner(preconditioner="additive"),
+            coef_tol=1e-8,
+            predict_tol=1e-6,
+            resid_tol=1e-6,
+            # Full covariance matrices amplify LSMR stopping error in large
+            # factor expansions more than the historical X1 diagonal check.
+            inference_tol=1e-6,
+            tstat_tol=1e-6,
+        ),
+        id="within_additive",
+    ),
+    pytest.param(
+        BackendCase(
+            name="within_diagonal",
+            demeaner=pf.LsmrDemeaner(preconditioner="diagonal"),
+            coef_tol=1e-8,
+            predict_tol=1e-6,
+            resid_tol=1e-6,
+            # Full covariance matrices amplify LSMR stopping error in large
+            # factor expansions more than the historical X1 diagonal check.
+            inference_tol=1e-6,
+            tstat_tol=1e-6,
+        ),
+        id="within_diagonal",
+    ),
+    torch_param(
+        BackendCase(
+            name="torch",
+            demeaner=pf.LsmrDemeaner(backend="torch", device="auto"),
+            coef_tol=1e-8,
+            predict_tol=5e-5,
+            resid_tol=5e-5,
+            inference_tol=1e-6,
+            tstat_tol=1e-5,
+        ),
+        id="torch",
+    ),
+    torch_param(
+        BackendCase(
+            name="torch_cpu",
+            demeaner=pf.LsmrDemeaner(backend="torch", device="cpu"),
+            coef_tol=1e-8,
+            predict_tol=5e-5,
+            resid_tol=5e-5,
+            inference_tol=1e-6,
+            tstat_tol=1e-5,
+        ),
+        id="torch_cpu",
+    ),
+    torch_param(
+        BackendCase(
+            name="torch_mps",
+            demeaner=pf.LsmrDemeaner(
+                backend="torch", precision="float32", device="mps"
+            ),
+            coef_tol=5e-6,
+            predict_tol=2e-4,
+            resid_tol=2e-4,
+            inference_tol=1e-5,
+            tstat_tol=1e-5,
+        ),
+        id="torch_mps",
+        require="mps",
+    ),
+    torch_param(
+        BackendCase(
+            name="torch_cuda",
+            demeaner=pf.LsmrDemeaner(backend="torch", device="cuda"),
+            coef_tol=1e-8,
+            predict_tol=5e-5,
+            resid_tol=5e-5,
+            inference_tol=1e-6,
+            tstat_tol=1e-5,
+        ),
+        id="torch_cuda",
+        require="cuda",
+    ),
+    torch_param(
+        BackendCase(
+            name="torch_cuda32",
+            demeaner=pf.LsmrDemeaner(
+                backend="torch", precision="float32", device="cuda"
+            ),
+            coef_tol=5e-6,
+            predict_tol=2e-4,
+            resid_tol=2e-4,
+            inference_tol=1e-5,
+            tstat_tol=1e-5,
+        ),
+        id="torch_cuda32",
+        require="cuda",
+    ),
+]
+
+
+@pytest.fixture(scope="module")
+def backend_data() -> dict[tuple[bool, str], pd.DataFrame]:
+    base = pf.get_data(
+        N=1000,
+        seed=76540251,
+        beta_type="2",
+        error_type="2",
+        model="Feols",
+    )
+    variants = {}
+    for dropna in (False, True):
+        for f3_type in ("str", "object", "int", "categorical", "float"):
+            data = base.dropna() if dropna else base.copy()
+            data.where(data != "nan", np.nan, inplace=True)
+            variants[(dropna, f3_type)] = convert_f3(data, f3_type)
+    return variants
+
+
+def _assert_backend_matches(
+    actual,
+    reference,
+    case: BackendCase,
+) -> None:
+    context = f"backend={case.name}"
+
+    assert actual._coefnames == reference._coefnames, context
+    assert actual._collin_vars == reference._collin_vars, context
+    assert actual._N == reference._N, context
+    assert actual._df_k == reference._df_k, context
+    assert actual._df_t == reference._df_t, context
+
+    np.testing.assert_allclose(
+        actual.coef(),
+        reference.coef(),
+        rtol=0,
+        atol=case.coef_tol,
+        err_msg=f"coefficients differ for {context}",
+    )
+    np.testing.assert_allclose(
+        actual._vcov,
+        reference._vcov,
+        rtol=0,
+        atol=case.inference_tol,
+        err_msg=f"vcov differs for {context}",
+    )
+    np.testing.assert_allclose(
+        actual.se(),
+        reference.se(),
+        rtol=0,
+        atol=case.inference_tol,
+        err_msg=f"standard errors differ for {context}",
+    )
+    np.testing.assert_allclose(
+        actual.tstat(),
+        reference.tstat(),
+        rtol=0,
+        atol=case.tstat_tol,
+        err_msg=f"t statistics differ for {context}",
+    )
+    np.testing.assert_allclose(
+        actual.pvalue(),
+        reference.pvalue(),
+        rtol=0,
+        atol=case.inference_tol,
+        err_msg=f"p-values differ for {context}",
+    )
+    np.testing.assert_allclose(
+        actual.confint(),
+        reference.confint(),
+        rtol=0,
+        atol=case.inference_tol,
+        err_msg=f"confidence intervals differ for {context}",
+    )
+    np.testing.assert_allclose(
+        actual.resid()[:5],
+        reference.resid()[:5],
+        rtol=0,
+        atol=case.resid_tol,
+        err_msg=f"residuals differ for {context}",
+    )
+    np.testing.assert_allclose(
+        actual.predict()[:5],
+        reference.predict()[:5],
+        rtol=0,
+        atol=case.predict_tol,
+        err_msg=f"predictions differ for {context}",
+    )
+    np.testing.assert_allclose(
+        [actual._r2, actual._adj_r2, actual._r2_within, actual._adj_r2_within],
+        [
+            reference._r2,
+            reference._adj_r2,
+            reference._r2_within,
+            reference._adj_r2_within,
+        ],
+        rtol=0,
+        atol=case.inference_tol,
+        equal_nan=True,
+        err_msg=f"fit statistics differ for {context}",
+    )
+
+
+@pytest.mark.parametrize("dropna", [False, True])
+@pytest.mark.parametrize("inference", ["iid", "hetero", {"CRV1": "group_id"}])
+@pytest.mark.parametrize("weights", [None, "weights"])
+@pytest.mark.parametrize("case", BACKEND_CASES)
+@pytest.mark.parametrize(
+    "fml,f3_type",
+    FEOLS_FORMULA_F3_CASES,
+    ids=lambda value: str(value),
+)
+def test_feols_demeaner_backends_match_reference(
+    backend_data,
+    dropna,
+    inference,
+    weights,
+    case,
+    fml,
+    f3_type,
+):
+    data = backend_data[(dropna, f3_type)]
+    fit_kwargs = {
+        "fml": fml,
+        "data": data,
+        "vcov": inference,
+        "weights": weights,
+        "ssc": pf.ssc(k_adj=True, G_adj=True),
+    }
+
+    reference = pf.feols(**fit_kwargs, demeaner=REFERENCE_DEMEANER)
+    actual = pf.feols(**fit_kwargs, demeaner=case.demeaner)
+    _assert_backend_matches(actual, reference, case)

--- a/tests/test_demeaner_backends.py
+++ b/tests/test_demeaner_backends.py
@@ -7,7 +7,7 @@ import pandas as pd
 import pytest
 
 import pyfixest as pf
-from tests._feols_test_cases import FEOLS_FORMULA_F3_CASES, convert_f3
+from tests._feols_test_cases import FEOLS_FORMULA_F3_CASES, build_feols_data_variants
 from tests._torch_test_utils import torch_param
 
 pytestmark = [
@@ -156,13 +156,7 @@ def backend_data() -> dict[tuple[bool, str], pd.DataFrame]:
         error_type="2",
         model="Feols",
     )
-    variants = {}
-    for dropna in (False, True):
-        for f3_type in ("str", "object", "int", "categorical", "float"):
-            data = base.dropna() if dropna else base.copy()
-            data.where(data != "nan", np.nan, inplace=True)
-            variants[(dropna, f3_type)] = convert_f3(data, f3_type)
-    return variants
+    return build_feols_data_variants(base)
 
 
 def _assert_backend_matches(

--- a/tests/test_vs_fixest.py
+++ b/tests/test_vs_fixest.py
@@ -1604,25 +1604,39 @@ ssc_fmls = [
     "Y ~ X1 + X2 | f1:f2",
 ]
 
+ssc_formula_vcov_dropna_cases = [
+    pytest.param(
+        fml,
+        dropna,
+        vcov,
+        id=f"fml={fml_id}-vcov={vcov}-dropna={dropna}",
+    )
+    for fml_id, fml in enumerate(ssc_fmls)
+    for dropna in [True, False]
+    for vcov in ["iid", "hetero", "f1", "f2", "f1+f2"]
+    if dropna or vcov in ["iid", "hetero"] or vcov in fml
+]
+
+
+@pytest.fixture(scope="module")
+def ssc_data():
+    data = {}
+    for model, data_model in [("feols", "Feols"), ("fepois", "Fepois")]:
+        base = pf.get_data(model=data_model)
+        data[(model, False)] = base
+        data[(model, True)] = base.dropna()
+    return data
+
 
 @pytest.mark.against_r_core
-@pytest.mark.parametrize("fml", ssc_fmls)
-@pytest.mark.parametrize("dropna", [True, False])
+@pytest.mark.parametrize("fml,dropna,vcov", ssc_formula_vcov_dropna_cases)
 @pytest.mark.parametrize("weights", [None, "weights"])
-@pytest.mark.parametrize("vcov", ["iid", "hetero", "f1", "f2", "f1+f2"])
 @pytest.mark.parametrize("k_adj", [True, False])
 @pytest.mark.parametrize("G_adj", [True, False])
 @pytest.mark.parametrize("k_fixef", ["full", "none", "nonnested"])
 @pytest.mark.parametrize("model", ["feols", "fepois"])
-def test_ssc(fml, dropna, weights, vcov, k_adj, G_adj, k_fixef, model):
-    df = pf.get_data(model="Feols") if model == "feols" else pf.get_data(model="Fepois")
-    if dropna:
-        df.dropna(inplace=True)
-
-    if not dropna and vcov in ["f1", "f2", "f1+f2"] and vcov not in fml:
-        pytest.skip(
-            "vcov = f2 requires dropping NAs internally, which is not supported."
-        )
+def test_ssc(ssc_data, fml, dropna, weights, vcov, k_adj, G_adj, k_fixef, model):
+    df = ssc_data[(model, dropna)]
 
     r_kwargs = {
         "fml": ro.Formula(_fixed_effect_interactions_to_fixest(fml)),
@@ -1693,55 +1707,47 @@ def test_ssc(fml, dropna, weights, vcov, k_adj, G_adj, k_fixef, model):
         err_msg=f"df.K do not match for fml = {fml}, vcov = {vcov}, k_adj = {k_adj}, G_adj = {G_adj}, k_fixef = {k_fixef}",
     )
 
-    # df.t identical:
+    # SEs identical:
     np.testing.assert_allclose(
-        py_df_t,
-        r_df_t,
-        err_msg=f"df.t do not match for fml = {fml}, vcov = {vcov}, k_adj = {k_adj}, G_adj = {G_adj}, k_fixef = {k_fixef}",
+        py_fit.se(),
+        ro.r("r_fit$coeftable[,2]"),
+        rtol=1e-07 if model == "feols" else 1e-06,
+        atol=1e-07 if model == "feols" else 1e-06,
+        err_msg=f"SEs do not match for fml = {fml}, vcov = {vcov}, k_adj = {k_adj}, G_adj = {G_adj}, k_fixef = {k_fixef}",
+    )
+    # p-values identical:
+    np.testing.assert_allclose(
+        py_fit.pvalue(),
+        ro.r("r_fit$coeftable[,4]"),
+        rtol=1e-07 if model == "feols" else 1e-06,
+        atol=1e-07 if model == "feols" else 1e-06,
+        err_msg=f"p-values do not match for fml = {fml}, vcov = {vcov}, k_adj = {k_adj}, G_adj = {G_adj}, k_fixef = {k_fixef}",
+    )
+    # t-stats identical:
+    np.testing.assert_allclose(
+        py_fit.tstat(),
+        ro.r("r_fit$coeftable[,3]"),
+        rtol=1e-07 if model == "feols" else 1e-06,
+        atol=1e-07 if model == "feols" else 1e-06,
+        err_msg=f"t-stats do not match for fml = {fml}, vcov = {vcov}, k_adj = {k_adj}, G_adj = {G_adj}, k_fixef = {k_fixef}",
     )
 
-    if True:
-        # SEs identical:
-        np.testing.assert_allclose(
-            py_fit.se(),
-            ro.r("r_fit$coeftable[,2]"),
-            rtol=1e-07 if model == "feols" else 1e-06,
-            atol=1e-07 if model == "feols" else 1e-06,
-            err_msg=f"SEs do not match for fml = {fml}, vcov = {vcov}, k_adj = {k_adj}, G_adj = {G_adj}, k_fixef = {k_fixef}",
-        )
-        # p-values identical:
-        np.testing.assert_allclose(
-            py_fit.pvalue(),
-            ro.r("r_fit$coeftable[,4]"),
-            rtol=1e-07 if model == "feols" else 1e-06,
-            atol=1e-07 if model == "feols" else 1e-06,
-            err_msg=f"p-values do not match for fml = {fml}, vcov = {vcov}, k_adj = {k_adj}, G_adj = {G_adj}, k_fixef = {k_fixef}",
-        )
-        # t-stats identical:
-        np.testing.assert_allclose(
-            py_fit.tstat(),
-            ro.r("r_fit$coeftable[,3]"),
-            rtol=1e-07 if model == "feols" else 1e-06,
-            atol=1e-07 if model == "feols" else 1e-06,
-            err_msg=f"t-stats do not match for fml = {fml}, vcov = {vcov}, k_adj = {k_adj}, G_adj = {G_adj}, k_fixef = {k_fixef}",
-        )
-
-        # confint identical:
-        np.testing.assert_allclose(
-            py_fit.confint().values,
-            pd.DataFrame(stats.confint(r_fit)).T.values,
-            rtol=1e-07 if model == "feols" else 1e-06,
-            atol=1e-07 if model == "feols" else 1e-06,
-            err_msg=f"confint do not match for fml = {fml}, vcov = {vcov}, k_adj = {k_adj}, G_adj = {G_adj}, k_fixef = {k_fixef}",
-        )
-        ## vcov identical:
-        np.testing.assert_allclose(
-            py_fit._vcov,
-            stats.vcov(r_fit),
-            rtol=1e-07 if model == "feols" else 1e-06,
-            atol=1e-07 if model == "feols" else 1e-06,
-            err_msg=f"vcov do not match for fml = {fml}, vcov = {vcov}, k_adj = {k_adj}, G_adj = {G_adj}, k_fixef = {k_fixef}",
-        )
+    # confint identical:
+    np.testing.assert_allclose(
+        py_fit.confint().values,
+        pd.DataFrame(stats.confint(r_fit)).T.values,
+        rtol=1e-07 if model == "feols" else 1e-06,
+        atol=1e-07 if model == "feols" else 1e-06,
+        err_msg=f"confint do not match for fml = {fml}, vcov = {vcov}, k_adj = {k_adj}, G_adj = {G_adj}, k_fixef = {k_fixef}",
+    )
+    # vcov identical:
+    np.testing.assert_allclose(
+        py_fit._vcov,
+        stats.vcov(r_fit),
+        rtol=1e-07 if model == "feols" else 1e-06,
+        atol=1e-07 if model == "feols" else 1e-06,
+        err_msg=f"vcov do not match for fml = {fml}, vcov = {vcov}, k_adj = {k_adj}, G_adj = {G_adj}, k_fixef = {k_fixef}",
+    )
 
 
 @pytest.mark.against_r_core

--- a/tests/test_vs_fixest.py
+++ b/tests/test_vs_fixest.py
@@ -12,6 +12,10 @@ import pyfixest as pf
 from pyfixest.estimation import feols
 from pyfixest.estimation.FixestMulti_ import FixestMulti
 from pyfixest.utils.utils import get_data, ssc
+from tests._feols_test_cases import (
+    ols_but_not_poisson_fml,
+    ols_fmls,
+)
 from tests._torch_test_utils import torch_param
 
 fixest = importr("fixest")
@@ -34,61 +38,6 @@ OFFSET_COEF_RTOL = 1e-7
 OFFSET_COEF_ATOL = 1e-7
 OFFSET_PRED_RTOL = 1e-5
 OFFSET_PRED_ATOL = 1e-5
-
-ols_fmls = [
-    ("Y~X1"),
-    ("Y~X1+X2"),
-    ("Y~X1|f2"),
-    ("Y~X1|f2+f3"),
-    ("Y ~ X1 + exp(X2)"),
-    ("Y ~ X1 + C(f1)"),
-    ("Y ~ X1 + i(f1, ref = 1)"),
-    ("Y ~ X1 + C(f1)"),
-    ("Y ~ X1 + i(f2, ref = 2.0)"),
-    ("Y ~ X1 + C(f1) + C(f2)"),
-    ("Y ~ X1 + C(f1) | f2"),
-    ("Y ~ X1 + i(f1, ref = 3.0) | f2"),
-    ("Y ~ X1 + C(f1) | f2 + f3"),
-    ("Y ~ X1 + i(f1, ref = 1) | f2 + f3"),
-    ("Y ~ X1 + i(f1) + i(f2)"),
-    ("Y ~ X1 + i(f1, ref = 1) + i(f2, ref = 2)"),
-    # ("Y ~ X1 + C(f1):C(fe2)"),                  # currently does not work as C():C() translation not implemented
-    # ("Y ~ X1 + C(f1):C(fe2) | f3"),             # currently does not work as C():C() translation not implemented
-    ("Y ~ X1 + X2:f1"),
-    ("Y ~ X1 + X2:f1 | f3"),
-    ("Y ~ X1 + X2:f1 | f3 + f1"),
-    # ("log(Y) ~ X1:X2 | f3 + f1"),               # currently, causes big problems for Fepois (takes a long time)
-    # ("log(Y) ~ log(X1):X2 | f3 + f1"),          # currently, causes big problems for Fepois (takes a long time)
-    # ("Y ~  X2 + exp(X1) | f3 + f1"),            # currently, causes big problems for Fepois (takes a long time)
-    ("Y ~ X1 + i(f1,X2)"),
-    ("Y ~ X1 + i(f1,X2) + i(f2, X2)"),
-    ("Y ~ X1 + i(f1,X2, ref =1) + i(f2)"),
-    ("Y ~ X1 + i(f1,X2, ref =1) + i(f2, X1, ref =2)"),
-    ("Y ~ X1 + i(f2,X2)"),
-    ("Y ~ X1 + i(f1,X2) | f2"),
-    ("Y ~ X1 + i(f1,X2) | f2 + f3"),
-    ("Y ~ X1 + i(f1,X2, ref=1.0)"),
-    ("Y ~ X1 + i(f2,X2, ref=2.0)"),
-    ("Y ~ X1 + i(f1,X2, ref=3.0) | f2"),
-    ("Y ~ X1 + i(f1,X2, ref=4.0) | f2 + f3"),
-    # ("Y ~ C(f1):X2"),                          # currently does not work as C():X translation not implemented
-    # ("Y ~ C(f1):C(f2)"),                       # currently does not work
-    ("Y ~ X1 + I(X2 ** 2)"),
-    ("Y ~ X1 + I(X1 ** 2) + I(X2**4)"),
-    ("Y ~ X1*X2"),
-    ("Y ~ X1*X2 | f1+f2"),
-    # ("Y ~ X1/X2"),                             # currently does not work as X1/X2 translation not implemented
-    # ("Y ~ X1/X2 | f1+f2"),                     # currently does not work as X1/X2 translation not implemented
-    ("Y ~ X1 + poly(X2, 2) | f1"),
-]
-
-
-ols_but_not_poisson_fml = [
-    ("log(Y) ~ X1"),
-    ("Y~X1|f2:f3"),
-    ("Y~X1|f1 + f2:f3"),
-    ("Y~X1|f2:f3:f1"),
-]
 
 empty_models = [
     ("Y ~ 1 | f1"),

--- a/tests/test_vs_fixest.py
+++ b/tests/test_vs_fixest.py
@@ -13,10 +13,13 @@ from pyfixest.estimation import feols
 from pyfixest.estimation.FixestMulti_ import FixestMulti
 from pyfixest.utils.utils import get_data, ssc
 from tests._feols_test_cases import (
-    ols_but_not_poisson_fml,
+    FEOLS_FORMULA_F3_CASES,
+    build_feols_data_variants,
     ols_fmls,
 )
-from tests._torch_test_utils import torch_param
+from tests._feols_test_cases import (
+    convert_f3 as _convert_f3,
+)
 
 fixest = importr("fixest")
 stats = importr("stats")
@@ -94,6 +97,11 @@ def data_feols(N=1000, seed=76540251, beta_type="2", error_type="2"):
     )
 
 
+@pytest.fixture(scope="module")
+def data_feols_variants(data_feols):
+    return build_feols_data_variants(data_feols)
+
+
 @pytest.fixture
 def data_fepois(N=1000, seed=7651, beta_type="2", error_type="2"):
     return pf.get_data(
@@ -146,7 +154,6 @@ def _get_vcov_diag(py_model, r_model, coefname, is_iv=False):
     return py_vcov, r_vcov
 
 
-test_counter_feols = 0
 test_counter_fepois = 0
 test_counter_feiv = 0
 test_counter_feglm = 0
@@ -163,80 +170,19 @@ test_counter_feglm = 0
 # - G_adj: True
 
 
-ALL_F3 = ["str", "object", "int", "categorical", "float"]
-SINGLE_F3 = ALL_F3[0]
-
-
-BACKEND_F3 = [
-    *[
-        pytest.param(name, pf.MapDemeaner(backend="numba"), t, id=name)
-        for name in ("numba",)
-        for t in ALL_F3
-    ],
-    pytest.param(
-        "within",
-        pf.LsmrDemeaner(preconditioner="additive"),
-        SINGLE_F3,
-        id="within_additive",
-    ),
-    pytest.param(
-        "within_diag",
-        pf.LsmrDemeaner(preconditioner="diagonal"),
-        SINGLE_F3,
-        id="within_diagonal",
-    ),
-    *[
-        pytest.param(name, pf.MapDemeaner(backend=name), SINGLE_F3, id=name)
-        for name in ("rust",)
-    ],
-    torch_param(
-        ("torch", pf.LsmrDemeaner(backend="torch", device="auto"), SINGLE_F3),
-        id="torch",
-    ),
-    torch_param(
-        ("torch_cpu", pf.LsmrDemeaner(backend="torch", device="cpu"), SINGLE_F3),
-        id="torch_cpu",
-    ),
-    torch_param(
-        (
-            "torch_mps",
-            pf.LsmrDemeaner(backend="torch", precision="float32", device="mps"),
-            SINGLE_F3,
-        ),
-        id="torch_mps",
-        require="mps",
-    ),
-    torch_param(
-        (
-            "torch_cuda",
-            pf.LsmrDemeaner(backend="torch", device="cuda"),
-            SINGLE_F3,
-        ),
-        id="torch_cuda",
-        require="cuda",
-    ),
-    torch_param(
-        (
-            "torch_cuda32",
-            pf.LsmrDemeaner(backend="torch", precision="float32", device="cuda"),
-            SINGLE_F3,
-        ),
-        id="torch_cuda32",
-        require="cuda",
-    ),
-]
-
-
 @pytest.mark.against_r_core
-@pytest.mark.parametrize("backend_name,demeaner,f3_type", BACKEND_F3)
 @pytest.mark.parametrize("dropna", [False, True])
 @pytest.mark.parametrize("inference", ["iid", "hetero", {"CRV1": "group_id"}])
 @pytest.mark.parametrize("weights", [None, "weights"])
-@pytest.mark.parametrize("fml", ols_fmls + ols_but_not_poisson_fml)
+@pytest.mark.parametrize(
+    "fml,f3_type",
+    FEOLS_FORMULA_F3_CASES,
+    ids=lambda value: str(value),
+)
 @pytest.mark.parametrize("k_adj", [True])
 @pytest.mark.parametrize("G_adj", [True])
 def test_single_fit_feols(
-    data_feols,
+    data_feols_variants,
     dropna,
     inference,
     weights,
@@ -244,29 +190,9 @@ def test_single_fit_feols(
     fml,
     k_adj,
     G_adj,
-    backend_name,
-    demeaner,
 ):
-    global test_counter_feols
-    test_counter_feols += 1
-
-    _skip_f3_checks(fml, f3_type)
-    _skip_dropna(test_counter_feols, dropna)
-
     ssc_ = ssc(k_adj=k_adj, G_adj=G_adj)
-
-    data = data_feols.copy()
-
-    if dropna:
-        data = data.dropna()
-
-    # long story, but categories need to be strings to be converted to R factors,
-    # this then produces 'nan' values in the pd.DataFrame ...
-    data.where(data != "nan", np.nan, inplace=True)
-
-    # test fixed effects that are not floats, but ints or categoricals, etc
-
-    data = _convert_f3(data, f3_type)
+    data = data_feols_variants[(dropna, f3_type)]
 
     data_r = get_data_r(fml, data)
     r_fml = _c_to_as_factor(fml)
@@ -279,7 +205,6 @@ def test_single_fit_feols(
         vcov=inference,
         weights=weights,
         ssc=ssc_,
-        demeaner=demeaner,
     )
     if weights is not None:
         r_fixest = fixest.feols(
@@ -326,24 +251,11 @@ def test_single_fit_feols(
     r_df_k = int(ro.r('attr(r_fixest$cov.scaled, "df.K")')[0])
     r_df_t = int(ro.r('attr(r_fixest$cov.scaled, "df.t")')[0])
 
-    if backend_name in ("torch", "torch_cpu", "torch_cuda"):
-        coef_tol = 1e-08
-        predict_tol = 5e-05
-        resid_tol = 5e-05
-        inference_tol = 1e-06
-        tstat_tol = 1e-05
-    elif backend_name in ("torch_mps", "torch_cuda32"):
-        coef_tol = 5e-06
-        predict_tol = 2e-04
-        resid_tol = 2e-04
-        inference_tol = 1e-05
-        tstat_tol = 1e-05
-    else:
-        coef_tol = 1e-08
-        predict_tol = 1e-06
-        resid_tol = 1e-06
-        inference_tol = 1e-07
-        tstat_tol = 1e-06
+    coef_tol = 1e-08
+    predict_tol = 1e-06
+    resid_tol = 1e-06
+    inference_tol = 1e-07
+    tstat_tol = 1e-06
 
     if inference == "iid" and k_adj and G_adj:
         py_resid = mod.resid()
@@ -1850,23 +1762,6 @@ def test_inf_dropping(fml, weights):
         fit_py = feols(fml=fml, data=data, weights=weights, fixef_rm="none")
 
     assert int(data.shape[0] - n_zeros) == fit_py._N
-
-
-def _convert_f3(data, f3_type):
-    """Convert f3 to the desired type."""
-    if f3_type == "categorical":
-        data["f3"] = pd.Categorical(data["f3"])
-    elif f3_type == "int":
-        data["f3"] = data["f3"].astype(float).astype(np.int32)
-    elif f3_type == "str":
-        data["f3"] = data["f3"].astype(str)
-    elif f3_type == "object":
-        data["f3"] = data["f3"].astype(object)
-    elif f3_type == "float":
-        data["f3"] = data["f3"].astype(float)
-    else:
-        pass
-    return data
 
 
 def _get_r_inference(inference):

--- a/tests/test_vs_fixest.py
+++ b/tests/test_vs_fixest.py
@@ -154,10 +154,6 @@ def _get_vcov_diag(py_model, r_model, coefname, is_iv=False):
     return py_vcov, r_vcov
 
 
-test_counter_fepois = 0
-test_counter_feiv = 0
-test_counter_feglm = 0
-
 # What is being tested in all tests:
 # - pyfixest vs fixest
 # - inference: iid, hetero, cluster
@@ -431,7 +427,6 @@ def test_single_fit_feols_empty(
 
 
 @pytest.mark.against_r_core
-@pytest.mark.parametrize("dropna", [False])
 @pytest.mark.parametrize("inference", ["iid", "hetero", {"CRV1": "group_id"}])
 @pytest.mark.parametrize("f3_type", ["str"])
 @pytest.mark.parametrize("fml", ols_fmls)
@@ -440,13 +435,9 @@ def test_single_fit_feols_empty(
 @pytest.mark.parametrize("weights", [None, "weights"])
 @pytest.mark.parametrize("offset", [False, True])
 def test_single_fit_fepois(
-    data_fepois, dropna, inference, f3_type, fml, k_adj, G_adj, weights, offset
+    data_fepois, inference, f3_type, fml, k_adj, G_adj, weights, offset
 ):
-    global test_counter_fepois
-    test_counter_fepois += 1
-
     _skip_f3_checks(fml, f3_type)
-    _skip_dropna(test_counter_fepois, dropna)
 
     ssc_ = ssc(k_adj=k_adj, G_adj=G_adj)
 
@@ -458,8 +449,6 @@ def test_single_fit_fepois(
         offset_var = "offset_var"
     else:
         offset_var = None
-    if dropna:
-        data_fepois.dropna(inplace=True)
     # long story, but categories need to be strings to be converted to R factors,
     # this then produces 'nan' values in the pd.DataFrame ...
     data_fepois.where(data_fepois != "nan", np.nan, inplace=True)
@@ -708,9 +697,6 @@ def test_single_fit_feglm(data_fepois, inference, fml, weights, family):
     (loglik, loglik_null, pseudo_r2, pearson_chi2) are not defined for
     logit/probit/gaussian and are therefore skipped.
     """
-    global test_counter_feglm
-    test_counter_feglm += 1
-
     _skip_f3_checks(fml, "str")
 
     ssc_ = ssc(k_adj=True, G_adj=True)
@@ -849,7 +835,6 @@ def test_single_fit_feglm(data_fepois, inference, fml, weights, family):
 
 
 @pytest.mark.against_r_core
-@pytest.mark.parametrize("dropna", [False])
 @pytest.mark.parametrize("weights", [None, "weights"])
 @pytest.mark.parametrize("inference", ["iid", "hetero", {"CRV1": "group_id"}])
 @pytest.mark.parametrize("f3_type", ["str"])
@@ -858,7 +843,6 @@ def test_single_fit_feglm(data_fepois, inference, fml, weights, family):
 @pytest.mark.parametrize("G_adj", [True])
 def test_single_fit_iv(
     data_feols,
-    dropna,
     inference,
     weights,
     f3_type,
@@ -866,17 +850,11 @@ def test_single_fit_iv(
     k_adj,
     G_adj,
 ):
-    global test_counter_feiv
-    test_counter_feiv += 1
-
     _skip_f3_checks(fml, f3_type)
-    _skip_dropna(test_counter_feiv, dropna)
 
     ssc_ = ssc(k_adj=k_adj, G_adj=G_adj)
 
     data = data_feols.copy()
-    if dropna:
-        data.dropna(inplace=True)
     # long story, but categories need to be strings to be converted to R factors,
     # this then produces 'nan' values in the pd.DataFrame ...
     data.where(data != "nan", np.nan, inplace=True)
@@ -1614,6 +1592,9 @@ ssc_formula_vcov_dropna_cases = [
     for fml_id, fml in enumerate(ssc_fmls)
     for dropna in [True, False]
     for vcov in ["iid", "hetero", "f1", "f2", "f1+f2"]
+    # Clustering with missing data is supported only when every cluster variable
+    # occurs in the formula. Select supported cases at collection time rather
+    # than collecting them and skipping them during the test run.
     if dropna or vcov in ["iid", "hetero"] or vcov in fml
 ]
 
@@ -1806,8 +1787,3 @@ def _skip_f3_checks(fml, f3_type):
         pytest.skip(
             "No need to tests for different types of factor variable when not included in formula."
         )
-
-
-def _skip_dropna(test_counter, dropna):
-    if test_counter % 4 != 0 and dropna:
-        pytest.skip(f"Skipping dropna=True for test number {test_counter}")


### PR DESCRIPTION
We reorganize the tests against fixest, for faster test feedback: 

- By default, we only test the default demeaner backend against fixest via an integration test. 
- All other demeaner backends are tests in a separated test workflow.

FYI @leostimpfle 