### PR TITLE
fix(demeaning): stabilize float32 LSMR tolerance

### DIFF
--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -35,6 +35,14 @@ fit3 = pf.feols("Y ~ X1 + X2 | f1", data = df)
 - Pixi tasks now share a writable project-local Matplotlib configuration
   directory, avoiding repeated font-cache rebuilds across fresh test processes.
 
+### Demeaning Backends
+
+- Float32 Torch demeaning now stops at a tolerance supported by its numerical
+  precision. This keeps MPS and CUDA32 estimates stable when a model contains
+  large factor expansions.
+- Alternative demeaner checks now cover predictions on both fitting and new
+  data, including prediction uncertainty wherever the model supports it.
+
 ### Inference Types
 
 - `tidy()`, `confint()`, and `summary()` gain an `inference_type` argument.

--- a/docs/how-to/demeaner-backends.qmd
+++ b/docs/how-to/demeaner-backends.qmd
@@ -100,7 +100,9 @@ The `MapDemeaner` accepts `fixef_tol` and `fixef_maxiter` arguments to control
 convergence. `LsmrDemeaner` uses `fixef_atol` and `fixef_btol`. For the
 `within` backend the two tolerances are collapsed to
 `max(fixef_atol, fixef_btol)` (the solver takes a single tolerance);
-`torch` uses both independently (SciPy LSMR convention).
+the `torch` backend does the same. To avoid unstable iterations below the
+selected dtype's useful precision, `torch` also uses three times machine epsilon
+as a lower bound for the effective tolerance.
 
 ```{python}
 fit = pf.feols(

--- a/pyfixest/demeaners.py
+++ b/pyfixest/demeaners.py
@@ -205,10 +205,10 @@ class LsmrDemeaner(BaseDemeaner):
 
     Notes
     -----
-    The `within`` backend takes a single tolerance, so `fixef_atol` and
-    `fixef_btol` are collapsed to `max(fixef_atol, fixef_btol)` for that
-    backend. The `torch` backend uses both tolerances independently
-    (SciPy LSMR convention).
+    The `within` and `torch` backends take a single tolerance, so `fixef_atol`
+    and `fixef_btol` are collapsed to `max(fixef_atol, fixef_btol)`. For
+    floating-point stability, the `torch` backend also bounds the effective
+    tolerance below by three times the selected precision's machine epsilon.
 
     The `local_size` field only applies to `backend="within"`; the
     `torch` backend ignores it.

--- a/pyfixest/estimation/torch/demean_torch_.py
+++ b/pyfixest/estimation/torch/demean_torch_.py
@@ -28,6 +28,14 @@ from pyfixest.estimation.torch.lsmr_torch import lsmr_torch, lsmr_torch_batched
 # Benchmarked breakeven is device-specific.
 _BATCHED_K_THRESHOLD_CUDA = 2
 _BATCHED_K_THRESHOLD_MPS = 5
+# LSMR's stopping tests combine several dtype-level norms. A small margin
+# above one epsilon prevents float32 recurrences from iterating into roundoff.
+_LSMR_TOL_EPS_MULTIPLIER = 3.0
+
+
+def _effective_lsmr_tol(tol: float, dtype: torch.dtype) -> float:
+    """Keep LSMR's stopping tolerance above the dtype's noise floor."""
+    return max(tol, _LSMR_TOL_EPS_MULTIPLIER * torch.finfo(dtype).eps)
 
 
 def _lsmr_istop_is_success(istop: int) -> bool:
@@ -87,6 +95,8 @@ def _demean_torch_on_device_impl(
         raise ValueError("flist cannot be None")
     if weights is None:
         weights = np.ones(x.shape[0], dtype=np.float64)
+
+    tol = _effective_lsmr_tol(tol, dtype)
 
     # Track original shape to restore on output
     was_1d = x.ndim == 1
@@ -201,7 +211,9 @@ def demean_torch(
     weights : np.ndarray, shape (N,)
         Observation weights (1.0 for equal weighting).
     tol : float
-        Convergence tolerance for LSMR (used as both atol and btol).
+        Convergence tolerance for LSMR (used as both atol and btol). Values
+        below three times the selected dtype's machine epsilon use that numerical
+        floor instead.
     maxiter : int
         Maximum LSMR iterations per column.
     dtype : torch.dtype

--- a/tests/test_demean.py
+++ b/tests/test_demean.py
@@ -19,7 +19,11 @@ GENERIC_DEMEAN_FUNCS = [
 ]
 
 if HAS_TORCH:
-    from pyfixest.estimation.torch.demean_torch_ import demean_torch
+    from pyfixest.estimation.torch.demean_torch_ import (
+        _demean_torch_on_device_impl,
+        _effective_lsmr_tol,
+        demean_torch,
+    )
 
     GENERIC_DEMEAN_FUNCS.append(pytest.param(demean_torch, id="demean_torch"))
 
@@ -115,6 +119,38 @@ def test_torch_device_backends_match_pyhdfe(backend_name, rtol, atol, demean_dat
     res_torch, success = demean_func(x, flist, weights, tol=1e-10)
     assert success, f"{backend_name} did not converge on weighted demeaning"
     np.testing.assert_allclose(res_torch, res_pyhdfe, rtol=rtol, atol=atol)
+
+
+@pytest.mark.skipif(not HAS_TORCH, reason="torch is not installed")
+def test_torch_float32_tolerance_respects_machine_precision(demean_data):
+    """Sub-epsilon requests should produce the stable float32-floor solution."""
+    import torch
+
+    x, flist, weights = demean_data
+    floor = _effective_lsmr_tol(1e-12, torch.float32)
+
+    actual, actual_success = _demean_torch_on_device_impl(
+        x=x,
+        flist=flist,
+        weights=weights,
+        tol=1e-12,
+        maxiter=1_000,
+        device=torch.device("cpu"),
+        dtype=torch.float32,
+    )
+    expected, expected_success = _demean_torch_on_device_impl(
+        x=x,
+        flist=flist,
+        weights=weights,
+        tol=floor,
+        maxiter=1_000,
+        device=torch.device("cpu"),
+        dtype=torch.float32,
+    )
+
+    assert actual_success
+    assert expected_success
+    np.testing.assert_array_equal(actual, expected)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_demeaner_backends.py
+++ b/tests/test_demeaner_backends.py
@@ -27,11 +27,14 @@ pytestmark = [
 class BackendCase:
     name: str
     demeaner: pf.MapDemeaner | pf.LsmrDemeaner
+    coef_rtol: float
     coef_tol: float
     predict_tol: float
     resid_tol: float
     inference_tol: float
     tstat_tol: float
+    confint_rtol: float
+    confint_tol: float
 
 
 REFERENCE_DEMEANER = pf.MapDemeaner(backend="rust")
@@ -41,11 +44,14 @@ BACKEND_CASES = [
         BackendCase(
             name="numba",
             demeaner=pf.MapDemeaner(backend="numba"),
+            coef_rtol=0,
             coef_tol=1e-8,
             predict_tol=1e-6,
             resid_tol=1e-6,
             inference_tol=1e-7,
             tstat_tol=1e-6,
+            confint_rtol=0,
+            confint_tol=1e-7,
         ),
         id="numba",
     ),
@@ -53,6 +59,7 @@ BACKEND_CASES = [
         BackendCase(
             name="within_additive",
             demeaner=pf.LsmrDemeaner(preconditioner="additive"),
+            coef_rtol=0,
             coef_tol=1e-8,
             predict_tol=1e-6,
             resid_tol=1e-6,
@@ -60,6 +67,8 @@ BACKEND_CASES = [
             # factor expansions more than the historical X1 diagonal check.
             inference_tol=1e-6,
             tstat_tol=1e-6,
+            confint_rtol=0,
+            confint_tol=1e-6,
         ),
         id="within_additive",
     ),
@@ -67,6 +76,7 @@ BACKEND_CASES = [
         BackendCase(
             name="within_diagonal",
             demeaner=pf.LsmrDemeaner(preconditioner="diagonal"),
+            coef_rtol=0,
             coef_tol=1e-8,
             predict_tol=1e-6,
             resid_tol=1e-6,
@@ -74,6 +84,8 @@ BACKEND_CASES = [
             # factor expansions more than the historical X1 diagonal check.
             inference_tol=1e-6,
             tstat_tol=1e-6,
+            confint_rtol=0,
+            confint_tol=1e-6,
         ),
         id="within_diagonal",
     ),
@@ -81,11 +93,14 @@ BACKEND_CASES = [
         BackendCase(
             name="torch",
             demeaner=pf.LsmrDemeaner(backend="torch", device="auto"),
+            coef_rtol=0,
             coef_tol=1e-8,
             predict_tol=5e-5,
             resid_tol=5e-5,
             inference_tol=1e-6,
             tstat_tol=1e-5,
+            confint_rtol=0,
+            confint_tol=1e-6,
         ),
         id="torch",
     ),
@@ -93,11 +108,14 @@ BACKEND_CASES = [
         BackendCase(
             name="torch_cpu",
             demeaner=pf.LsmrDemeaner(backend="torch", device="cpu"),
+            coef_rtol=0,
             coef_tol=1e-8,
             predict_tol=5e-5,
             resid_tol=5e-5,
             inference_tol=1e-6,
             tstat_tol=1e-5,
+            confint_rtol=0,
+            confint_tol=1e-6,
         ),
         id="torch_cpu",
     ),
@@ -107,11 +125,21 @@ BACKEND_CASES = [
             demeaner=pf.LsmrDemeaner(
                 backend="torch", precision="float32", device="mps"
             ),
-            coef_tol=5e-6,
+            # Preserve a strict absolute guard near zero while allowing the
+            # expected float32 rounding scale for large coefficients.
+            coef_rtol=1e-6,
+            # Float32 LSMR stopping error is amplified by large factor
+            # expansions; the observed coefficient error is below 2e-4.
+            coef_tol=2e-4,
             predict_tol=2e-4,
             resid_tol=2e-4,
-            inference_tol=1e-5,
-            tstat_tol=1e-5,
+            # Full covariance matrices and derived inference amplify the
+            # float32 residualization error more than point estimates.
+            inference_tol=2e-4,
+            tstat_tol=2e-4,
+            # Confidence bounds combine coefficient and standard-error error.
+            confint_rtol=2e-6,
+            confint_tol=3e-4,
         ),
         id="torch_mps",
         require="mps",
@@ -120,11 +148,14 @@ BACKEND_CASES = [
         BackendCase(
             name="torch_cuda",
             demeaner=pf.LsmrDemeaner(backend="torch", device="cuda"),
+            coef_rtol=0,
             coef_tol=1e-8,
             predict_tol=5e-5,
             resid_tol=5e-5,
             inference_tol=1e-6,
             tstat_tol=1e-5,
+            confint_rtol=0,
+            confint_tol=1e-6,
         ),
         id="torch_cuda",
         require="cuda",
@@ -135,11 +166,14 @@ BACKEND_CASES = [
             demeaner=pf.LsmrDemeaner(
                 backend="torch", precision="float32", device="cuda"
             ),
+            coef_rtol=0,
             coef_tol=5e-6,
             predict_tol=2e-4,
             resid_tol=2e-4,
             inference_tol=1e-5,
             tstat_tol=1e-5,
+            confint_rtol=0,
+            confint_tol=1e-5,
         ),
         id="torch_cuda32",
         require="cuda",
@@ -175,7 +209,7 @@ def _assert_backend_matches(
     np.testing.assert_allclose(
         actual.coef(),
         reference.coef(),
-        rtol=0,
+        rtol=case.coef_rtol,
         atol=case.coef_tol,
         err_msg=f"coefficients differ for {context}",
     )
@@ -210,8 +244,8 @@ def _assert_backend_matches(
     np.testing.assert_allclose(
         actual.confint(),
         reference.confint(),
-        rtol=0,
-        atol=case.inference_tol,
+        rtol=case.confint_rtol,
+        atol=case.confint_tol,
         err_msg=f"confidence intervals differ for {context}",
     )
     np.testing.assert_allclose(
@@ -241,6 +275,94 @@ def _assert_backend_matches(
         equal_nan=True,
         err_msg=f"fit statistics differ for {context}",
     )
+
+
+def _assert_backend_prediction_paths_match(
+    actual,
+    reference,
+    data: pd.DataFrame,
+    case: BackendCase,
+) -> None:
+    context = f"backend={case.name}"
+    newdata = data.iloc[:100]
+
+    actual_prediction = actual.predict(newdata=newdata, atol=1e-12, btol=1e-12)
+    reference_prediction = reference.predict(
+        newdata=newdata,
+        atol=1e-12,
+        btol=1e-12,
+    )
+    np.testing.assert_array_equal(
+        np.isnan(actual_prediction),
+        np.isnan(reference_prediction),
+        err_msg=f"new-data prediction missingness differs for {context}",
+    )
+    observed = ~np.isnan(reference_prediction)
+    np.testing.assert_allclose(
+        actual_prediction[observed][:5],
+        reference_prediction[observed][:5],
+        rtol=0,
+        atol=case.predict_tol,
+        err_msg=f"new-data predictions differ for {context}",
+    )
+
+    if not actual._has_fixef and not actual._has_weights:
+        np.testing.assert_allclose(
+            actual.predict(se_fit=True),
+            reference.predict(se_fit=True),
+            rtol=0,
+            atol=case.predict_tol,
+            err_msg=f"prediction standard errors differ for {context}",
+        )
+        np.testing.assert_allclose(
+            actual.predict(newdata=newdata, se_fit=True),
+            reference.predict(newdata=newdata, se_fit=True),
+            rtol=0,
+            atol=case.predict_tol,
+            equal_nan=True,
+            err_msg=f"new-data prediction standard errors differ for {context}",
+        )
+
+        actual_interval = actual.predict(interval="prediction")
+        reference_interval = reference.predict(interval="prediction")
+        for column in ["fit", "se_fit", "ci_low", "ci_high"]:
+            np.testing.assert_allclose(
+                actual_interval[column].to_numpy()[-4:],
+                reference_interval[column].to_numpy()[-4:],
+                rtol=0,
+                atol=case.predict_tol,
+                err_msg=(f"prediction intervals differ for {context}, column={column}"),
+            )
+
+        actual_interval = actual.predict(
+            newdata=newdata,
+            interval="prediction",
+        )
+        reference_interval = reference.predict(
+            newdata=newdata,
+            interval="prediction",
+        )
+        for column in ["fit", "se_fit", "ci_low", "ci_high"]:
+            np.testing.assert_allclose(
+                actual_interval[column].to_numpy()[-4:],
+                reference_interval[column].to_numpy()[-4:],
+                rtol=0,
+                atol=case.predict_tol,
+                equal_nan=True,
+                err_msg=(
+                    "new-data prediction intervals differ for "
+                    f"{context}, column={column}"
+                ),
+            )
+    else:
+        with pytest.raises(NotImplementedError):
+            actual.predict(se_fit=True)
+        with pytest.raises(NotImplementedError):
+            actual.predict(interval="prediction")
+        with pytest.raises(NotImplementedError):
+            actual.predict(newdata=newdata, se_fit=True)
+        with pytest.raises(NotImplementedError):
+            actual.predict(newdata=newdata, interval="prediction")
 
 
 @pytest.mark.parametrize("dropna", [False, True])
@@ -273,3 +395,10 @@ def test_feols_demeaner_backends_match_reference(
     reference = pf.feols(**fit_kwargs, demeaner=REFERENCE_DEMEANER)
     actual = pf.feols(**fit_kwargs, demeaner=case.demeaner)
     _assert_backend_matches(actual, reference, case)
+    if inference == "iid":
+        _assert_backend_prediction_paths_match(
+            actual=actual,
+            reference=reference,
+            data=data,
+            case=case,
+        )


### PR DESCRIPTION
## Summary

Stabilizes float32 Torch LSMR demeaning by preventing stopping tolerances from
falling below the dtype's useful precision. Sub-epsilon requests previously let
float32 recurrences iterate into roundoff; on large factor expansions this
shifted MPS coefficients by about `1.2e-2`. The effective tolerance is now
floored at three times machine epsilon (about `3.6e-7` for float32).

