### PR TITLE
docs(estimation): document mutable state lifecycle

### DIFF
--- a/.agents/skills/change-verification/SKILL.md
+++ b/.agents/skills/change-verification/SKILL.md
@@ -17,11 +17,15 @@ changed-file format/lint/type checks. Once the implementation stabilizes, run
 the selected broader baseline once and assign each required long check to a
 local run or exact-head CI.
 
-- Numerical/API changes require the relevant public integration tests and
-  external-reference suite. `test-py` is a Python-only regression baseline and
-  never substitutes for an external numerical comparison. Use the fast R suite
-  for edit feedback; produce canonical evidence after stabilization, locally or
-  in exact-head CI.
+- Estimation/inference numerical changes require the relevant public integration
+  tests and external-reference suite. Run fast release numerical-contract
+  snapshots for edit feedback; the task prepares its platform-local pinned
+  release cache automatically. Run the full matrix through `test-py` after
+  stabilization. Other API changes use their targeted public tests.
+  `test-py` and snapshots are Python-only and
+  never substitute for an external numerical comparison. After stabilization,
+  use targeted or fast R feedback; produce canonical evidence locally or in
+  exact-head CI.
 - HAC changes require the single-threaded HAC suite.
 - Rust changes require kernel/reference tests and platform CI.
 - Performance-sensitive changes require before/after evidence.

--- a/.agents/skills/numerical-validation/SKILL.md
+++ b/.agents/skills/numerical-validation/SKILL.md
@@ -47,13 +47,23 @@ estimator-specific tolerance, and extend the nearest permanent matrix before
 adding a new test function or file.
 
 Keep the permanent test parametrized through the public API where possible and
-keep its runtime suitable for regular CI use. Live R comparisons must run
+keep its runtime suitable for regular CI use. Use the release numerical-contract
+snapshots for broad repeatable regression feedback, but never treat a released
+pyfixest result as an external correctness reference. Live R comparisons must run
 through rpy2 inside pytest. Register every rpy2-importing test file in
 `tests/conftest.py` and use the strict R marker matching dependency
 availability. Do not replace an available live reference merely to shorten the
 edit loop; first select affected live cases or use the fast matrix. Follow the
 stored-reference criteria in `docs/developer/testing.md` when live execution is
 unavailable, unreliable, or impractical.
+
+Release snapshots are generated in a platform-local gitignored cache from the
+pinned release environment, never from development head. The snapshot task
+prepares and invalidates that cache automatically. When a snapshot drifts,
+inspect the post-baseline changelog first. Narrowly comment a single comparison
+only when it is a documented intentional behavior change and retain external R
+evidence; leave unexplained drift as an ordinary failure for human review.
+Change the pinned version only for an explicit baseline roll.
 
 Use R `fixest` as the default reference for `feols`, `fepois`, and `feglm`.
 Use R `quantreg` for `quantreg`. The fast direct matrix is available as:
@@ -62,7 +72,9 @@ Use R `quantreg` for `quantreg`. The fast direct matrix is available as:
 pixi run -e py312-r test-r-fixest-fast
 ```
 
-Use the fast suite while editing. After the implementation stabilizes, produce
-the affected canonical evidence locally or in exact-head CI. The fast suite
-does not replace or establish permanent estimator-specific coverage and is not
-complete merge evidence.
+Use fast release snapshots while editing and their complete matrix through
+`test-py` or the explicit full task after stabilization. Then use the targeted
+or fast live-R suite for direct external feedback and produce the affected
+canonical evidence locally or in exact-head CI. The fast suite does not replace
+or establish permanent estimator-specific coverage and is not complete merge
+evidence.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,8 +147,10 @@ fixture boundary.
 Use `pixi run` for every Python, pytest, lint, docs, and R command. Bare tools
 may miss dependencies or the compiled extension.
 
-- Edit feedback: targeted tests with `-x -q --no-cov`, changed-file lint/type
-  checks, and targeted or fast live-R cases for numerical work.
+- Edit feedback: targeted tests with `-x -q --no-cov` and changed-file lint/type
+  checks. For affected estimator/inference work, also run the broad Python-only
+  release snapshot task; after numerical work stabilizes, use targeted or fast
+  live-R cases as an external correctness check.
 - Stabilized implementation: run the selected broader baseline once.
   `test-py` remains Python-only and does not establish numerical agreement.
 - Merge evidence: affected R, HAC, no-JIT, docs, plots, Rust, extended, and
@@ -204,6 +206,8 @@ qualitative and depends on hardware and caches; report the actual elapsed time.
 | Command | Purpose | Typical scale |
 |---|---|---|
 | `pixi run -e py312-r pytest tests/test_<feature>.py -x -q --no-cov` | Test the changed seam without the repository coverage report | Seconds to a few minutes |
+| `pixi run -e py312 test-estimation-snapshots` | Fast balanced public-fit regression feedback against the platform-local cached release contract; no R or coverage | Seconds to a few minutes after first-use preparation |
+| `pixi run -e py312 test-estimation-snapshots-full` | Complete release-contract matrix (also executed once by `test-py`) | Minutes |
 | `pixi run -e py312-r test-r-fixest-fast` | Get edit feedback from representative `feols`, `fepois`, and `feglm` comparisons with R `fixest`, and `quantreg` with R `quantreg` | Seconds to a few minutes |
 | `pixi run test-py` | Run the broad Python-only regression suite; this is not an external numerical comparison | Minutes |
 | `pixi run -e py312-r test-r-fixest` | Produce canonical `tests/test_vs_fixest.py` merge evidence | Minutes to tens of minutes |

--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -39,6 +39,11 @@ fit3 = pf.feols("Y ~ X1 + X2 | f1", data = df)
   `quantreg` fits. Each machine generates its own cached baseline from the
   pinned release environment, avoiding cross-platform snapshot failures. It
   complements rather than replaces the fast and canonical live-R evidence.
+- The developer architecture guide now documents how estimator fields move
+  through formula, fixed-effect-within, and square-root-weighted solver scales,
+  including the distinct observation- and working-weight domains in GLMs. It
+  also defines the vocabulary for the planned immutable estimator-state
+  refactor.
 
 ### Inference Types
 

--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -34,6 +34,11 @@ fit3 = pf.feols("Y ~ X1 + X2 | f1", data = df)
   workflow.
 - Pixi tasks now share a writable project-local Matplotlib configuration
   directory, avoiding repeated font-cache rebuilds across fresh test processes.
+- A Python-only release numerical-contract snapshot suite now provides broad,
+  repeatable edit feedback for public `feols`, `fepois`, `feglm`, and
+  `quantreg` fits. Each machine generates its own cached baseline from the
+  pinned release environment, avoiding cross-platform snapshot failures. It
+  complements rather than replaces the fast and canonical live-R evidence.
 
 ### Inference Types
 

--- a/docs/developer/architecture.md
+++ b/docs/developer/architecture.md
@@ -77,6 +77,119 @@ shared estimator API
 `FixestMulti` is a container for fitted results. Numerical behavior belongs in
 the individual models and shared primitives, not in the container.
 
+## Current estimator-state lifecycle
+
+The fitted-model classes currently use themselves as both a work area and a
+result object. Several private attributes therefore change representation and
+numerical scale while a model is fitted. This section records that status quo;
+it is not a contract for new code.
+
+For linear models, the transformations are:
+
+```text
+formula-materialized scale
+  -> weighted fixed-effect projection
+within scale (original units; not premultiplied)
+  -> multiplication by sqrt(observation weights)
+solver scale
+```
+
+The word *weighted* has two distinct meanings in that sequence. Fixed-effect
+residualization uses the observation weights when computing group projections,
+but its output is still in the dependent variable's and covariates' original
+units. Only `wls_transform()` premultiplies those within-scale values by the
+square root of the weights.
+
+### Linear and IV models
+
+`Feols.prepare_model_matrix()` initially stores formula-materialized pandas
+objects in `_Y`, `_X`, `_fe`, `_weights_df`, and, for IV models, `_Z` and
+`_endogvar`. It also retains a copy of the response in `_Y_untransformed`.
+The subsequent stages reuse the same model object:
+
+| Stage | OLS fields | Additional IV fields | Representation and scale |
+|---|---|---|---|
+| `demean()` | `_Yd`, `_Xd` | `_Zd`, `_endogvard` | pandas DataFrames on within scale; the FE projection uses observation weights |
+| `to_array()` | `_Y`, `_X` are reassigned | `_Z` and `_endogvar` are reassigned | NumPy arrays; `_Y` and `_X` now hold within-scale values |
+| `drop_multicol_vars()` | `_X` may lose columns | `_Z` may lose columns | NumPy arrays on within scale; coefficient-name lists mutate in parallel |
+| `wls_transform()` | `_Y`, `_X` are reassigned again | `_Z` and `_endogvar` are reassigned again | NumPy arrays on solver scale, premultiplied by `sqrt(_weights)` |
+| solve | `_Z` aliases `_X`; fit products overwrite empty placeholders | IV cross-products and fit outputs replace placeholders | Solver-scale arrays remain attached to the fitted result |
+
+Consequently, the meaning of `_X`, `_Y`, and `_Z` cannot be inferred from
+their names or type annotations alone. OLS and IV `_u_hat` are also stored on
+solver scale; the public `resid()` accessor divides by `sqrt(_weights)` to
+return residuals in response units. Consumers such as leverage, covariance,
+fixed-effect recovery, and decomposition either expect solver-scale fields or
+undo the transform locally.
+
+The API currently accepts analytic weights (`aweights`) and frequency weights
+(`fweights`), not probability weights. Both weight types use the same weighted
+point-estimation transform. They differ in effective sample size and parts of
+inference: analytic weights use the number of retained rows, while frequency
+weights use the sum of the weights. Estimator-specific support limitations
+must remain explicit rather than being inferred from the array representation.
+
+### GLM, Poisson, and quantile models
+
+`Feglm` starts with formula-materialized DataFrames and converts `_Y`, `_X`,
+and `_fe` to arrays before IRLS. Each iteration creates a working response and
+working weights, performs a weighted FE projection, and solves a square-root-
+weighted least-squares problem. After the final iteration:
+
+- `_X` and `_Y` are replaced by the final solver-scale working design and
+  response;
+- `_weights`, which initially contains observation weights, is replaced by the
+  final IRLS weights and duplicated in `_irls_weights`;
+- `_u_hat` is the solver-scale working residual, while
+  `_u_hat_response` and `_u_hat_working` record two public residual domains;
+- `_scores`, `_scores_response`, and `_scores_working` similarly coexist on
+  different scales.
+
+`Fepois` must copy the observation weights before delegating to this GLM path
+because the inherited `_weights` field changes meaning. `Quantreg` does not
+support fixed effects or weights, but it still reassigns formula-materialized
+`_Y` and `_X` DataFrames to NumPy arrays before solving.
+
+### Shared caches, result completion, and cleanup
+
+For a multiple-estimation cache block, the runner gives each model a
+`DemeanCache` backed by the same mutable dictionaries. Its linear-model cache
+converts pandas inputs to arrays for demeaning, wraps the results in a
+DataFrame, stores that frame, and converts selected columns back to arrays in
+each model. The cache key is the retained-row index set because formulas in one
+cache block share fixed effects and observation weights. GLM iterations do not
+cache demeaned values because their working weights change; they share only a
+preconditioner cache.
+
+Model constructors also create many empty-array and `None` placeholders. The
+runner then mutates the model through preparation, fitting, covariance
+calculation, inference, performance statistics or IV first stages, and finally
+`_clear_attributes()`. `store_data=False` deletes `_data`; `lean=True` deletes
+the retained matrices and several fit products. The public `vcov()` method is
+intentionally in-place and remains a post-fit mutation boundary. User input is
+copied by default, with the documented `copy_data=False` path as the exception.
+
+## Estimation-state vocabulary
+
+New shared-core work should name the transformation domain instead of relying
+on `_X`, `_Y`, `_Z`, or `_weights`. The planned immutable-state refactor uses
+the following vocabulary:
+
+| Term | Meaning |
+|---|---|
+| formula data | Post-filtering, formula-materialized tabular values and metadata; not necessarily identical to raw user columns |
+| observation weights | The weights supplied by the user, together with their `aweights` or `fweights` interpretation |
+| within data | Arrays after the possibly weighted FE projection, still in original units and not premultiplied by square-root weights |
+| solver data | Ephemeral arrays such as `design_sqrt_weighted` used by a numerical solve |
+| working state | GLM iteration values, including a working response and working weights, kept distinct from observation weights |
+| response residual | A residual in the response's units; weighted scores and solver residuals should be named separately |
+
+These states should be completed values returned by transformations. Persisted
+arrays should not change type or numerical domain, and solver scratch should
+not replace canonical within data. A fitted result may still expose explicitly
+in-place post-estimation operations, but those operations must not repurpose
+estimation fields.
+
 ## Repository map and extension seams
 
 | Change | Primary location | Pattern to follow |

--- a/docs/developer/testing.md
+++ b/docs/developer/testing.md
@@ -12,16 +12,17 @@ selection affect wall time.
 
 | Stage | Purpose | Typical scale | Examples |
 |---|---|---|---|
-| Edit feedback | Exercise the changed seam repeatedly | Seconds to a few minutes | targeted pytest, targeted or fast live-R checks, changed-file Ruff/mypy |
+| Edit feedback | Exercise the changed seam repeatedly | Seconds to a few minutes | targeted pytest, release snapshots, changed-file Ruff/mypy; targeted or fast live-R checks after numerical work stabilizes |
 | Stabilized implementation | Broaden local confidence once | Minutes | selected subsystem checks, `pixi run test-py` when required |
 | Merge evidence | Validate the exact PR head in affected environments | May take tens of minutes | canonical R, HAC, no-JIT, docs, plots, Rust, platform CI |
 | Exhaustive or release | Exercise everything available | Potentially substantially longer | `test-all`, CRAN-only dependencies, platform CI, benchmarks |
 
 Run edit checks repeatedly, but do not repeatedly launch `test-r-fixest`,
-`test-r-core`, or `test-all` while iterating. Use a targeted test or
-`test-r-fixest-fast` instead. Once the design is stable, run the selected
-baseline once. A required long check may be deferred to exact-head CI at
-implementation handoff when the report names the check and destination.
+`test-r-core`, or `test-all` while iterating. Use a targeted test or the
+Python-only release snapshot task first. Once numerical work stabilizes, use
+the targeted or fast live-R suite as an external correctness check, then run the
+selected baseline once. A required long check may be deferred to exact-head CI
+at implementation handoff when the report names the check and destination.
 Deferred is never equivalent to passed, and the change is not merge-ready
 until all required merge evidence is green.
 
@@ -41,6 +42,12 @@ platform CI and benchmarks.
 ```bash
 # Targeted, without the repository-wide coverage report
 pixi run -e py312-r pytest tests/test_<feature>.py -x -q --no-cov
+
+# Fast Python-only release-contract edit feedback
+pixi run -e py312 test-estimation-snapshots
+
+# Complete release-contract matrix (also collected once by test-py)
+pixi run -e py312 test-estimation-snapshots-full
 
 # Targeted live-R edit feedback
 pixi run -e py312-r pytest -q tests/test_vs_r_fast.py --no-cov -k feols
@@ -72,6 +79,68 @@ pixi run docs-build
 pixi run docs-render
 ```
 
+## Release numerical-contract snapshots
+
+`tests/test_estimation_snapshots.py` replays broad, end-to-end public fits
+against results generated locally from the pinned stable pyfixest release. It
+covers `feols`, `fepois`, `feglm`, and `quantreg`, including the
+complete fit-time SSC matrix, weighted IV, and frequency weights where that
+release and current head overlap. It compares aligned named coefficients and
+inference quantities using explicit
+estimator/quantity tolerances, and matches structural metadata exactly. It is a
+fast regression alarm, not an external correctness oracle: a release bug would
+also be captured.
+
+The complete matrix is part of ordinary `test-py` exactly once. The direct
+no-coverage task selects a deterministic balanced fast tier; use the explicit
+full task after stabilization when `test-py` is not otherwise selected. Keep
+`test-r-fixest-fast`: after numerical work
+stabilizes, it provides direct external feedback and remains the same-job R CI
+preflight. The canonical R suites remain the authoritative exact-head merge
+evidence.
+
+The first snapshot task uses the locked workspace in
+`tests/snapshots/release/` to generate the baseline with pyfixest 0.60.0. It
+stores the JSON under `.pixi/release-contract/`, which is gitignored. Later
+runs on the same platform reuse that cache. CI generates its own baseline on
+each fresh runner, so snapshots run on Linux, macOS, Windows, and contributor
+machines without comparing one platform's floating-point output with another's.
+
+A short fingerprint names the cache. It hashes the release manifest and
+lockfile, the declared release version, case matrix, data generation and
+extraction code, the generator, and the operating system and architecture.
+Changing any of these inputs selects a new cache automatically. The generator
+writes a completion marker last so interrupted generation is never treated as
+a valid baseline.
+
+Normal test commands prepare the cache automatically. To prepare or explicitly
+replace it without running the current checkout's tests, use:
+
+```bash
+pixi run --locked --clean-env --manifest-path tests/snapshots/release/pixi.toml prepare
+pixi run --locked --clean-env --manifest-path tests/snapshots/release/pixi.toml regenerate
+```
+
+Do not commit generated JSON or restore it across operating systems or
+architectures. The generated manifest records the release version, isolated
+distribution and environment facts, deterministic data specification, every
+case, fast selection, platform, and fingerprint.
+
+The baseline is never generated from development head. On drift, inspect the
+post-baseline changelog first: narrowly comment only a documented intentional
+quantity and retain external R evidence; leave unexplained drift as an ordinary
+failing assertion for human review. Change the pinned release only for an
+explicit baseline roll to a newly selected stable version.
+The release contract deliberately excludes paths unavailable in that release;
+for example, 0.60.0 cannot parse current canonical `:` fixed-effect
+interactions. Do not create a synthetic baseline for such a path: classify it
+with the existing live-R evidence instead.
+Although 0.60.0 exposes a FEPoisson frequency-weight argument, its released
+IRLS path fails dimensionally. Current FEPoisson frequency weights remain a
+known skipped issue ([#367](https://github.com/py-econometrics/pyfixest/issues/367)),
+so they are deliberately outside this PR rather than represented by a
+synthetic release artifact or claimed live-R coverage.
+
 `test-r-core` remains the convenient local aggregate for all canonical
 conda-forge R comparisons. CI partitions that population into
 `test-r-fixest` and the internal `test-r-core-other` shard so
@@ -86,7 +155,7 @@ preflight in the canonical `fixest` job.
 | Content under `docs/` | `git diff --check`; execute changed examples; render the affected page when practical | `docs-render` only for site-wide configuration, navigation, templates, or cross-page changes |
 | Repository guidance or workflow metadata outside `docs/` | `git diff --check`; targeted skill, template, or configuration validation | affected CI workflow only; no docs build by default |
 | Python API or internals | targeted public tests; changed-file lint/type checks | Python baseline |
-| Estimation or inference numerics | targeted integration and edge tests | applicable live external-reference suite |
+| Estimation or inference numerics | targeted integration and release snapshots; targeted/fast live-R after stabilization | applicable live external-reference suite |
 | New estimator | complete support matrix and permanent external comparison | Python baseline, external suite, full platform CI |
 | HAC | targeted HAC/meat tests | single-threaded `test-r-hac` |
 | Rust | kernel/reference integration tests | Python baseline, platform CI, and relevant benchmarks |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,7 @@ markers = [
     "against_r_core: mark test to be part of the test suite that depends on conda available R modules",
     "against_r_extended: mark test to be part of the test suite that depends on other R modules",
     "fast_r: marks tests in the fast R comparison suite",
+    "snapshot_fast: marks deterministic release-contract cases for edit feedback",
     "extended: mark test to be part of the extended test suite",
     "plots: marks all tests for plotting functionality, tests only triggered when using tag in github issue",
     "hac: marks all tests for HAC SEs"
@@ -215,7 +216,10 @@ maturin = ">=1.8"
 MPLCONFIGDIR = "$PIXI_PROJECT_ROOT/.pixi/matplotlib"
 
 [tool.pixi.tasks]
-test-py = { cmd = 'pytest tests -n auto -m "not (extended or against_r_core or against_r_extended or plots or hac)" --cov=pyfixest --cov-report=xml', depends-on = ["_setup"], description = "Quick Python tests (no R, extended, plots, or HAC)" }
+_prepare-estimation-snapshots = { cmd = "pixi run --locked --clean-env --manifest-path tests/snapshots/release/pixi.toml prepare", description = "Prepare the platform-local pyfixest 0.60.0 release contract" }
+test-py = { cmd = 'pytest tests -n auto -m "not (extended or against_r_core or against_r_extended or plots or hac)" --cov=pyfixest --cov-report=xml', depends-on = ["_setup", "_prepare-estimation-snapshots"], description = "Quick Python tests (no R, extended, plots, or HAC)" }
+test-estimation-snapshots = { cmd = "pytest -p no:sugar -q tests/test_estimation_snapshots.py -m snapshot_fast --no-cov --durations=20 --durations-min=0.05", depends-on = ["_setup", "_prepare-estimation-snapshots"], description = "Fast Python-only release numerical-contract regression tests" }
+test-estimation-snapshots-full = { cmd = "pytest -p no:sugar -q tests/test_estimation_snapshots.py --no-cov --durations=20 --durations-min=0.05", depends-on = ["_setup", "_prepare-estimation-snapshots"], description = "Complete Python-only release numerical-contract regression tests" }
 test-py-extended = { cmd = 'pytest tests -n auto -m "extended" --cov=pyfixest --cov-report=xml', depends-on = ["_setup"], description = "Extended Python tests" }
 test-py-nojit = { cmd = 'pytest tests/test_ses.py tests/test_demean.py tests/test_collinearity.py tests/test_count_fixef_fully_nested.py -n auto --cov=pyfixest --cov-report=xml:coverage-nojit.xml', env = { NUMBA_DISABLE_JIT = "1" }, depends-on = ["_setup"], description = "Run numba-heavy tests with NUMBA_DISABLE_JIT=1 so codecov sees numba code paths (weekly extended suite)" }
 render-notebooks = { cmd = "python scripts/run_notebooks.py", description = "Run all notebooks" }
@@ -276,7 +280,7 @@ description = "HAC standard error tests vs R"
 env = { OMP_NUM_THREADS = "1", OPENBLAS_NUM_THREADS = "1", MKL_NUM_THREADS = "1", VECLIB_MAXIMUM_THREADS = "1", NUMEXPR_NUM_THREADS = "1" }
 
 [tool.pixi.feature.r.tasks]
-test-all = { cmd = "pytest -rs -n auto --cov-report=term tests", depends-on = ["_setup"], description = "Run all tests available in the current Python + R environment" }
+test-all = { cmd = "pytest -rs -n auto --cov-report=term tests", depends-on = ["_setup", "_prepare-estimation-snapshots"], description = "Run all tests available in the current Python + R environment" }
 test-r-core = { cmd = 'pytest -rs -n auto tests -m "against_r_core and not fast_r" --cov=pyfixest --cov-report=xml', depends-on = ["_setup"], description = "Canonical tests against R packages available on conda-forge" }
 test-r-core-other = { cmd = 'pytest -rs -n auto tests --ignore=tests/test_vs_fixest.py -m "against_r_core and not fast_r" --cov=pyfixest --cov-report=xml', depends-on = ["_setup"], description = "CI shard for canonical conda-forge R tests outside test_vs_fixest.py" }
 test-r-extended = { cmd = 'pytest -rs -n auto tests -m "against_r_extended" --cov=pyfixest --cov-report=xml', depends-on = ["_setup"], description = "Tests against R (requires manual Rscript r_test_requirements.R)" }

--- a/scripts/generate_estimation_snapshots.py
+++ b/scripts/generate_estimation_snapshots.py
@@ -1,0 +1,164 @@
+"""Prepare the platform-local release numerical-contract cache."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.metadata
+import json
+import platform
+import shutil
+import sys
+import tempfile
+import warnings
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+# Import the release wheel before adding any checkout-local helper to sys.path.
+# The Pixi task uses ``python -P`` so the checkout cannot
+# shadow this package just because the command is launched at repository root.
+import pyfixest  # noqa: E402
+
+_module_path = Path(pyfixest.__file__).resolve()
+if _module_path.is_relative_to(ROOT / "pyfixest"):
+    raise RuntimeError(
+        "The generator imported pyfixest from this checkout, not the isolated release wheel."
+    )
+
+sys.path.insert(0, str(ROOT / "tests"))
+
+from _estimation_snapshot_cache import (  # noqa: E402
+    CACHE_ROOT,
+    COMPLETE_MARKER,
+    snapshot_dir,
+    snapshot_fingerprint,
+)
+from _estimation_snapshot_contract import (  # noqa: E402
+    AUGMENTATION_SEED,
+    DATA_SEED,
+    NOBS,
+    RELEASE_VERSION,
+    SCHEMA_VERSION,
+    build_cases,
+    extract_snapshot,
+    fast_case_ids,
+    fit_case,
+)
+
+
+def _json_bytes(value: object) -> bytes:
+    return (
+        json.dumps(value, indent=2, sort_keys=True, allow_nan=False) + "\n"
+    ).encode()
+
+
+def _artifacts(output_dir: Path) -> dict[Path, dict[str, object]]:
+    installed_version = importlib.metadata.version("pyfixest")
+    if installed_version != RELEASE_VERSION:
+        raise RuntimeError(
+            f"Expected pyfixest=={RELEASE_VERSION}, found {installed_version}. "
+            "Use an isolated interpreter containing the recorded release wheel."
+        )
+    cases = build_cases()
+    snapshots: dict[str, dict[str, object]] = {}
+    print(f"Generating {len(cases)} release snapshot cases...")
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        for case in cases:
+            estimator = str(case["estimator"])
+            snapshots.setdefault(estimator, {})[str(case["id"])] = extract_snapshot(
+                fit_case(case)
+            )
+
+    manifest = {
+        "schema_version": SCHEMA_VERSION,
+        "baseline": {
+            "pyfixest_version": installed_version,
+            "pyfixest_distribution": "pyfixest",
+            "pyfixest_module_location": "site-packages/pyfixest",
+            "python_environment": "tests/snapshots/release/.pixi/envs/default",
+            "python_version": platform.python_version(),
+            "platform": platform.system(),
+            "architecture": platform.machine(),
+            "numpy_version": importlib.metadata.version("numpy"),
+            "pandas_version": importlib.metadata.version("pandas"),
+            "scipy_version": importlib.metadata.version("scipy"),
+        },
+        "fingerprint": snapshot_fingerprint(),
+        "generation_command": (
+            "pixi run --locked --clean-env --manifest-path "
+            "tests/snapshots/release/pixi.toml prepare"
+        ),
+        "data": {
+            "base_seed": DATA_SEED,
+            "augmentation_seed": AUGMENTATION_SEED,
+            "nobs_before_complete_case": NOBS,
+            "description": (
+                "Base data use a deterministic NumPy Generator; a separate deterministic "
+                "augmentation stream supplies IV Z1/X_endog/Y_iv and positive integer "
+                "fweights. f3 has seven missing rows for complete-case SSC paths."
+            ),
+        },
+        "cases": cases,
+        "snapshot_files": {
+            estimator: f"{estimator}.json" for estimator in sorted(snapshots)
+        },
+        "fast_case_ids": sorted(fast_case_ids(cases)),
+    }
+    artifacts: dict[Path, dict[str, object]] = {output_dir / "manifest.json": manifest}
+    artifacts.update(
+        {
+            output_dir / f"{estimator}.json": {
+                "schema_version": SCHEMA_VERSION,
+                "estimator": estimator,
+                "cases": values,
+            }
+            for estimator, values in snapshots.items()
+        }
+    )
+    return artifacts
+
+
+def _prepare(*, force: bool) -> Path:
+    target = snapshot_dir()
+    complete = target / COMPLETE_MARKER
+    if complete.exists() and not force:
+        print(f"Release snapshot cache hit: {target.relative_to(ROOT)}")
+        return target
+
+    CACHE_ROOT.mkdir(parents=True, exist_ok=True)
+    if target.exists():
+        if not force and complete.exists():
+            print(f"Release snapshot cache hit: {target.relative_to(ROOT)}")
+            return target
+        if not force:
+            raise RuntimeError(f"Incomplete release snapshot cache: {target}")
+        shutil.rmtree(target)
+    temporary = Path(tempfile.mkdtemp(prefix=".building-", dir=CACHE_ROOT))
+    try:
+        for path, value in _artifacts(temporary).items():
+            path.write_bytes(_json_bytes(value))
+        (temporary / COMPLETE_MARKER).write_text(snapshot_fingerprint() + "\n")
+        try:
+            temporary.rename(target)
+        except FileExistsError:
+            if not complete.exists():
+                raise
+    finally:
+        if temporary.exists():
+            shutil.rmtree(temporary)
+    print(f"Prepared release snapshot cache: {target.relative_to(ROOT)}")
+    return target
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--force", action="store_true", help="replace this platform's current cache"
+    )
+    args = parser.parse_args()
+    _prepare(force=args.force)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/_estimation_snapshot_cache.py
+++ b/tests/_estimation_snapshot_cache.py
@@ -1,0 +1,36 @@
+"""Locate the platform-local cache for release-contract snapshots."""
+
+from __future__ import annotations
+
+import hashlib
+import platform
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CACHE_ROOT = ROOT / ".pixi" / "release-contract"
+COMPLETE_MARKER = ".complete"
+FINGERPRINT_INPUTS = (
+    "tests/snapshots/release/pixi.toml",
+    "tests/snapshots/release/pixi.lock",
+    "tests/_estimation_snapshot_cache.py",
+    # This contract owns the release version, cases, data, and extraction.
+    "tests/_estimation_snapshot_contract.py",
+    "tests/_feols_test_cases.py",
+    "scripts/generate_estimation_snapshots.py",
+)
+
+
+def snapshot_fingerprint() -> str:
+    """Hash the locked baseline contract and current operating platform."""
+    digest = hashlib.sha256(
+        f"{platform.system().lower()}:{platform.machine().lower()}".encode()
+    )
+    for relative_path in FINGERPRINT_INPUTS:
+        digest.update(relative_path.encode())
+        digest.update((ROOT / relative_path).read_bytes())
+    return digest.hexdigest()[:16]
+
+
+def snapshot_dir() -> Path:
+    """Return the ignored cache directory for the current contract fingerprint."""
+    return CACHE_ROOT / snapshot_fingerprint()

--- a/tests/_estimation_snapshot_contract.py
+++ b/tests/_estimation_snapshot_contract.py
@@ -1,0 +1,555 @@
+"""Shared release-contract data, cases, extraction, and assertions.
+
+The cached JSON artifacts are generated with a released wheel, not with the
+editable checkout. This module is dependency-light so the isolated generator
+can import it.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+from _feols_test_cases import FEOLS_FORMULA_F3_CASES, convert_f3
+
+SCHEMA_VERSION = 1
+RELEASE_VERSION = "0.60.0"
+DATA_SEED = 20260831
+AUGMENTATION_SEED = DATA_SEED + 1
+NOBS = 500
+SAMPLE_SIZE = 5
+
+# These are numerical regression tolerances, not release-to-R tolerances. They
+# allow only normal floating-point variation between the release wheel and head.
+TOLERANCES: dict[str, dict[str, tuple[float, float]]] = {
+    "feols": {
+        "coef": (1e-8, 1e-9),
+        "vcov": (1e-7, 1e-9),
+        "inference": (1e-7, 1e-9),
+        # Frequency-weighted three-way FE t statistics differ by 1.54e-7
+        # relative between the release wheel and head; other inference outputs
+        # remain at the tighter generic bound.
+        "tstat": (2e-7, 1e-9),
+        "samples": (1e-6, 1e-9),
+        "metrics": (1e-7, 1e-9),
+    },
+    "fepois": {
+        "coef": (1e-6, 1e-8),
+        "vcov": (1e-6, 1e-8),
+        "inference": (1e-6, 1e-8),
+        # Tiny absolute p-values require a small absolute allowance; all other
+        # FEPoisson quantities retain the tighter 1e-6 relative tolerance.
+        "pvalue": (2e-6, 5e-8),
+        "confint": (3e-6, 5e-8),
+        "samples": (1e-6, 1e-8),
+        "metrics": (1e-10, 1e-10),
+    },
+    "feglm": {
+        "coef": (1e-6, 1e-8),
+        "vcov": (1e-6, 1e-8),
+        "inference": (1e-6, 1e-8),
+        "samples": (1e-6, 1e-8),
+        "metrics": (1e-7, 1e-8),
+    },
+    "quantreg": {
+        "coef": (1e-7, 1e-8),
+        "vcov": (1e-7, 1e-8),
+        "inference": (1e-7, 1e-8),
+        "samples": (1e-7, 1e-8),
+        "metrics": (1e-7, 1e-8),
+    },
+}
+
+
+def build_data(data_id: str, *, variant: str, f3_type: str = "str") -> pd.DataFrame:
+    """Build a deterministic, small public-API input frame for one estimator."""
+    rng = np.random.default_rng(DATA_SEED)
+    nobs = NOBS
+    f1 = rng.integers(0, 10, size=nobs)
+    f2 = rng.integers(0, 12, size=nobs)
+    f3 = rng.integers(0, 8, size=nobs).astype(float)
+    x1 = rng.normal(size=nobs)
+    x2 = rng.normal(size=nobs)
+    weights = 0.5 + rng.random(size=nobs)
+    linear = 5.0 + 0.7 * x1 - 0.4 * x2 + 0.15 * f1 - 0.1 * f2
+
+    if data_id == "linear":
+        outcome = linear + rng.normal(scale=0.8, size=nobs)
+    elif data_id == "count":
+        outcome = 1 + rng.poisson(
+            np.exp(np.clip(-0.2 + 0.25 * x1 - 0.15 * x2 + 0.04 * f1, -3, 3))
+        )
+    elif data_id == "binary":
+        probability = 1 / (
+            1 + np.exp(-np.clip(-0.1 + 0.55 * x1 - 0.35 * x2 + 0.1 * f1, -6, 6))
+        )
+        outcome = rng.binomial(1, probability)
+    elif data_id == "quantile":
+        outcome = 1 + 2 * x1 + 3 * x2 - 0.5 * x2**2 + rng.normal(size=nobs)
+    else:  # pragma: no cover - closed case matrix
+        raise ValueError(f"Unknown snapshot data id: {data_id}")
+
+    # Keep the original base-data random stream fixed as this contract grows.
+    # IV and frequency-weight coverage use a separate deterministic stream so
+    # adding them cannot perturb established formula/SSC/GLM release cases.
+    iv_rng = np.random.default_rng(AUGMENTATION_SEED)
+    z1 = iv_rng.normal(size=nobs)
+    endog_error = iv_rng.normal(size=nobs)
+    x_endog = 0.9 * z1 + 0.6 * endog_error
+    fweights = iv_rng.integers(1, 5, size=nobs)
+
+    data = pd.DataFrame(
+        {
+            "Y": outcome,
+            "Y_iv": linear + 0.8 * x_endog + 0.5 * endog_error,
+            "X1": x1,
+            "X2": x2,
+            "X_endog": x_endog,
+            "Z1": z1,
+            "f1": f1,
+            "f2": f2,
+            "f3": f3,
+            "weights": weights,
+            "fweights": fweights,
+        }
+    )
+    # This makes the complete-case SSC path observable even for formulas that
+    # do not otherwise reference f3, matching the canonical SSC matrix setup.
+    data.loc[data.index[:7], "f3"] = np.nan
+    if variant == "complete":
+        data = data.dropna().copy()
+    elif variant != "full":  # pragma: no cover - closed case matrix
+        raise ValueError(f"Unknown snapshot data variant: {variant}")
+    return convert_f3(data, f3_type)
+
+
+def _id(prefix: str, index: int, **parts: object) -> str:
+    suffix = "-".join(f"{key}={value}" for key, value in parts.items())
+    return f"{prefix}-{index:03d}-{suffix}" if suffix else f"{prefix}-{index:03d}"
+
+
+def _ssc_cases() -> list[dict[str, Any]]:
+    """Return the canonical exhaustive fit-time SSC matrix for feols/fepois."""
+    formulas = (
+        "Y ~ X1 + X2 + f1",
+        "Y ~ X1 + X2 | f1",
+        "Y ~ X1 + X2 | f2",
+        "Y ~ X1 + X2 | f1 + f2",
+        "Y ~ X1 + X2 | f1 + f2 + f3",
+        # ``^`` is the release-compatible fixed-effect interaction spelling.
+        # Current pyfixest still accepts it (with a deprecation warning).
+        "Y ~ X1 + X2 | f1^f2",
+    )
+    cases: list[dict[str, Any]] = []
+    index = 0
+    for estimator, data_id in (("feols", "linear"), ("fepois", "count")):
+        for formula_index, formula in enumerate(formulas):
+            for variant in ("complete", "full"):
+                for vcov_name in ("iid", "hetero", "f1", "f2", "f1+f2"):
+                    if (
+                        variant == "full"
+                        and vcov_name not in {"iid", "hetero"}
+                        and vcov_name not in formula
+                    ):
+                        continue
+                    vcov: str | dict[str, str] = (
+                        vcov_name
+                        if vcov_name in {"iid", "hetero"}
+                        else {"CRV1": vcov_name}
+                    )
+                    weight_options = (
+                        (
+                            (None, None),
+                            ("weights", "aweights"),
+                            ("fweights", "fweights"),
+                        )
+                        if estimator == "feols"
+                        # 0.60.0 exposes fweights in the FEPoisson signature,
+                        # but its IRLS dimensions fail (current issue #367).
+                        # It remains outside this release contract.
+                        else ((None, None), ("weights", "aweights"))
+                    )
+                    for weights, weights_type in weight_options:
+                        for k_adj in (True, False):
+                            for g_adj in (True, False):
+                                for k_fixef in ("full", "none", "nonnested"):
+                                    cases.append(
+                                        {
+                                            "id": _id(
+                                                estimator,
+                                                index,
+                                                group="ssc",
+                                                formula=formula_index,
+                                                data=variant,
+                                                vcov=vcov_name,
+                                                weights=weights or "none",
+                                                k_adj=k_adj,
+                                                g_adj=g_adj,
+                                                k_fixef=k_fixef,
+                                            ),
+                                            "estimator": estimator,
+                                            "formula": formula,
+                                            "data": data_id,
+                                            "data_variant": variant,
+                                            "kwargs": {
+                                                "vcov": vcov,
+                                                "weights": weights,
+                                                **(
+                                                    {"weights_type": weights_type}
+                                                    if weights_type is not None
+                                                    else {}
+                                                ),
+                                                "ssc": {
+                                                    "k_adj": k_adj,
+                                                    "G_adj": g_adj,
+                                                    "G_df": "min",
+                                                    "k_fixef": k_fixef,
+                                                },
+                                                **(
+                                                    {
+                                                        "iwls_tol": 1e-10,
+                                                        "iwls_maxiter": 100,
+                                                    }
+                                                    if estimator == "fepois"
+                                                    else {}
+                                                ),
+                                            },
+                                        }
+                                    )
+                                    index += 1
+    return cases
+
+
+def build_cases() -> list[dict[str, Any]]:
+    """Return every released, overlapping end-to-end public fit contract case."""
+    cases: list[dict[str, Any]] = []
+    release_formula_cases = tuple(
+        (formula, f3_type)
+        for formula, f3_type in FEOLS_FORMULA_F3_CASES
+        # 0.60.0 cannot parse current canonical ``:`` fixed-effect interactions.
+        # Formula interactions before the FE separator remain in the contract.
+        if "|" not in formula or ":" not in formula.split("|", maxsplit=1)[1]
+    )
+    for index, (formula, f3_type) in enumerate(release_formula_cases):
+        cases.append(
+            {
+                "id": _id("feols", index, group="formula", f3_type=f3_type),
+                "estimator": "feols",
+                "formula": formula,
+                "data": "linear",
+                "data_variant": "complete",
+                "f3_type": f3_type,
+                "kwargs": {"vcov": "hetero"},
+            }
+        )
+    cases.extend(_ssc_cases())
+
+    for index, (formula, vcov) in enumerate(
+        (
+            ("Y_iv ~ X1 + X2 | X_endog ~ Z1", "iid"),
+            ("Y_iv ~ X1 + X2 | X_endog ~ Z1", "hetero"),
+            ("Y_iv ~ X1 + X2 | X_endog ~ Z1", {"CRV1": "f1"}),
+            ("Y_iv ~ X1 + X2 | f1 | X_endog ~ Z1", "iid"),
+            ("Y_iv ~ X1 + X2 | f1 | X_endog ~ Z1", "hetero"),
+            ("Y_iv ~ X1 + X2 | f1 | X_endog ~ Z1", {"CRV1": "f1"}),
+        )
+    ):
+        for weights, weights_type in (
+            (None, None),
+            ("weights", "aweights"),
+            ("fweights", "fweights"),
+        ):
+            cases.append(
+                {
+                    "id": _id(
+                        "feols",
+                        index,
+                        group="iv",
+                        fe=("yes" if "| f1 |" in formula else "no"),
+                        vcov=("crv1" if isinstance(vcov, dict) else vcov),
+                        weights=weights or "none",
+                    ),
+                    "estimator": "feols",
+                    "formula": formula,
+                    "data": "linear",
+                    "data_variant": "complete",
+                    "kwargs": {
+                        "vcov": vcov,
+                        "weights": weights,
+                        **(
+                            {"weights_type": weights_type}
+                            if weights_type is not None
+                            else {}
+                        ),
+                    },
+                }
+            )
+
+    # 0.60.0 predates the development-head fepois-through-feglm API additions.
+    # The overlapping feglm contract is therefore unweighted logit/probit only.
+    for index, (family, formula, vcov) in enumerate(
+        (
+            ("logit", "Y ~ X1 + X2", "iid"),
+            ("logit", "Y ~ X1 + X2 | f1", "hetero"),
+            ("logit", "Y ~ X1 + X2 | f1", {"CRV1": "f1"}),
+            ("probit", "Y ~ X1 + X2", "iid"),
+            ("probit", "Y ~ X1 + X2 | f1", "hetero"),
+            ("probit", "Y ~ X1 + X2 | f1", {"CRV1": "f1"}),
+        )
+    ):
+        cases.append(
+            {
+                "id": _id(
+                    "feglm",
+                    index,
+                    family=family,
+                    vcov=("crv1" if isinstance(vcov, dict) else vcov),
+                ),
+                "estimator": "feglm",
+                "formula": formula,
+                "data": "binary",
+                "data_variant": "complete",
+                "kwargs": {
+                    "family": family,
+                    "vcov": vcov,
+                    "iwls_tol": 1e-10,
+                    "iwls_maxiter": 100,
+                },
+            }
+        )
+
+    for index, (formula, quantile, method, vcov) in enumerate(
+        (
+            ("Y ~ X1", 0.02, "fn", "nid"),
+            ("Y ~ X1 + X2", 0.35, "pfn", "nid"),
+            ("Y ~ X1", 0.5, "pfn", "nid"),
+            ("Y ~ X1 + X2", 0.9, "fn", "nid"),
+            ("Y ~ X1 + X2", 0.5, "fn", {"CRV1": "f1"}),
+        )
+    ):
+        cases.append(
+            {
+                "id": _id(
+                    "quantreg",
+                    index,
+                    quantile=quantile,
+                    method=method,
+                    vcov=("crv1" if isinstance(vcov, dict) else vcov),
+                ),
+                "estimator": "quantreg",
+                "formula": formula,
+                "data": "quantile",
+                "data_variant": "complete",
+                "kwargs": {
+                    "quantile": quantile,
+                    "method": method,
+                    "vcov": vcov,
+                    "tol": 1e-6,
+                    "seed": 83838,
+                    "ssc": {"k_adj": False, "G_adj": False},
+                },
+            }
+        )
+    return cases
+
+
+def fast_case_ids(cases: list[dict[str, Any]]) -> frozenset[str]:
+    """Select a small, reviewable edit tier without weakening the full contract."""
+    formula_cases = (
+        "Y~X1",
+        "Y~X1+X2",
+        "Y~X1|f2",
+        "Y~X1|f2+f3",
+        "Y ~ X1 + exp(X2)",
+        "Y ~ X1 + C(f1)",
+        "Y ~ X1 + i(f1, ref = 1)",
+        "Y ~ X1 + X2:f1",
+        "Y ~ X1 + i(f1,X2) | f2",
+        "Y ~ X1 + I(X2 ** 2)",
+        "Y ~ X1*X2 | f1+f2",
+        "Y ~ X1 + poly(X2, 2) | f1",
+        "log(Y) ~ X1",
+    )
+    selected: set[str] = set()
+    for formula in formula_cases:
+        selected.add(
+            next(
+                case["id"]
+                for case in cases
+                if case["estimator"] == "feols"
+                and case["formula"] == formula
+                and case.get("f3_type", "str") == "str"
+            )
+        )
+    # One FE formula across all pandas f3 representations preserves that input
+    # boundary without replaying every formula in every representation.
+    for f3_type in ("str", "object", "int", "categorical", "float"):
+        selected.add(
+            next(
+                case["id"]
+                for case in cases
+                if case["estimator"] == "feols"
+                and case["formula"] == "Y~X1|f2+f3"
+                and case.get("f3_type") == f3_type
+            )
+        )
+
+    ssc_formulas = (
+        "Y ~ X1 + X2 + f1",
+        "Y ~ X1 + X2 | f1",
+        "Y ~ X1 + X2 | f2",
+        "Y ~ X1 + X2 | f1 + f2",
+        "Y ~ X1 + X2 | f1 + f2 + f3",
+        "Y ~ X1 + X2 | f1^f2",
+    )
+    ssc_variants = (
+        ("complete", "iid", None, True, True, "full"),
+        ("full", "hetero", "weights", False, False, "none"),
+        ("complete", "f2", None, True, False, "nonnested"),
+        ("complete", "f1+f2", "weights", False, True, "full"),
+        ("complete", "f1", None, True, True, "none"),
+        ("complete", "f1+f2", "weights", False, False, "nonnested"),
+    )
+    for estimator in ("feols", "fepois"):
+        for formula, (variant, vcov_name, weights, k_adj, g_adj, k_fixef) in zip(
+            ssc_formulas, ssc_variants, strict=True
+        ):
+            selected.add(
+                next(
+                    case["id"]
+                    for case in cases
+                    if case["estimator"] == estimator
+                    and case["formula"] == formula
+                    and case["data_variant"] == variant
+                    and case["kwargs"]["weights"] == weights
+                    and case["kwargs"]["ssc"]
+                    == {
+                        "k_adj": k_adj,
+                        "G_adj": g_adj,
+                        "G_df": "min",
+                        "k_fixef": k_fixef,
+                    }
+                    and (
+                        case["kwargs"]["vcov"] == vcov_name
+                        or case["kwargs"]["vcov"] == {"CRV1": vcov_name}
+                    )
+                )
+            )
+        if estimator == "feols":
+            # Keep released frequency weights in the fast tier without replaying
+            # the entire SSC matrix. FEPoisson fweights are broken in 0.60.0.
+            selected.add(
+                next(
+                    case["id"]
+                    for case in cases
+                    if case["estimator"] == estimator
+                    and case["formula"] == ssc_formulas[0]
+                    and case["kwargs"]["weights"] == "fweights"
+                )
+            )
+    for weights in ("weights", "fweights"):
+        selected.add(
+            next(
+                case["id"]
+                for case in cases
+                if case["estimator"] == "feols"
+                and "group=iv" in case["id"]
+                and case["kwargs"]["weights"] == weights
+                and case["kwargs"]["vcov"] == "hetero"
+            )
+        )
+    selected.update(
+        case["id"] for case in cases if case["estimator"] in {"feglm", "quantreg"}
+    )
+    return frozenset(selected)
+
+
+def fit_case(case: Mapping[str, Any]) -> Any:
+    """Fit one declared case strictly through its public pyfixest entry point."""
+    import pyfixest as pf
+
+    data = build_data(
+        str(case["data"]),
+        variant=str(case["data_variant"]),
+        f3_type=str(case.get("f3_type", "str")),
+    )
+    kwargs = dict(case["kwargs"])
+    if "ssc" in kwargs:
+        kwargs["ssc"] = pf.ssc(**kwargs["ssc"])
+    return getattr(pf, str(case["estimator"]))(
+        str(case["formula"]), data=data, **kwargs
+    )
+
+
+def _number(value: object) -> float | None:
+    """Make non-finite released inference explicit and JSON-safe."""
+    numeric = float(value)
+    return numeric if np.isfinite(numeric) else None
+
+
+def _named(series: pd.Series) -> dict[str, float | None]:
+    return {str(name): _number(value) for name, value in series.sort_index().items()}
+
+
+def extract_snapshot(fit: Any) -> dict[str, Any]:
+    """Extract stable named values without serialising a fitted model or repr."""
+    coef = fit.coef()
+    confint = fit.confint().sort_index()
+    names = list(coef.index)
+    vcov = np.asarray(fit._vcov)
+    order = [names.index(name) for name in sorted(names)]
+    sorted_names = sorted(names)
+    try:
+        predict_sample = [
+            _number(value) for value in np.asarray(fit.predict()).ravel()[:SAMPLE_SIZE]
+        ]
+        prediction_supported = True
+    except NotImplementedError:
+        predict_sample = []
+        prediction_supported = False
+    metadata: dict[str, Any] = {
+        "coefnames": names,
+        "nobs": int(fit._N),
+        "df_k": int(fit._df_k),
+        "df_t": int(fit._df_t),
+        "dropped_terms": sorted(str(name) for name in getattr(fit, "_collin_vars", [])),
+        "prediction_supported": prediction_supported,
+    }
+    if hasattr(fit, "convergence"):
+        metadata["convergence"] = bool(fit.convergence)
+    if hasattr(fit, "_has_converged"):
+        metadata["convergence"] = bool(fit._has_converged)
+    if getattr(fit, "deviance", None) is not None:
+        metadata["deviance"] = float(fit.deviance)
+    vcov_by_name = {
+        row_name: {
+            column_name: _number(vcov[row_position, column_position])
+            for column_name, column_position in zip(sorted_names, order, strict=True)
+        }
+        for row_name, row_position in zip(sorted_names, order, strict=True)
+    }
+    return {
+        "coef": _named(coef),
+        "vcov": vcov_by_name,
+        "se": _named(fit.se()),
+        "tstat": _named(fit.tstat()),
+        "pvalue": _named(fit.pvalue()),
+        "confint": {
+            str(name): {str(column): _number(value) for column, value in row.items()}
+            for name, row in confint.to_dict(orient="index").items()
+        },
+        "metadata": metadata,
+        "resid_sample": [
+            _number(value) for value in np.asarray(fit.resid()).ravel()[:SAMPLE_SIZE]
+        ],
+        "predict_sample": predict_sample,
+    }
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    """Read one cached JSON artifact."""
+    return json.loads(path.read_text())

--- a/tests/snapshots/release/pixi.lock
+++ b/tests/snapshots/release/pixi.lock
@@ -1,0 +1,2637 @@
+version: 7
+platforms:
+- name: linux-64
+  virtual-packages:
+  - __unix=0=0
+  - __linux=4.18
+  - __glibc=2.28
+  - __archspec=0=x86_64
+- name: osx-arm64
+  virtual-packages:
+  - __unix=0=0
+  - __osx=13.0
+  - __archspec=0=m1
+- name: win-64
+  virtual-packages:
+  - __win=10.0
+  - __archspec=0=x86_64
+environments:
+  default:
+    channels:
+    - url: https://conda.anaconda.org/conda-forge/
+    indexes:
+    - https://pypi.org/simple
+    packages:
+      linux-64:
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-py310h44b86e0_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.46.1-default_hbd61a6d_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.7.0-h81df57d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-16.2.0-ha9f2e26_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-16.2.0-he0feb66_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.4-h13e7031_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-16.2.0-h934c35e_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.38-h280c20c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.4-h781a0a9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.14-h8ab3286_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-hd6e31c0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h1df4ec4_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+      - pypi: https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/12/98/e976540c1addf70442be7842a18cf70884a964abbf69442504f4d2939989/pandas-3.0.5-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/18/53/84099323c2ec4be98d935f63c033ac4151ee83836ca1050ede3b3aadf155/joblib-1.6.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/18/5f/f992b57e8deb8fa6c2e614b422d80698adb5107902bbc89832e203665bd1/ipython-9.17.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/22/a6/858897256d0deac81a172289110f31629fc4cee19b6f01283303e18c8db3/ptyprocess-0.7.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2f/b2/bd9bfa6d77641bd3be57c7cd6ce10294d26db20cb9aedf19ac5d78845886/htmltools-0.7.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/30/36/996c8cbc787b3a6b9509bd139a2ae19acd2df32038b0e30d180312cd0354/great_tables-0.24.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/3a/13/547360d81e6d88d58492968ffda9f9542854f11310ee556fef14260cc886/zipp-4.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/3a/5f/62d28cf019460c7f1394105b4d49d9911a9c444cb77ab0bd95a204c5a6de/numpy-2.5.2-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/3d/e0/a65b64f34d556925faef2c4f14167d58c571bc15a3e1f2bba71138830562/lxml-6.1.2-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/41/09/5b161152e2d90f7b87f781c2e1267494aef9c32498df793f73ad0a0a494a/matplotlib_inline-0.2.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/54/6f/84908cad2d6aa5144abcf7b42709fe4fdb459bc640ec7ac5786e7693dabc/prompt_toolkit-3.0.53-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/58/50/6c0d534c5f134586a8e1ba4e330569e32f057e33372ae556463212fb4cd3/click-8.5.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/63/34/ba1c580383c9eada3711951fef0795c80b829a078d72188184bcab9dd527/packaging-26.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/65/3c/1db1b0f878319bb227f35a0fca7cad64e1f528b518bcab1a708da305c86d/faicons-0.2.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/71/46/17f022dd3e953bf20a04a028a21ec746d942f8d2af30fa0f124fa0e6a684/pygments-2.21.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/73/dc/c35af5ccf8dbf3268750c54a3c0830f486b8faec38c811aff92335aa99ba/nokap-0.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/77/c7/2342da9830e3e9d4870305ca5d2091d2a83284f2953079b7bdd3b5e029d8/fonttools-4.63.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/83/11/00d3c3dfc25ad54e731d91449895a79e4bf2384dc3ac01809010ba88f6d5/seaborn-0.13.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/84/21/a35af28dcc61f37ed850a2d64c65c701321dfbf25085e469d5559360cbbf/pillow-12.3.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/87/4a/74d5c8ef7bc1677b5aec3b5f353b0c51917e79ee6d12d7cb7cf4ed4fb0f0/pyfixest-0.60.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8a/db/55a262f3606bebcae07cc14095338471ad7c0bbcaa37707e6f0ee49725b7/importlib_resources-7.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/99/5d/8268b644392ee874ee82a635cd0df1773de230bde356c38de28e298392cc/parso-0.8.7-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9a/93/242e2eab5fe682ffcb8b0084bde703a41d51e17ee0f3a31ff0d9d813620a/jedi-0.20.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9e/c3/059298687310d527a58bb01f3b1965787ee3b40dce76752eda8b44e9a2c5/pexpect-4.9.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a1/d3/20a61a248feb1249cd81f83ce731f0bdf5170ed96a08a298f7081cda9e90/interface_meta-2.0.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ac/cb/7ef3503279a4d2dc6b7fed0d0c53a9d97d98f7c28166ebfcc45eef64fe29/maketables-0.1.8-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ad/66/0d785f0bc5e4315a96c989bb476d0fc07ea4f85132550c7b156ca2035d52/traitlets-5.16.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b1/db/dceb9dd5b231e1da801793f8acc9f3c52a7e1afe40bb1aae37e02b0faad5/cffi-2.1.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/b3/55/ecca97ae19075f1fac62def77731e7f535e6c1fb8f92ff08160c5e6dade8/importlib_metadata-9.0.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c4/0e/57f6bb3024a597b2e8ec4aee710ffe62ddc95af2e2bb1ee7a7abdc22c68c/wcwidth-0.8.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c9/cf/b4ad2cc81b6672ea29ea04e64e350a9f9b493b0908ccd884c67eeff8f7b2/matplotlib-3.11.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/cc/8f/ec6289987824b29529d0dfda0d74a07cec60e54b9c92f3c9da4c0ac732de/contourpy-1.3.3-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/d0/00/1e03a4989fa5795da308cd774f05b704ace555a70f9bf9d3be057b680bcf/python_docx-1.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d4/2b/04b8a15f3a1c77bc79ddf5c73875327f34b4fa75982df2b76e45e402d364/asttokens-3.0.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d9/33/1f075bf72b0b747cb3288d011319aaf64083cf2efef8354174e3ed4540e2/ipython_pygments_lexers-1.1.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/df/64/ff35eb9e54894cf471ff4716abd3c81eb0a0626869217ce3e6ba4ccf17d7/scipy-1.18.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/e6/0f/5f8f31ef2fb8f3e82f07fd0567a4b0c9ab8c863a1c47aacb7eded43d607f/multimark-0.3.2-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/eb/dc/55481808fd70ef1567cf13540ffd4702af3f74b112e35427564b03f79c2d/narwhals-2.25.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f8/fd/b20e3cb3cab35131b515edf18e8cd777dff680fc76fc00919481f4e536af/wrapt-2.4.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/f9/1c/01bfd571a64e7f270e6bab5e33777debe0edc56759233ce84f27dec92d14/tqdm-4.70.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/fb/05/9f82d090c8d2d861604147ef6dfb938a90b039f9358d5193f1df62558593/websockets-17.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/fc/75/0576b03f7889ad25b5385b4f6c69e0543713425a6f193b056c9b0a2e65ce/formulaic-1.2.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/fc/f4/dadfec469313c7f428efa7e84b4aba9732f813c13ea7131a24b7b008ef57/kiwisolver-1.5.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+      osx-arm64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h4e30115_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-py310h579977c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.7.0-h47dc5ef_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.4-hca69786_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-he64c551_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.4-h55eecbc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.14-hd1323d7_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h8b90a29_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-hbeba79b_4.conda
+      - pypi: https://files.pythonhosted.org/packages/05/4a/78c6285577c375e7cf27277ea8ee6961224327f1e1a0c44af5f17f23635c/scipy-1.18.1-cp312-cp312-macosx_12_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/08/ef/b3c6b9b5be2f82416d73fe2ed2e96e2793cd80e7510bd6a17ca79cdd88ec/fonttools-4.63.0-cp312-cp312-macosx_10_13_universal2.whl
+      - pypi: https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/18/53/84099323c2ec4be98d935f63c033ac4151ee83836ca1050ede3b3aadf155/joblib-1.6.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/18/5f/f992b57e8deb8fa6c2e614b422d80698adb5107902bbc89832e203665bd1/ipython-9.17.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1d/9c/3087e95e4aa3d8e9f4437d3c0af6d553a67539dff178ccbf4fedd967402e/multimark-0.3.2-cp39-abi3-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/22/a6/858897256d0deac81a172289110f31629fc4cee19b6f01283303e18c8db3/ptyprocess-0.7.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2f/b2/bd9bfa6d77641bd3be57c7cd6ce10294d26db20cb9aedf19ac5d78845886/htmltools-0.7.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/30/36/996c8cbc787b3a6b9509bd139a2ae19acd2df32038b0e30d180312cd0354/great_tables-0.24.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/3a/13/547360d81e6d88d58492968ffda9f9542854f11310ee556fef14260cc886/zipp-4.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/41/09/5b161152e2d90f7b87f781c2e1267494aef9c32498df793f73ad0a0a494a/matplotlib_inline-0.2.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/53/3e/405b59cfa13021a56bba395a6b3aca8cec012b45bf177b0eaf7a202cde2c/contourpy-1.3.3-cp312-cp312-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/54/6f/84908cad2d6aa5144abcf7b42709fe4fdb459bc640ec7ac5786e7693dabc/prompt_toolkit-3.0.53-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/54/7d/16e5a096677b5e313ca80cd5e5170efa3ea44624a82bb111925522da64b1/cffi-2.1.1-cp312-cp312-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/58/50/6c0d534c5f134586a8e1ba4e330569e32f057e33372ae556463212fb4cd3/click-8.5.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5d/90/095984648cec62a786bb27c0b50f6cfa5856d1e073ba1006fe148d190084/wrapt-2.4.0-cp312-cp312-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/60/2e/b5aee50a1f74ac815cf8331812cb8251e29024025de462e0c047641c614c/numpy-2.5.2-cp312-cp312-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/63/34/ba1c580383c9eada3711951fef0795c80b829a078d72188184bcab9dd527/packaging-26.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/65/3c/1db1b0f878319bb227f35a0fca7cad64e1f528b518bcab1a708da305c86d/faicons-0.2.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/68/56/fbe81c09195924d8b7b8d4461a20458fe80a6a5ed6b24f0314da684277e1/pandas-3.0.5-cp312-cp312-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/6f/12/0ab3920643f52eb21271b952b79998b374bf2e68a651f5201b4ac8aa044e/pyfixest-0.60.0-cp312-cp312-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/71/46/17f022dd3e953bf20a04a028a21ec746d942f8d2af30fa0f124fa0e6a684/pygments-2.21.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/73/dc/c35af5ccf8dbf3268750c54a3c0830f486b8faec38c811aff92335aa99ba/nokap-0.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/83/11/00d3c3dfc25ad54e731d91449895a79e4bf2384dc3ac01809010ba88f6d5/seaborn-0.13.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/84/e5/bdb34e21523e01dceda064d63713f3bdec91388af24fba1eca7ea5e85864/kiwisolver-1.5.1-cp312-cp312-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8a/db/55a262f3606bebcae07cc14095338471ad7c0bbcaa37707e6f0ee49725b7/importlib_resources-7.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8f/e7/df821761772beaa48c211ee0e234930b35c1473778470773823f56d3911b/websockets-17.1-cp312-cp312-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/99/5d/8268b644392ee874ee82a635cd0df1773de230bde356c38de28e298392cc/parso-0.8.7-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9a/93/242e2eab5fe682ffcb8b0084bde703a41d51e17ee0f3a31ff0d9d813620a/jedi-0.20.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9e/c3/059298687310d527a58bb01f3b1965787ee3b40dce76752eda8b44e9a2c5/pexpect-4.9.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a1/d3/20a61a248feb1249cd81f83ce731f0bdf5170ed96a08a298f7081cda9e90/interface_meta-2.0.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ac/cb/7ef3503279a4d2dc6b7fed0d0c53a9d97d98f7c28166ebfcc45eef64fe29/maketables-0.1.8-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ad/66/0d785f0bc5e4315a96c989bb476d0fc07ea4f85132550c7b156ca2035d52/traitlets-5.16.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b3/55/ecca97ae19075f1fac62def77731e7f535e6c1fb8f92ff08160c5e6dade8/importlib_metadata-9.0.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c4/0e/57f6bb3024a597b2e8ec4aee710ffe62ddc95af2e2bb1ee7a7abdc22c68c/wcwidth-0.8.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d0/00/1e03a4989fa5795da308cd774f05b704ace555a70f9bf9d3be057b680bcf/python_docx-1.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d4/2b/04b8a15f3a1c77bc79ddf5c73875327f34b4fa75982df2b76e45e402d364/asttokens-3.0.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d8/66/9a386a92561f402389a4fc70c18838bf6d35eb5eb5c6850b4b2dc64f5048/pillow-12.3.0-cp312-cp312-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/d9/33/1f075bf72b0b747cb3288d011319aaf64083cf2efef8354174e3ed4540e2/ipython_pygments_lexers-1.1.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/eb/dc/55481808fd70ef1567cf13540ffd4702af3f74b112e35427564b03f79c2d/narwhals-2.25.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/eb/f8/6d0c312c8d9738e7d9677f09fe5c986b3239e651a7b73a2deb38b65e4a71/matplotlib-3.11.1-cp312-cp312-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ee/a4/55eb54507073089ab27743c5da2113c84f0d0b1715b33175fdd943c9652d/lxml-6.1.2-cp312-cp312-macosx_10_13_universal2.whl
+      - pypi: https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f9/1c/01bfd571a64e7f270e6bab5e33777debe0edc56759233ce84f27dec92d14/tqdm-4.70.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/fc/75/0576b03f7889ad25b5385b4f6c69e0543713425a6f193b056c9b0a2e65ce/formulaic-1.2.2-py3-none-any.whl
+      win-64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-h4c7d964_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.8.1-hac47afa_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.7.0-h3d046cb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/liblzma-5.8.3-hfd05255_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.53.4-hf5d6505_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.2-hfd05255_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.6.4-hf411b9b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.12.14-hb12b558_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h967ab96_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.5-ha367084_41.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.51.36247-habf1de7_41.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.51.36247-habf1de7_41.conda
+      - pypi: https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/18/53/84099323c2ec4be98d935f63c033ac4151ee83836ca1050ede3b3aadf155/joblib-1.6.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/18/5f/f992b57e8deb8fa6c2e614b422d80698adb5107902bbc89832e203665bd1/ipython-9.17.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/19/e8/6026ed58a64563186a9ee3f29f41261fd1828f527dd93d33b60feca63352/contourpy-1.3.3-cp312-cp312-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/1a/ab/f534d8b8a1db1e00ae25254dcba64c220b7af50aefe11e584d54bd45d0ec/multimark-0.3.2-cp39-abi3-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/1b/fb/909584e16d2148c1a252cc2c32dd99fe0e2682459c586d3d7a192e74a0ae/lxml-6.1.2-cp312-cp312-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/2f/b2/bd9bfa6d77641bd3be57c7cd6ce10294d26db20cb9aedf19ac5d78845886/htmltools-0.7.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/30/36/996c8cbc787b3a6b9509bd139a2ae19acd2df32038b0e30d180312cd0354/great_tables-0.24.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/39/e7/979fd14e75008623df31ba70d6bb144700f68feadcea042021c06a05bf82/scipy-1.18.1-cp312-cp312-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/3a/13/547360d81e6d88d58492968ffda9f9542854f11310ee556fef14260cc886/zipp-4.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/41/09/5b161152e2d90f7b87f781c2e1267494aef9c32498df793f73ad0a0a494a/matplotlib_inline-0.2.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/45/89/da2f7971a317f83d807fdd4065c0af40208e59e692cc43d315a71a0e96d1/pillow-12.3.0-cp312-cp312-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/50/23/493ecfdaf32898e5ea24dc900e33e5e317f9662d5d9ab2d44b2e111b4e1c/websockets-17.1-cp312-cp312-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/54/6f/84908cad2d6aa5144abcf7b42709fe4fdb459bc640ec7ac5786e7693dabc/prompt_toolkit-3.0.53-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/58/50/6c0d534c5f134586a8e1ba4e330569e32f057e33372ae556463212fb4cd3/click-8.5.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/63/34/ba1c580383c9eada3711951fef0795c80b829a078d72188184bcab9dd527/packaging-26.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/65/3c/1db1b0f878319bb227f35a0fca7cad64e1f528b518bcab1a708da305c86d/faicons-0.2.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6e/7c/7b210498f9f92e1cd7855f260fa69ef056881087b199ee20c208f0e4189a/kiwisolver-1.5.1-cp312-cp312-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/70/b5/d2d3e9ae73362ba4229651b0ee1455cf78073a1ce585f6ff693782ce263e/pandas-3.0.5-cp312-cp312-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/71/46/17f022dd3e953bf20a04a028a21ec746d942f8d2af30fa0f124fa0e6a684/pygments-2.21.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/73/dc/c35af5ccf8dbf3268750c54a3c0830f486b8faec38c811aff92335aa99ba/nokap-0.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7f/b9/87fea2769fe1c47c1b5b01d8310772c9d1a85d485de7cf386ef7a3332b02/numpy-2.5.2-cp312-cp312-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/83/11/00d3c3dfc25ad54e731d91449895a79e4bf2384dc3ac01809010ba88f6d5/seaborn-0.13.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/87/36/cccb9bc2a6ab63d1b2980374f0dca72ce95ae267c9b4cfe77455bb70d0d4/fonttools-4.63.0-cp312-cp312-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/88/89/56649bbaa2fd12e20f3be03dbcc135b0c8676d88bac17977599e3eb442a0/matplotlib-3.11.1-cp312-cp312-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/8a/db/55a262f3606bebcae07cc14095338471ad7c0bbcaa37707e6f0ee49725b7/importlib_resources-7.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/99/5d/8268b644392ee874ee82a635cd0df1773de230bde356c38de28e298392cc/parso-0.8.7-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9a/93/242e2eab5fe682ffcb8b0084bde703a41d51e17ee0f3a31ff0d9d813620a/jedi-0.20.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a1/d3/20a61a248feb1249cd81f83ce731f0bdf5170ed96a08a298f7081cda9e90/interface_meta-2.0.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ac/cb/7ef3503279a4d2dc6b7fed0d0c53a9d97d98f7c28166ebfcc45eef64fe29/maketables-0.1.8-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ad/66/0d785f0bc5e4315a96c989bb476d0fc07ea4f85132550c7b156ca2035d52/traitlets-5.16.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ad/ec/a7b10705172bdb669b9687a8ff68bbe5f566437d2a49ad6d976af48b6d10/wrapt-2.4.0-cp312-cp312-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/b3/55/ecca97ae19075f1fac62def77731e7f535e6c1fb8f92ff08160c5e6dade8/importlib_metadata-9.0.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c4/0e/57f6bb3024a597b2e8ec4aee710ffe62ddc95af2e2bb1ee7a7abdc22c68c/wcwidth-0.8.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d0/00/1e03a4989fa5795da308cd774f05b704ace555a70f9bf9d3be057b680bcf/python_docx-1.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d4/2b/04b8a15f3a1c77bc79ddf5c73875327f34b4fa75982df2b76e45e402d364/asttokens-3.0.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d9/33/1f075bf72b0b747cb3288d011319aaf64083cf2efef8354174e3ed4540e2/ipython_pygments_lexers-1.1.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d9/79/615cc094e2fb508cade7de88d3b4f6c4ec2bab695c97bce9153dc65aadf5/cffi-2.1.1-cp312-cp312-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/e5/6d/b53b99a9f2766d095985947a5782f1702cabb129a34f7a802d7197af832f/tzdata-2026.3-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e9/27/cbb72acb991867ff61394895ca1652dcd4c4a0ec14f4f8fb0ac8a3f5a0b3/pyfixest-0.60.0-cp312-cp312-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/eb/dc/55481808fd70ef1567cf13540ffd4702af3f74b112e35427564b03f79c2d/narwhals-2.25.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f9/1c/01bfd571a64e7f270e6bab5e33777debe0edc56759233ce84f27dec92d14/tqdm-4.70.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/fc/75/0576b03f7889ad25b5385b4f6c69e0543713425a6f193b056c9b0a2e65ce/formulaic-1.2.2-py3-none-any.whl
+packages:
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+  build_number: 20
+  sha256: 1dd3fffd892081df9726d7eb7e0dea6198962ba775bd88842135a4ddb4deb3c9
+  md5: a9f577daf3de00bca7c3c76c0ecbd1de
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgomp >=7.5.0
+  constrains:
+  - openmp_impl <0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  run_exports:
+    strong:
+    - _openmp_mutex >=4.5
+  size: 28948
+  timestamp: 1770939786096
+- conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_10.conda
+  sha256: 1a0d382c515ebf55f8ee1f38c8b81bc95af5c2acc42ad53b66bc5df932032f96
+  md5: e675fabcf81499adc7edf58124fb1e01
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: bzip2-1.0.6
+  license_family: BSD
+  purls: []
+  run_exports:
+    weak:
+    - bzip2 >=1.0.8,<2.0a0
+  size: 257808
+  timestamp: 1785906269155
+- conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-py310h44b86e0_2.conda
+  sha256: 9f07834f0c546ab14d885ce0366285f61f44e326c0edd1fc63b8294e113ae432
+  md5: 72a381cbad04f24b1c2a43ef707f45b4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - icu >=78.3,<79.0a0
+  size: 14459115
+  timestamp: 1786545741408
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.46.1-default_hbd61a6d_102.conda
+  sha256: 27d83f1188cd19bcb7754a078b3fa7f4cfb8527f8eb2fde54dd01fc529d1adec
+  md5: 449500f2c089da11c40f5c21312e3e07
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - zstd >=1.5.7,<1.6.0a0
+  constrains:
+  - binutils_impl_linux-64 2.46.1
+  license: GPL-3.0-only
+  license_family: GPL
+  purls: []
+  run_exports: {}
+  size: 745303
+  timestamp: 1784214507189
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
+  sha256: 16feffd9ddbbe5b718515d38ee376c685ba95491cd901244e24671d20b952a77
+  md5: b24d3c612f71e7aa74158d92106318b2
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  constrains:
+  - expat 2.8.1.*
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports: {}
+  size: 77856
+  timestamp: 1781203599810
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.7.0-h81df57d_1.conda
+  sha256: c8c7583ef063bc3c430f1d48298e5ad24f796a35c22ed5b14183325825a61106
+  md5: 6525a0b06aa4fd390795f0740636a9dd
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=15
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - libffi >=3.7.0,<3.8.0a0
+  size: 68004
+  timestamp: 1787753412298
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-16.2.0-ha9f2e26_4.conda
+  sha256: 24090e675d34403b4ee1cd4372d8f6c0937da7ecfd66a19a57cac2ed0f4ea793
+  md5: cba14d01083fc62ffd32c24d7d390633
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - _openmp_mutex >=4.5
+  constrains:
+  - libgcc-ng ==16.2.0=*_4
+  - libgomp 16.2.0 he0feb66_4
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  run_exports: {}
+  size: 1058083
+  timestamp: 1787618680111
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-16.2.0-he0feb66_4.conda
+  sha256: 0fe5cb8e0752241ab55e11656ed1b9726248b522d23b929fe7c95b83eb55b9bb
+  md5: 89d2c1231f47bd818f5d624b9411459d
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  run_exports:
+    strong:
+    - _openmp_mutex >=4.5
+  size: 639968
+  timestamp: 1787618616266
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_1.conda
+  sha256: 9787df8c22a59c9a70d3e5a10db9ad663485e75e9ccc3f09bd092cb7b95e0dab
+  md5: 1390b7c5ac0b1d8e447bc5efa6d3c8c2
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  constrains:
+  - xz 5.8.3.*
+  license: 0BSD
+  purls: []
+  run_exports:
+    weak:
+    - liblzma >=5.8.3,<6.0a0
+  size: 112995
+  timestamp: 1786348617826
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
+  sha256: 927fe72b054277cde6cb82597d0fcf6baf127dcbce2e0a9d8925a68f1265eef5
+  md5: d864d34357c3b65a4b731f78c0801dc4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: LGPL-2.1-only
+  license_family: GPL
+  purls: []
+  run_exports:
+    weak:
+    - libnsl >=2.0.1,<2.1.0a0
+  size: 33731
+  timestamp: 1750274110928
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.4-h13e7031_1.conda
+  sha256: f20d70da54e5b31dd4a51fb1efeaafafd5ab6dd8d7ac9d1438eaa2526ac4ed3d
+  md5: e72bbec309c2b0f37823ee7d4fabfcd3
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - icu >=78.3,<79.0a0
+  - libgcc >=15
+  - libzlib >=1.3.2,<2.0a0
+  license: blessing
+  purls: []
+  run_exports:
+    weak:
+    - libsqlite >=3.53.4,<4.0a0
+  size: 974348
+  timestamp: 1787051145557
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-16.2.0-h934c35e_4.conda
+  sha256: 40b792b0186c1e8859280a1f6f19a54fc50a11b32724fc7b637009c1a9bd302b
+  md5: 2f2ef0d96de5bdd8c1270ff22fdf9352
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc 16.2.0 ha9f2e26_4
+  constrains:
+  - libstdcxx-ng ==16.2.0=*_4
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  run_exports: {}
+  size: 6613148
+  timestamp: 1787618704262
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
+  sha256: 9b1bdce27a7e31f7d241aeecff67a1f3101d52a2b1e33ccc2cdf2613072bf81f
+  md5: 01bb81d12c957de066ea7362007df642
+  depends:
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  run_exports:
+    weak:
+    - libuuid >=2.42.2,<3.0a0
+  size: 40017
+  timestamp: 1781625522462
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.38-h280c20c_0.conda
+  sha256: f7e9292dd219a6435bbb1223da9586c3e70d66d169c5a92f08db3f2127df04e9
+  md5: f7a7ff5a6ab331e037abd34f379a631d
+  depends:
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  license: LGPL-2.1-or-later
+  purls: []
+  run_exports:
+    weak:
+    - libxcrypt >=4.4.38
+  size: 101957
+  timestamp: 1785887123445
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_3.conda
+  sha256: eb8a0db0aa570124f7d2a93d7c7f596e3390df5e047818d873baad32985fc736
+  md5: 0de0122d9570a8ab637c6b73db268389
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  constrains:
+  - zlib 1.3.2 *_3
+  license: Zlib
+  license_family: Other
+  purls: []
+  run_exports:
+    weak:
+    - libzlib >=1.3.2,<2.0a0
+  size: 63713
+  timestamp: 1785362952714
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_1.conda
+  sha256: 5d46557214ed184381dafe835b7c94a474a1c3b307a08a250b1ea4779b44ffb3
+  md5: ee6c0cd80a60961a1f48aa3e0b91f986
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: X11 AND BSD-3-Clause
+  purls: []
+  run_exports:
+    weak:
+    - ncurses >=6.6,<7.0a0
+  size: 911196
+  timestamp: 1786355078102
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.4-h781a0a9_0.conda
+  sha256: 4747b2d6a8336f52343bceb8a1ebf41a9e6e665b9d2e3f989972de53a310599e
+  md5: 16e3034a330cc625f2c685edec60cf4e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - ca-certificates
+  - libgcc >=15
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  run_exports:
+    weak:
+    - openssl >=3.6.4,<4.0a0
+  size: 3202955
+  timestamp: 1787698780103
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.14-h8ab3286_0_cpython.conda
+  sha256: ceb9c724de53ee3560f121dbfcb00fe8acb22c08691158fce7b6c32425855626
+  md5: e9dcdd23a1c68738eb3257d23d5f7285
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - ld_impl_linux-64 >=2.36.1
+  - libexpat >=2.8.1,<3.0a0
+  - libffi >=3.7.0,<3.8.0a0
+  - libgcc >=14
+  - liblzma >=5.8.3,<6.0a0
+  - libnsl >=2.0.1,<2.1.0a0
+  - libsqlite >=3.53.4,<4.0a0
+  - libuuid >=2.42.2,<3.0a0
+  - libxcrypt >=4.4.38
+  - libzlib >=1.3.2,<2.0a0
+  - ncurses >=6.6,<7.0a0
+  - openssl >=3.5.7,<4.0a0
+  - readline >=8.3,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  constrains:
+  - python_abi 3.12.* *_cp312
+  license: Python-2.0
+  purls: []
+  run_exports:
+    weak:
+    - python_abi 3.12.* *_cp312
+    noarch:
+    - python
+  size: 31590137
+  timestamp: 1787353586056
+- conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-hd6e31c0_1.conda
+  sha256: 01b3fe073a66e321970d09e04b388708f8cbdca5cdfbfcb7c9eeb470ad10383d
+  md5: 69c01c781e7c8190bbdaf79e3848c5ca
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=15
+  - ncurses >=6.6,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  purls: []
+  run_exports:
+    weak:
+    - readline >=8.3,<9.0a0
+  size: 348899
+  timestamp: 1787033801506
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h1df4ec4_4.conda
+  build_number: 104
+  sha256: a1a241d172c1ccab067ba245206dd048bc3c2d1b84504b53c9468e99adfc16a1
+  md5: 676a2f9b1c4fcf57b70aa5c65f6c60d0
+  depends:
+  - libgcc >=15
+  - __glibc >=2.17,<3.0.a0
+  - libzlib >=1.3.2,<2.0a0
+  constrains:
+  - xorg-libx11 >=1.8.13,<2.0a0
+  license: TCL
+  purls: []
+  run_exports:
+    weak:
+    - tk >=8.6.13,<8.7.0a0
+  size: 3566806
+  timestamp: 1787272857910
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_7.conda
+  sha256: 47d682b9f6d6ec9eb1a6e6c3e75ea6273e899e78fb7fc59f81d39745009fbc60
+  md5: aa459086047c0e5e27023ab19f8cb86a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libzlib >=1.3.2,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  run_exports:
+    weak:
+    - zstd >=1.5.7,<1.6.0a0
+  size: 601301
+  timestamp: 1786599621503
+- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-h4c7d964_0.conda
+  sha256: 95e8e74062a5fe5f870ac8c90302b6e89945165fdaed7810606e84ddee6aac12
+  md5: e27d2ac27b096dc51fedfcf775a53f9b
+  depends:
+  - __win
+  license: ISC
+  purls: []
+  run_exports: {}
+  size: 132136
+  timestamp: 1784754918886
+- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+  sha256: 0a0544cf95f64394fe4959286f5c71f5444ad58feb0602e53becb27448d24da6
+  md5: 0f51e2391ade309db462a55611263e9c
+  depends:
+  - __unix
+  license: ISC
+  purls: []
+  run_exports: {}
+  size: 131780
+  timestamp: 1784754889428
+- conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+  sha256: b928c30ddcb0e3f544c6eade8352737e6e610e263276b90232db6a578ef899d8
+  md5: fcb489df604d100968b737f2cb6076c6
+  license: LicenseRef-Public-Domain
+  purls: []
+  run_exports: {}
+  size: 118849
+  timestamp: 1784250406640
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h4e30115_10.conda
+  sha256: 8ec22f0ba25cbfc2e64d70cf29459eccd7ffdf6436f6a6ff15bbfef799f7d4f6
+  md5: b50612e7d190b8061ab4e7dc119cf4d5
+  depends:
+  - __osx >=11.0
+  license: bzip2-1.0.6
+  license_family: BSD
+  purls: []
+  run_exports:
+    weak:
+    - bzip2 >=1.0.8,<2.0a0
+  size: 124965
+  timestamp: 1785906749812
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-py310h579977c_2.conda
+  sha256: 6cdb5dee54c72e56ab189fb3ad33cb28533553d42590e7e831160248f4416a43
+  md5: a5efc0b42bb8b42e97d0a29ae3e3c187
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - icu >=78.3,<79.0a0
+  size: 14070242
+  timestamp: 1786545847761
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
+  sha256: 5af74261101e3c777399c6294b2b5d290e508153268eb2e9ff99c4d69834612f
+  md5: a915151d5d3c5bf039f5ccc8402a436f
+  depends:
+  - __osx >=11.0
+  constrains:
+  - expat 2.8.1.*
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports: {}
+  size: 69362
+  timestamp: 1781203631990
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.7.0-h47dc5ef_1.conda
+  sha256: 2783389a7b9dda04c62cc54c6bbeb03dd3cef24b3fc642715d02a3fa19464a9a
+  md5: 216bbcc23c11e9695b3db4a8771d76eb
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - libffi >=3.7.0,<3.8.0a0
+  size: 43637
+  timestamp: 1787753403688
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_1.conda
+  sha256: 23d0630046a3e8b164d8f80f2b74ed2605af2e7050ab9913018056402fae4311
+  md5: 8ab10323068b107661a4b9a4af84f3b5
+  depends:
+  - __osx >=11.0
+  constrains:
+  - xz 5.8.3.*
+  license: 0BSD
+  purls: []
+  run_exports:
+    weak:
+    - liblzma >=5.8.3,<6.0a0
+  size: 91720
+  timestamp: 1786348695846
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.4-hca69786_1.conda
+  sha256: 839b31d4830e896b4d315b551d27f2bb08026bc946df04bcc360d8627c3ba2cd
+  md5: fde96d40ebe9a9cb34e4122380189ddb
+  depends:
+  - __osx >=11.0
+  - icu >=78.3,<79.0a0
+  - libzlib >=1.3.2,<2.0a0
+  license: blessing
+  purls: []
+  run_exports:
+    weak:
+    - libsqlite >=3.53.4,<4.0a0
+  size: 942754
+  timestamp: 1787051243846
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_3.conda
+  sha256: a18fa5d5bac452401459f966cf0d872224e8080c4ff93c77e168d43ab42ef9d7
+  md5: f39288f0ea63ae962e1a2e4f355a0d75
+  depends:
+  - __osx >=11.0
+  constrains:
+  - zlib 1.3.2 *_3
+  license: Zlib
+  license_family: Other
+  purls: []
+  run_exports:
+    weak:
+    - libzlib >=1.3.2,<2.0a0
+  size: 47822
+  timestamp: 1785277049190
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-he64c551_1.conda
+  sha256: 7024a48c8c0d0114ed4ab53c76bf9275d50e91ba7cea367a9aead638d3c29c68
+  md5: 3dfa0d0316dc246cd44937a557de4501
+  depends:
+  - __osx >=11.0
+  license: X11 AND BSD-3-Clause
+  purls: []
+  run_exports:
+    weak:
+    - ncurses >=6.6,<7.0a0
+  size: 804298
+  timestamp: 1786355189145
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.4-h55eecbc_0.conda
+  sha256: f23239eacd75c4c50705e68fae1aa3292da473e6a3a4abe2330f1e6afa680704
+  md5: ae71ab40048c19a389a7dcccb86c2481
+  depends:
+  - __osx >=11.0
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  run_exports:
+    weak:
+    - openssl >=3.6.4,<4.0a0
+  size: 3110142
+  timestamp: 1787698648639
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.14-hd1323d7_0_cpython.conda
+  sha256: e49baab119eaf6b37cd3fec27dd6b3a6fad10b67ac79842145fd15a340f2c3ba
+  md5: f68540325a8a1385c22938a01e851355
+  depends:
+  - __osx >=11.0
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - libffi >=3.7.0,<3.8.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - libsqlite >=3.53.4,<4.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - ncurses >=6.6,<7.0a0
+  - openssl >=3.5.7,<4.0a0
+  - readline >=8.3,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  constrains:
+  - python_abi 3.12.* *_cp312
+  license: Python-2.0
+  purls: []
+  run_exports:
+    weak:
+    - python_abi 3.12.* *_cp312
+    noarch:
+    - python
+  size: 13409190
+  timestamp: 1787352325281
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h8b90a29_1.conda
+  sha256: d6782b430e6dce4fe8c7ac118cd988d5a193eb4a7f60741edfaede58016b6110
+  md5: 9347fd56a002e6b58946831d48fe62f6
+  depends:
+  - __osx >=11.0
+  - ncurses >=6.6,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  purls: []
+  run_exports:
+    weak:
+    - readline >=8.3,<9.0a0
+  size: 314395
+  timestamp: 1787033878899
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-hbeba79b_4.conda
+  sha256: 857d89087ae7f2c328cf256728affcb7343031a148b4af847334d248a9cf564c
+  md5: 90a01bf394d1c594e0eb9258f967d828
+  depends:
+  - __osx >=11.0
+  - libzlib >=1.3.2,<2.0a0
+  license: TCL
+  purls: []
+  run_exports:
+    weak:
+    - tk >=8.6.13,<8.7.0a0
+  size: 3342183
+  timestamp: 1787272852357
+- conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_10.conda
+  sha256: 04767466ee9227c9c57ab2c6503e0149177d34111c7418d2f420297acb1eb229
+  md5: c3301c058362f340100d91cd8be0393f
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: bzip2-1.0.6
+  license_family: BSD
+  purls: []
+  run_exports:
+    weak:
+    - bzip2 >=1.0.8,<2.0a0
+  size: 55919
+  timestamp: 1785906343696
+- conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.8.1-hac47afa_1.conda
+  sha256: 1a54d874addda73b6f7164d5f3905821277a1831bcc05edd74b3085391688571
+  md5: ccc490c81ffe14181861beac0e8f3169
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  constrains:
+  - expat 2.8.1.*
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports: {}
+  size: 71631
+  timestamp: 1781203724164
+- conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.7.0-h3d046cb_1.conda
+  sha256: 613e8077c5cca5df7fe84ade7d5050301bee3c6c4c450ffe61d34a349ab4f11c
+  md5: ceb38b0ba900847d8da4289c3c8e5708
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - libffi >=3.7.0,<3.8.0a0
+  size: 49992
+  timestamp: 1787753517346
+- conda: https://conda.anaconda.org/conda-forge/win-64/liblzma-5.8.3-hfd05255_1.conda
+  sha256: d36c4a1e1f80fd08e18a407e03622ff2f34dfdd022da6488ad19603dea19e6d5
+  md5: 880a0c8549479b198af21ba5dc49b109
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  constrains:
+  - xz 5.8.3.*
+  license: 0BSD
+  purls: []
+  run_exports:
+    weak:
+    - liblzma >=5.8.3,<6.0a0
+  size: 105809
+  timestamp: 1786348717883
+- conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.53.4-hf5d6505_1.conda
+  sha256: 0a45d7c0f20146fff787a106f8fa187872e309c70975ff8f0936e188914c26ad
+  md5: a72d495965b144bb7da033642d389047
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: blessing
+  purls: []
+  run_exports:
+    weak:
+    - libsqlite >=3.53.4,<4.0a0
+  size: 1314919
+  timestamp: 1787051140039
+- conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.2-hfd05255_3.conda
+  sha256: 0629c2cc0404d3bb29d6baa7b4ba62da80797015e86de050db81ea5a07050527
+  md5: 5d2ff29d465097458cc3ff6569151991
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  constrains:
+  - zlib 1.3.2 *_3
+  license: Zlib
+  license_family: Other
+  purls: []
+  run_exports:
+    weak:
+    - libzlib >=1.3.2,<2.0a0
+  size: 58529
+  timestamp: 1785276664143
+- conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.6.4-hf411b9b_0.conda
+  sha256: 9dddb559ba49744d5d94092d8d13cb0567f5c3b3f439f3acf28433d1f4256acc
+  md5: 73cb1783f47c452be4c309430fbef89f
+  depends:
+  - ca-certificates
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  run_exports:
+    weak:
+    - openssl >=3.6.4,<4.0a0
+  size: 9474879
+  timestamp: 1787699876495
+- conda: https://conda.anaconda.org/conda-forge/win-64/python-3.12.14-hb12b558_0_cpython.conda
+  sha256: 0911d8c3e93d5746e7cb1d8f76ba680aa7cbdf90a68dcd697e641e9f761642af
+  md5: 1948cdb3b317f50c8c8c4b6b96ce8a72
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - libffi >=3.7.0,<3.8.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - libsqlite >=3.53.4,<4.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - openssl >=3.5.7,<4.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  constrains:
+  - python_abi 3.12.* *_cp312
+  license: Python-2.0
+  purls: []
+  run_exports:
+    weak:
+    - python_abi 3.12.* *_cp312
+    noarch:
+    - python
+  size: 15964232
+  timestamp: 1787352042257
+- conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h967ab96_4.conda
+  sha256: f19618a3a82cc483dacf1c70a30367ee7b0c7e71b90f1f80e14feff44fbd3688
+  md5: dd9eb33c99d352b6356f86964d6040f7
+  depends:
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  license: TCL
+  purls: []
+  run_exports:
+    weak:
+    - tk >=8.6.13,<8.7.0a0
+  size: 3782376
+  timestamp: 1787272860855
+- conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
+  sha256: 3005729dce6f3d3f5ec91dfc49fc75a0095f9cd23bab49efb899657297ac91a5
+  md5: 71b24316859acd00bdb8b38f5e2ce328
+  constrains:
+  - vc14_runtime >=14.29.30037
+  - vs2015_runtime >=14.29.30037
+  license: LicenseRef-MicrosoftWindowsSDK10
+  purls: []
+  run_exports: {}
+  size: 694692
+  timestamp: 1756385147981
+- conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.5-ha367084_41.conda
+  sha256: 35444c55a92e2f7f7ba26bc70f81e56e52344f7d064c0fd4b40a46a58517b79c
+  md5: aa805b5522c2a98fa286e551a1f48546
+  depends:
+  - vc14_runtime >=14.51.36247
+  track_features:
+  - vc14
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  run_exports: {}
+  size: 21383
+  timestamp: 1785359368566
+- conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.51.36247-habf1de7_41.conda
+  sha256: 4e4cb599cdc41bf2109d1464c127b5bcbddf548ce3e322e612afb691338b48f8
+  md5: ac5333bb3d429361f23adf704cc49a78
+  depends:
+  - ucrt >=10.0.20348.0
+  - vcomp14 14.51.36247 habf1de7_41
+  constrains:
+  - vs2015_runtime 14.51.36247.* *_41
+  license: LicenseRef-MicrosoftVisualCpp2015-2022Runtime
+  license_family: Proprietary
+  purls: []
+  run_exports: {}
+  size: 767955
+  timestamp: 1785359364369
+- conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.51.36247-habf1de7_41.conda
+  sha256: 731e043390c9457299484d39e427221fc868a9249540a498a5a4f6456c7744d1
+  md5: 350bb67a5c8e5f1c53347ac544ab6600
+  depends:
+  - ucrt >=10.0.20348.0
+  constrains:
+  - vs2015_runtime 14.51.36247.* *_41
+  license: LicenseRef-MicrosoftVisualCpp2015-2022Runtime
+  license_family: Proprietary
+  purls: []
+  run_exports:
+    strong:
+    - vcomp14 >=14.51.36247
+  size: 155910
+  timestamp: 1785359349999
+- pypi: https://files.pythonhosted.org/packages/05/4a/78c6285577c375e7cf27277ea8ee6961224327f1e1a0c44af5f17f23635c/scipy-1.18.1-cp312-cp312-macosx_12_0_arm64.whl
+  name: scipy
+  version: 1.18.1
+  sha256: e708533e8b2ae2497d65346538a7dcc92814410b25b81432eac66de0f2af8265
+  requires_dist:
+  - numpy>=2.0.0,<2.8
+  - pytest>=8.0.0 ; extra == 'test'
+  - pytest-cov ; extra == 'test'
+  - pytest-timeout ; extra == 'test'
+  - pytest-xdist ; extra == 'test'
+  - asv ; extra == 'test'
+  - mpmath ; extra == 'test'
+  - gmpy2 ; extra == 'test'
+  - threadpoolctl ; extra == 'test'
+  - scikit-umfpack ; extra == 'test'
+  - pooch ; extra == 'test'
+  - hypothesis>=6.30 ; extra == 'test'
+  - array-api-strict>=2.3.1 ; extra == 'test'
+  - cython ; extra == 'test'
+  - meson ; extra == 'test'
+  - ninja ; sys_platform != 'emscripten' and extra == 'test'
+  - scipy-doctest>=2.0.0 ; extra == 'test'
+  - sphinx>=5.0.0,<8.2.0 ; extra == 'doc'
+  - intersphinx-registry ; extra == 'doc'
+  - pydata-sphinx-theme>=0.15.2 ; extra == 'doc'
+  - sphinx-copybutton ; extra == 'doc'
+  - sphinx-design>=0.4.0 ; extra == 'doc'
+  - matplotlib>=3.5 ; extra == 'doc'
+  - numpydoc ; extra == 'doc'
+  - jupytext ; extra == 'doc'
+  - myst-nb>=1.2.0 ; extra == 'doc'
+  - pooch ; extra == 'doc'
+  - jupyterlite-sphinx>=0.19.1 ; extra == 'doc'
+  - jupyterlite-pyodide-kernel ; extra == 'doc'
+  - linkify-it-py ; extra == 'doc'
+  - tabulate ; extra == 'doc'
+  - click<8.3.0 ; extra == 'dev'
+  - spin ; extra == 'dev'
+  - mypy==1.19.1 ; extra == 'dev'
+  - pyrefly==0.63.0 ; extra == 'dev'
+  - typing-extensions ; extra == 'dev'
+  - types-psutil ; extra == 'dev'
+  - pycodestyle ; extra == 'dev'
+  - ruff>=0.12.0 ; extra == 'dev'
+  - cython-lint>=0.12.2 ; extra == 'dev'
+  requires_python: '>=3.12'
+- pypi: https://files.pythonhosted.org/packages/08/ef/b3c6b9b5be2f82416d73fe2ed2e96e2793cd80e7510bd6a17ca79cdd88ec/fonttools-4.63.0-cp312-cp312-macosx_10_13_universal2.whl
+  name: fonttools
+  version: 4.63.0
+  sha256: 37dd23e621e3b0aef1baa70a303b80aaf38449632cfc8fd2a55fb285bbccfc02
+  requires_dist:
+  - lxml>=4.0 ; extra == 'lxml'
+  - brotli>=1.0.1 ; platform_python_implementation == 'CPython' and extra == 'woff'
+  - brotlicffi>=0.8.0 ; platform_python_implementation != 'CPython' and extra == 'woff'
+  - zopfli>=0.1.4 ; extra == 'woff'
+  - unicodedata2>=17.0.0 ; python_full_version < '3.15' and extra == 'unicode'
+  - lz4>=1.7.4.2 ; extra == 'graphite'
+  - scipy ; platform_python_implementation != 'PyPy' and extra == 'interpolatable'
+  - munkres ; platform_python_implementation == 'PyPy' and extra == 'interpolatable'
+  - pycairo ; extra == 'interpolatable'
+  - matplotlib ; extra == 'plot'
+  - sympy ; extra == 'symfont'
+  - xattr ; sys_platform == 'darwin' and extra == 'type1'
+  - skia-pathops>=0.5.0 ; extra == 'pathops'
+  - uharfbuzz>=0.45.0 ; extra == 'repacker'
+  - lxml>=4.0 ; extra == 'all'
+  - brotli>=1.0.1 ; platform_python_implementation == 'CPython' and extra == 'all'
+  - brotlicffi>=0.8.0 ; platform_python_implementation != 'CPython' and extra == 'all'
+  - zopfli>=0.1.4 ; extra == 'all'
+  - unicodedata2>=17.0.0 ; python_full_version < '3.15' and extra == 'all'
+  - lz4>=1.7.4.2 ; extra == 'all'
+  - scipy ; platform_python_implementation != 'PyPy' and extra == 'all'
+  - munkres ; platform_python_implementation == 'PyPy' and extra == 'all'
+  - pycairo ; extra == 'all'
+  - matplotlib ; extra == 'all'
+  - sympy ; extra == 'all'
+  - xattr ; sys_platform == 'darwin' and extra == 'all'
+  - skia-pathops>=0.5.0 ; extra == 'all'
+  - uharfbuzz>=0.45.0 ; extra == 'all'
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl
+  name: pycparser
+  version: '3.0'
+  sha256: b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl
+  name: pyparsing
+  version: 3.3.2
+  sha256: 850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d
+  requires_dist:
+  - railroad-diagrams ; extra == 'diagrams'
+  - jinja2 ; extra == 'diagrams'
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/12/98/e976540c1addf70442be7842a18cf70884a964abbf69442504f4d2939989/pandas-3.0.5-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
+  name: pandas
+  version: 3.0.5
+  sha256: d373ce03ffd84010ed9839fa73672a9c8256990532e158440c0085db7d914b34
+  requires_dist:
+  - numpy>=1.26.0 ; python_full_version < '3.14'
+  - numpy>=2.3.3 ; python_full_version >= '3.14'
+  - python-dateutil>=2.8.2
+  - tzdata ; sys_platform == 'win32'
+  - tzdata ; sys_platform == 'emscripten'
+  - hypothesis>=6.116.0 ; extra == 'test'
+  - pytest>=8.3.4,<9.1 ; extra == 'test'
+  - pytest-xdist>=3.6.1 ; extra == 'test'
+  - pyarrow>=13.0.0 ; extra == 'pyarrow'
+  - bottleneck>=1.4.2 ; extra == 'performance'
+  - numba>=0.60.0 ; extra == 'performance'
+  - numexpr>=2.10.2 ; extra == 'performance'
+  - scipy>=1.14.1 ; extra == 'computation'
+  - xarray>=2024.10.0 ; extra == 'computation'
+  - fsspec>=2024.10.0 ; extra == 'fss'
+  - s3fs>=2024.10.0 ; extra == 'aws'
+  - gcsfs>=2024.10.0 ; extra == 'gcp'
+  - odfpy>=1.4.1 ; extra == 'excel'
+  - openpyxl>=3.1.5 ; extra == 'excel'
+  - python-calamine>=0.3.0 ; extra == 'excel'
+  - pyxlsb>=1.0.10 ; extra == 'excel'
+  - xlrd>=2.0.1 ; extra == 'excel'
+  - xlsxwriter>=3.2.0 ; extra == 'excel'
+  - pyarrow>=13.0.0 ; extra == 'parquet'
+  - pyarrow>=13.0.0 ; extra == 'feather'
+  - pyiceberg>=0.8.1 ; extra == 'iceberg'
+  - tables>=3.10.1 ; extra == 'hdf5'
+  - pyreadstat>=1.2.8 ; extra == 'spss'
+  - sqlalchemy>=2.0.36 ; extra == 'postgresql'
+  - psycopg2>=2.9.10 ; extra == 'postgresql'
+  - adbc-driver-postgresql>=1.2.0 ; extra == 'postgresql'
+  - sqlalchemy>=2.0.36 ; extra == 'mysql'
+  - pymysql>=1.1.1 ; extra == 'mysql'
+  - sqlalchemy>=2.0.36 ; extra == 'sql-other'
+  - adbc-driver-postgresql>=1.2.0 ; extra == 'sql-other'
+  - adbc-driver-sqlite>=1.2.0 ; extra == 'sql-other'
+  - beautifulsoup4>=4.12.3 ; extra == 'html'
+  - html5lib>=1.1 ; extra == 'html'
+  - lxml>=5.3.0 ; extra == 'html'
+  - lxml>=5.3.0 ; extra == 'xml'
+  - matplotlib>=3.9.3 ; extra == 'plot'
+  - jinja2>=3.1.5 ; extra == 'output-formatting'
+  - tabulate>=0.9.0 ; extra == 'output-formatting'
+  - pyqt5>=5.15.9 ; extra == 'clipboard'
+  - qtpy>=2.4.2 ; extra == 'clipboard'
+  - zstandard>=0.23.0 ; extra == 'compression'
+  - pytz>=2020.1 ; extra == 'timezone'
+  - adbc-driver-postgresql>=1.2.0 ; extra == 'all'
+  - adbc-driver-sqlite>=1.2.0 ; extra == 'all'
+  - beautifulsoup4>=4.12.3 ; extra == 'all'
+  - bottleneck>=1.4.2 ; extra == 'all'
+  - fastparquet>=2024.11.0 ; extra == 'all'
+  - fsspec>=2024.10.0 ; extra == 'all'
+  - gcsfs>=2024.10.0 ; extra == 'all'
+  - html5lib>=1.1 ; extra == 'all'
+  - hypothesis>=6.116.0 ; extra == 'all'
+  - jinja2>=3.1.5 ; extra == 'all'
+  - lxml>=5.3.0 ; extra == 'all'
+  - matplotlib>=3.9.3 ; extra == 'all'
+  - numba>=0.60.0 ; extra == 'all'
+  - numexpr>=2.10.2 ; extra == 'all'
+  - odfpy>=1.4.1 ; extra == 'all'
+  - openpyxl>=3.1.5 ; extra == 'all'
+  - psycopg2>=2.9.10 ; extra == 'all'
+  - pyarrow>=13.0.0 ; extra == 'all'
+  - pyiceberg>=0.8.1 ; extra == 'all'
+  - pymysql>=1.1.1 ; extra == 'all'
+  - pyqt5>=5.15.9 ; extra == 'all'
+  - pyreadstat>=1.2.8 ; extra == 'all'
+  - pytest>=8.3.4 ; extra == 'all'
+  - pytest-xdist>=3.6.1 ; extra == 'all'
+  - python-calamine>=0.3.0 ; extra == 'all'
+  - pytz>=2020.1 ; extra == 'all'
+  - pyxlsb>=1.0.10 ; extra == 'all'
+  - qtpy>=2.4.2 ; extra == 'all'
+  - scipy>=1.14.1 ; extra == 'all'
+  - s3fs>=2024.10.0 ; extra == 'all'
+  - sqlalchemy>=2.0.36 ; extra == 'all'
+  - tables>=3.10.1 ; extra == 'all'
+  - tabulate>=0.9.0 ; extra == 'all'
+  - xarray>=2024.10.0 ; extra == 'all'
+  - xlrd>=2.0.1 ; extra == 'all'
+  - xlsxwriter>=3.2.0 ; extra == 'all'
+  - zstandard>=0.23.0 ; extra == 'all'
+  requires_python: '>=3.11'
+- pypi: https://files.pythonhosted.org/packages/18/53/84099323c2ec4be98d935f63c033ac4151ee83836ca1050ede3b3aadf155/joblib-1.6.0-py3-none-any.whl
+  name: joblib
+  version: 1.6.0
+  sha256: 3dbbf9f6e4b592a2357b854608e980fe6390d131d7a82f011a377ef2ebef7aba
+  requires_dist:
+  - cloudpickle>=3.0
+  - distributed ; extra == 'test'
+  - lz4 ; extra == 'test'
+  - numpy ; extra == 'test'
+  - memory-profiler ; extra == 'test'
+  - pytest ; extra == 'test'
+  - pytest-asyncio ; extra == 'test'
+  - pytest-cov ; extra == 'test'
+  - pytest-run-parallel ; extra == 'test'
+  - pytest-timeout ; extra == 'test'
+  - threadpoolctl ; extra == 'test'
+  - distributed ; extra == 'docs'
+  - lz4 ; extra == 'docs'
+  - numpy ; extra == 'docs'
+  - numpydoc ; extra == 'docs'
+  - matplotlib ; extra == 'docs'
+  - pandas ; extra == 'docs'
+  - psutil ; extra == 'docs'
+  - sphinx ; extra == 'docs'
+  - pydata-sphinx-theme ; extra == 'docs'
+  - sphinx-gallery ; extra == 'docs'
+  - sphinx-copybutton ; extra == 'docs'
+  - sphinx-design ; extra == 'docs'
+  - tqdm ; extra == 'docs'
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/18/5f/f992b57e8deb8fa6c2e614b422d80698adb5107902bbc89832e203665bd1/ipython-9.17.0-py3-none-any.whl
+  name: ipython
+  version: 9.17.0
+  sha256: ce647713be8fef3fab2418c515a0def4d45d6705dd102be2c6d1f3015d7368b0
+  requires_dist:
+  - colorama>=0.4.4 ; sys_platform == 'win32'
+  - ipython-pygments-lexers>=1.0.0
+  - jedi>=0.18.2
+  - matplotlib-inline>=0.1.6
+  - pexpect>4.6 ; sys_platform != 'emscripten' and sys_platform != 'win32'
+  - prompt-toolkit>=3.0.41,<3.1.0
+  - psutil>=7 ; sys_platform != 'cygwin' and sys_platform != 'emscripten'
+  - pygments>=2.14.0
+  - stack-data>=0.6.0
+  - traitlets>=5.13.0
+  - typing-extensions>=4.6 ; python_full_version < '3.12'
+  - black ; extra == 'black'
+  - docrepr ; extra == 'doc'
+  - exceptiongroup ; extra == 'doc'
+  - intersphinx-registry ; extra == 'doc'
+  - ipykernel ; extra == 'doc'
+  - ipython[matplotlib,test] ; extra == 'doc'
+  - setuptools>=80.0 ; extra == 'doc'
+  - sphinx-toml==0.0.4 ; extra == 'doc'
+  - sphinx-rtd-theme>=0.1.8 ; extra == 'doc'
+  - sphinx>=8.0 ; extra == 'doc'
+  - typing-extensions ; extra == 'doc'
+  - pytest>=7.0.0 ; extra == 'test'
+  - pytest-asyncio>=1.0.0 ; extra == 'test'
+  - testpath>=0.2 ; extra == 'test'
+  - packaging>=23.0.0 ; extra == 'test'
+  - setuptools>=80.0 ; extra == 'test'
+  - ipython[test] ; extra == 'test-extra'
+  - curio ; extra == 'test-extra'
+  - jupyter-ai ; extra == 'test-extra'
+  - ipython[matplotlib] ; extra == 'test-extra'
+  - nbformat ; extra == 'test-extra'
+  - nbclient ; extra == 'test-extra'
+  - ipykernel>6.30 ; extra == 'test-extra'
+  - numpy>=2.0 ; extra == 'test-extra'
+  - pandas>2.1 ; extra == 'test-extra'
+  - trio>=0.22.0 ; extra == 'test-extra'
+  - matplotlib>3.9 ; extra == 'matplotlib'
+  - ipython[doc,matplotlib,test,test-extra] ; extra == 'all'
+  - argcomplete>=3.0 ; extra == 'all'
+  requires_python: '>=3.11'
+- pypi: https://files.pythonhosted.org/packages/19/e8/6026ed58a64563186a9ee3f29f41261fd1828f527dd93d33b60feca63352/contourpy-1.3.3-cp312-cp312-win_amd64.whl
+  name: contourpy
+  version: 1.3.3
+  sha256: 8153b8bfc11e1e4d75bcb0bff1db232f9e10b274e0929de9d608027e0d34ff8b
+  requires_dist:
+  - numpy>=1.25
+  - furo ; extra == 'docs'
+  - sphinx>=7.2 ; extra == 'docs'
+  - sphinx-copybutton ; extra == 'docs'
+  - bokeh ; extra == 'bokeh'
+  - selenium ; extra == 'bokeh'
+  - contourpy[bokeh,docs] ; extra == 'mypy'
+  - bokeh ; extra == 'mypy'
+  - docutils-stubs ; extra == 'mypy'
+  - mypy==1.17.0 ; extra == 'mypy'
+  - types-pillow ; extra == 'mypy'
+  - contourpy[test-no-images] ; extra == 'test'
+  - matplotlib ; extra == 'test'
+  - pillow ; extra == 'test'
+  - pytest ; extra == 'test-no-images'
+  - pytest-cov ; extra == 'test-no-images'
+  - pytest-rerunfailures ; extra == 'test-no-images'
+  - pytest-xdist ; extra == 'test-no-images'
+  - wurlitzer ; extra == 'test-no-images'
+  requires_python: '>=3.11'
+- pypi: https://files.pythonhosted.org/packages/1a/ab/f534d8b8a1db1e00ae25254dcba64c220b7af50aefe11e584d54bd45d0ec/multimark-0.3.2-cp39-abi3-win_amd64.whl
+  name: multimark
+  version: 0.3.2
+  sha256: 2039c7278cb7cad4b587b046f7af686a4f321e5b6265fb0dec9f10d104cbdc6a
+  requires_dist:
+  - cffi>=1.15
+  - click>=8.0
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/1b/fb/909584e16d2148c1a252cc2c32dd99fe0e2682459c586d3d7a192e74a0ae/lxml-6.1.2-cp312-cp312-win_amd64.whl
+  name: lxml
+  version: 6.1.2
+  sha256: b97153ca609b434b712ddfb92cd6af101a7045a7724c542258bd4727a344472f
+  requires_dist:
+  - cssselect>=0.7 ; extra == 'cssselect'
+  - html5lib ; extra == 'html5'
+  - beautifulsoup4 ; extra == 'htmlsoup'
+  - lxml-html-clean ; extra == 'html-clean'
+  requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/1d/9c/3087e95e4aa3d8e9f4437d3c0af6d553a67539dff178ccbf4fedd967402e/multimark-0.3.2-cp39-abi3-macosx_11_0_arm64.whl
+  name: multimark
+  version: 0.3.2
+  sha256: 0a26acd0d1e2a0f0aca04b3705da73ec7a9d712c28201df7b7da92f721db153c
+  requires_dist:
+  - cffi>=1.15
+  - click>=8.0
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/22/a6/858897256d0deac81a172289110f31629fc4cee19b6f01283303e18c8db3/ptyprocess-0.7.0-py2.py3-none-any.whl
+  name: ptyprocess
+  version: 0.7.0
+  sha256: 4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35
+- pypi: https://files.pythonhosted.org/packages/2f/b2/bd9bfa6d77641bd3be57c7cd6ce10294d26db20cb9aedf19ac5d78845886/htmltools-0.7.0-py3-none-any.whl
+  name: htmltools
+  version: 0.7.0
+  sha256: 92e5d06aeadb56e0ff63b236971bc58bb9cf6058c7235e3af57868e7bf113e1b
+  requires_dist:
+  - typing-extensions>=4.12.0
+  - packaging>=20.9
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/30/36/996c8cbc787b3a6b9509bd139a2ae19acd2df32038b0e30d180312cd0354/great_tables-0.24.0-py3-none-any.whl
+  name: great-tables
+  version: 0.24.0
+  sha256: b50abd07539089683156e132eedd75acd17fe026cdc57a26afd9037a88a055d7
+  requires_dist:
+  - multimark>=0.1.3
+  - faicons>=0.2.2
+  - htmltools>=0.4.1
+  - importlib-metadata
+  - nokap>=0.1.0
+  - typing-extensions>=3.10.0.0
+  - babel>=2.13.1
+  - importlib-resources
+  - great-tables[extra] ; extra == 'all'
+  - great-tables[dev] ; extra == 'all'
+  - css-inline>=0.20.2,<0.21 ; extra == 'extra'
+  - selenium>=4.18.1 ; extra == 'extra'
+  - pillow>=10.2.0 ; extra == 'extra'
+  - great-tables[dev-no-pandas] ; extra == 'dev'
+  - pandas ; extra == 'dev'
+  - plotnine ; extra == 'dev'
+  - numpy>=1.22.4 ; extra == 'dev'
+  - ruff==0.8.0 ; extra == 'dev-no-pandas'
+  - jupyter ; extra == 'dev-no-pandas'
+  - gt-extras>=0.0.7 ; extra == 'dev-no-pandas'
+  - polars ; extra == 'dev-no-pandas'
+  - pre-commit==2.15.0 ; extra == 'dev-no-pandas'
+  - pyarrow ; extra == 'dev-no-pandas'
+  - pyright>=1.1.244 ; extra == 'dev-no-pandas'
+  - pytest>=3 ; extra == 'dev-no-pandas'
+  - pytest-cov ; extra == 'dev-no-pandas'
+  - shiny ; extra == 'dev-no-pandas'
+  - svg-py ; extra == 'dev-no-pandas'
+  - syrupy ; extra == 'dev-no-pandas'
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/39/e7/979fd14e75008623df31ba70d6bb144700f68feadcea042021c06a05bf82/scipy-1.18.1-cp312-cp312-win_amd64.whl
+  name: scipy
+  version: 1.18.1
+  sha256: 5e4d44984abc0020154ea81b247adeddcc3ac5527b975ff798bd1ba0adc513c2
+  requires_dist:
+  - numpy>=2.0.0,<2.8
+  - pytest>=8.0.0 ; extra == 'test'
+  - pytest-cov ; extra == 'test'
+  - pytest-timeout ; extra == 'test'
+  - pytest-xdist ; extra == 'test'
+  - asv ; extra == 'test'
+  - mpmath ; extra == 'test'
+  - gmpy2 ; extra == 'test'
+  - threadpoolctl ; extra == 'test'
+  - scikit-umfpack ; extra == 'test'
+  - pooch ; extra == 'test'
+  - hypothesis>=6.30 ; extra == 'test'
+  - array-api-strict>=2.3.1 ; extra == 'test'
+  - cython ; extra == 'test'
+  - meson ; extra == 'test'
+  - ninja ; sys_platform != 'emscripten' and extra == 'test'
+  - scipy-doctest>=2.0.0 ; extra == 'test'
+  - sphinx>=5.0.0,<8.2.0 ; extra == 'doc'
+  - intersphinx-registry ; extra == 'doc'
+  - pydata-sphinx-theme>=0.15.2 ; extra == 'doc'
+  - sphinx-copybutton ; extra == 'doc'
+  - sphinx-design>=0.4.0 ; extra == 'doc'
+  - matplotlib>=3.5 ; extra == 'doc'
+  - numpydoc ; extra == 'doc'
+  - jupytext ; extra == 'doc'
+  - myst-nb>=1.2.0 ; extra == 'doc'
+  - pooch ; extra == 'doc'
+  - jupyterlite-sphinx>=0.19.1 ; extra == 'doc'
+  - jupyterlite-pyodide-kernel ; extra == 'doc'
+  - linkify-it-py ; extra == 'doc'
+  - tabulate ; extra == 'doc'
+  - click<8.3.0 ; extra == 'dev'
+  - spin ; extra == 'dev'
+  - mypy==1.19.1 ; extra == 'dev'
+  - pyrefly==0.63.0 ; extra == 'dev'
+  - typing-extensions ; extra == 'dev'
+  - types-psutil ; extra == 'dev'
+  - pycodestyle ; extra == 'dev'
+  - ruff>=0.12.0 ; extra == 'dev'
+  - cython-lint>=0.12.2 ; extra == 'dev'
+  requires_python: '>=3.12'
+- pypi: https://files.pythonhosted.org/packages/3a/13/547360d81e6d88d58492968ffda9f9542854f11310ee556fef14260cc886/zipp-4.1.0-py3-none-any.whl
+  name: zipp
+  version: 4.1.0
+  sha256: 25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f
+  requires_dist:
+  - pytest>=6,!=8.1.* ; extra == 'test'
+  - jaraco-itertools ; extra == 'test'
+  - jaraco-functools ; extra == 'test'
+  - more-itertools ; extra == 'test'
+  - big-o ; extra == 'test'
+  - pytest-ignore-flaky ; extra == 'test'
+  - jaraco-test ; extra == 'test'
+  - sphinx>=3.5 ; extra == 'doc'
+  - jaraco-packaging>=9.3 ; extra == 'doc'
+  - rst-linker>=1.9 ; extra == 'doc'
+  - furo ; extra == 'doc'
+  - sphinx-lint ; extra == 'doc'
+  - jaraco-tidelift>=1.4 ; extra == 'doc'
+  - pytest-checkdocs>=2.14 ; extra == 'check'
+  - pytest-ruff>=0.2.1 ; sys_platform != 'cygwin' and extra == 'check'
+  - pytest-cov ; extra == 'cover'
+  - pytest-enabler>=3.4 ; extra == 'enabler'
+  - pytest-mypy>=1.0.1 ; platform_python_implementation != 'PyPy' and extra == 'type'
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/3a/5f/62d28cf019460c7f1394105b4d49d9911a9c444cb77ab0bd95a204c5a6de/numpy-2.5.2-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+  name: numpy
+  version: 2.5.2
+  sha256: 3cdec01fa790a186d430433fdd4d4ffb70eed6f0eeb4bf05c8dbe2dce0a9bcb8
+  requires_python: '>=3.12'
+- pypi: https://files.pythonhosted.org/packages/3d/e0/a65b64f34d556925faef2c4f14167d58c571bc15a3e1f2bba71138830562/lxml-6.1.2-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl
+  name: lxml
+  version: 6.1.2
+  sha256: 04cf9e3f4ee9cab9d9ba05401bef8668840fa9620fcd4d8e85a2d2fd0b0fa960
+  requires_dist:
+  - cssselect>=0.7 ; extra == 'cssselect'
+  - html5lib ; extra == 'html5'
+  - beautifulsoup4 ; extra == 'htmlsoup'
+  - lxml-html-clean ; extra == 'html-clean'
+  requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/41/09/5b161152e2d90f7b87f781c2e1267494aef9c32498df793f73ad0a0a494a/matplotlib_inline-0.2.2-py3-none-any.whl
+  name: matplotlib-inline
+  version: 0.2.2
+  sha256: 3c821cf1c209f59fb2d2d64abbf5b23b67bcb2210d663f9918dd851c6da1fcf6
+  requires_dist:
+  - traitlets
+  - flake8 ; extra == 'test'
+  - nbdime ; extra == 'test'
+  - nbval ; extra == 'test'
+  - notebook ; extra == 'test'
+  - pytest ; extra == 'test'
+  - matplotlib ; extra == 'test'
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/45/89/da2f7971a317f83d807fdd4065c0af40208e59e692cc43d315a71a0e96d1/pillow-12.3.0-cp312-cp312-win_amd64.whl
+  name: pillow
+  version: 12.3.0
+  sha256: a2b55dd6b2a4c4b7d87ffa56bdb33fdc5fdb9a462173861a7bc097f17d91cb09
+  requires_dist:
+  - furo ; extra == 'docs'
+  - olefile ; extra == 'docs'
+  - sphinx>=8.2 ; extra == 'docs'
+  - sphinx-autobuild ; extra == 'docs'
+  - sphinx-copybutton ; extra == 'docs'
+  - sphinx-inline-tabs ; extra == 'docs'
+  - sphinxext-opengraph ; extra == 'docs'
+  - olefile ; extra == 'fpx'
+  - olefile ; extra == 'mic'
+  - arro3-compute ; extra == 'test-arrow'
+  - arro3-core ; extra == 'test-arrow'
+  - nanoarrow ; extra == 'test-arrow'
+  - pyarrow ; extra == 'test-arrow'
+  - coverage>=7.4.2 ; extra == 'tests'
+  - defusedxml ; extra == 'tests'
+  - markdown2 ; extra == 'tests'
+  - olefile ; extra == 'tests'
+  - packaging ; extra == 'tests'
+  - pytest ; extra == 'tests'
+  - pytest-cov ; extra == 'tests'
+  - pytest-timeout ; extra == 'tests'
+  - pytest-xdist ; extra == 'tests'
+  - setuptools ; extra == 'tests'
+  - trove-classifiers>=2024.10.12 ; extra == 'tests'
+  - defusedxml ; extra == 'xmp'
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl
+  name: typing-extensions
+  version: 4.16.0
+  sha256: 481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/50/23/493ecfdaf32898e5ea24dc900e33e5e317f9662d5d9ab2d44b2e111b4e1c/websockets-17.1-cp312-cp312-win_amd64.whl
+  name: websockets
+  version: '17.1'
+  sha256: 617243e19a0992095956f406ee9cd3bc4ba92862d83cb1d83bb59ce574412bec
+  requires_python: '>=3.11'
+- pypi: https://files.pythonhosted.org/packages/53/3e/405b59cfa13021a56bba395a6b3aca8cec012b45bf177b0eaf7a202cde2c/contourpy-1.3.3-cp312-cp312-macosx_11_0_arm64.whl
+  name: contourpy
+  version: 1.3.3
+  sha256: 556dba8fb6f5d8742f2923fe9457dbdd51e1049c4a43fd3986a0b14a1d815fc6
+  requires_dist:
+  - numpy>=1.25
+  - furo ; extra == 'docs'
+  - sphinx>=7.2 ; extra == 'docs'
+  - sphinx-copybutton ; extra == 'docs'
+  - bokeh ; extra == 'bokeh'
+  - selenium ; extra == 'bokeh'
+  - contourpy[bokeh,docs] ; extra == 'mypy'
+  - bokeh ; extra == 'mypy'
+  - docutils-stubs ; extra == 'mypy'
+  - mypy==1.17.0 ; extra == 'mypy'
+  - types-pillow ; extra == 'mypy'
+  - contourpy[test-no-images] ; extra == 'test'
+  - matplotlib ; extra == 'test'
+  - pillow ; extra == 'test'
+  - pytest ; extra == 'test-no-images'
+  - pytest-cov ; extra == 'test-no-images'
+  - pytest-rerunfailures ; extra == 'test-no-images'
+  - pytest-xdist ; extra == 'test-no-images'
+  - wurlitzer ; extra == 'test-no-images'
+  requires_python: '>=3.11'
+- pypi: https://files.pythonhosted.org/packages/54/6f/84908cad2d6aa5144abcf7b42709fe4fdb459bc640ec7ac5786e7693dabc/prompt_toolkit-3.0.53-py3-none-any.whl
+  name: prompt-toolkit
+  version: 3.0.53
+  sha256: 01c0891d7f9237d5e339f7d3e42cdae80b7534abb1c7c0e3352efba6231492f2
+  requires_dist:
+  - wcwidth>=0.1.4
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/54/7d/16e5a096677b5e313ca80cd5e5170efa3ea44624a82bb111925522da64b1/cffi-2.1.1-cp312-cp312-macosx_11_0_arm64.whl
+  name: cffi
+  version: 2.1.1
+  sha256: f81b3b8f3d4e343550fa4baa0e479bba9f2d29ce9c2e9b51d1ce1718d7442fcf
+  requires_dist:
+  - pycparser ; implementation_name != 'PyPy'
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/58/50/6c0d534c5f134586a8e1ba4e330569e32f057e33372ae556463212fb4cd3/click-8.5.0-py3-none-any.whl
+  name: click
+  version: 8.5.0
+  sha256: 255bc9599cf7748b4b1a446ccc735421bd08a2ae529a8b88597d3de5664ee360
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/5d/90/095984648cec62a786bb27c0b50f6cfa5856d1e073ba1006fe148d190084/wrapt-2.4.0-cp312-cp312-macosx_11_0_arm64.whl
+  name: wrapt
+  version: 2.4.0
+  sha256: 6b9b32d5e4f0a179cef5075cc79b79d6d3482c44c434c12969e48c6719e06d95
+  requires_dist:
+  - pytest ; extra == 'dev'
+  - setuptools ; extra == 'dev'
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/60/2e/b5aee50a1f74ac815cf8331812cb8251e29024025de462e0c047641c614c/numpy-2.5.2-cp312-cp312-macosx_11_0_arm64.whl
+  name: numpy
+  version: 2.5.2
+  sha256: 4bbd96c833ecc8cc069ce518078fc8c60cb9cbfb0fea5b7a803ad65035596d03
+  requires_python: '>=3.12'
+- pypi: https://files.pythonhosted.org/packages/63/34/ba1c580383c9eada3711951fef0795c80b829a078d72188184bcab9dd527/packaging-26.3-py3-none-any.whl
+  name: packaging
+  version: '26.3'
+  sha256: d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/65/3c/1db1b0f878319bb227f35a0fca7cad64e1f528b518bcab1a708da305c86d/faicons-0.2.2-py3-none-any.whl
+  name: faicons
+  version: 0.2.2
+  sha256: d45d7c2635b53582a3375c67d7e975a28a91d2c16ef5f6b5033b5cdd507224b6
+  requires_dist:
+  - htmltools>=0.1.4.9002
+  - black>=23.1.0 ; extra == 'dev'
+  - wheel ; extra == 'dev'
+  - flake8==3.9.2 ; python_full_version < '3.8' and extra == 'dev'
+  - flake8>=6.0.0 ; python_full_version >= '3.8' and extra == 'dev'
+  - pytest>=6.2.4 ; extra == 'test'
+  requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/68/56/fbe81c09195924d8b7b8d4461a20458fe80a6a5ed6b24f0314da684277e1/pandas-3.0.5-cp312-cp312-macosx_11_0_arm64.whl
+  name: pandas
+  version: 3.0.5
+  sha256: c2e26bb46934b8a2ca0c3de1d3d606fc5f6746584791b2db264d58cf370e08dc
+  requires_dist:
+  - numpy>=1.26.0 ; python_full_version < '3.14'
+  - numpy>=2.3.3 ; python_full_version >= '3.14'
+  - python-dateutil>=2.8.2
+  - tzdata ; sys_platform == 'win32'
+  - tzdata ; sys_platform == 'emscripten'
+  - hypothesis>=6.116.0 ; extra == 'test'
+  - pytest>=8.3.4,<9.1 ; extra == 'test'
+  - pytest-xdist>=3.6.1 ; extra == 'test'
+  - pyarrow>=13.0.0 ; extra == 'pyarrow'
+  - bottleneck>=1.4.2 ; extra == 'performance'
+  - numba>=0.60.0 ; extra == 'performance'
+  - numexpr>=2.10.2 ; extra == 'performance'
+  - scipy>=1.14.1 ; extra == 'computation'
+  - xarray>=2024.10.0 ; extra == 'computation'
+  - fsspec>=2024.10.0 ; extra == 'fss'
+  - s3fs>=2024.10.0 ; extra == 'aws'
+  - gcsfs>=2024.10.0 ; extra == 'gcp'
+  - odfpy>=1.4.1 ; extra == 'excel'
+  - openpyxl>=3.1.5 ; extra == 'excel'
+  - python-calamine>=0.3.0 ; extra == 'excel'
+  - pyxlsb>=1.0.10 ; extra == 'excel'
+  - xlrd>=2.0.1 ; extra == 'excel'
+  - xlsxwriter>=3.2.0 ; extra == 'excel'
+  - pyarrow>=13.0.0 ; extra == 'parquet'
+  - pyarrow>=13.0.0 ; extra == 'feather'
+  - pyiceberg>=0.8.1 ; extra == 'iceberg'
+  - tables>=3.10.1 ; extra == 'hdf5'
+  - pyreadstat>=1.2.8 ; extra == 'spss'
+  - sqlalchemy>=2.0.36 ; extra == 'postgresql'
+  - psycopg2>=2.9.10 ; extra == 'postgresql'
+  - adbc-driver-postgresql>=1.2.0 ; extra == 'postgresql'
+  - sqlalchemy>=2.0.36 ; extra == 'mysql'
+  - pymysql>=1.1.1 ; extra == 'mysql'
+  - sqlalchemy>=2.0.36 ; extra == 'sql-other'
+  - adbc-driver-postgresql>=1.2.0 ; extra == 'sql-other'
+  - adbc-driver-sqlite>=1.2.0 ; extra == 'sql-other'
+  - beautifulsoup4>=4.12.3 ; extra == 'html'
+  - html5lib>=1.1 ; extra == 'html'
+  - lxml>=5.3.0 ; extra == 'html'
+  - lxml>=5.3.0 ; extra == 'xml'
+  - matplotlib>=3.9.3 ; extra == 'plot'
+  - jinja2>=3.1.5 ; extra == 'output-formatting'
+  - tabulate>=0.9.0 ; extra == 'output-formatting'
+  - pyqt5>=5.15.9 ; extra == 'clipboard'
+  - qtpy>=2.4.2 ; extra == 'clipboard'
+  - zstandard>=0.23.0 ; extra == 'compression'
+  - pytz>=2020.1 ; extra == 'timezone'
+  - adbc-driver-postgresql>=1.2.0 ; extra == 'all'
+  - adbc-driver-sqlite>=1.2.0 ; extra == 'all'
+  - beautifulsoup4>=4.12.3 ; extra == 'all'
+  - bottleneck>=1.4.2 ; extra == 'all'
+  - fastparquet>=2024.11.0 ; extra == 'all'
+  - fsspec>=2024.10.0 ; extra == 'all'
+  - gcsfs>=2024.10.0 ; extra == 'all'
+  - html5lib>=1.1 ; extra == 'all'
+  - hypothesis>=6.116.0 ; extra == 'all'
+  - jinja2>=3.1.5 ; extra == 'all'
+  - lxml>=5.3.0 ; extra == 'all'
+  - matplotlib>=3.9.3 ; extra == 'all'
+  - numba>=0.60.0 ; extra == 'all'
+  - numexpr>=2.10.2 ; extra == 'all'
+  - odfpy>=1.4.1 ; extra == 'all'
+  - openpyxl>=3.1.5 ; extra == 'all'
+  - psycopg2>=2.9.10 ; extra == 'all'
+  - pyarrow>=13.0.0 ; extra == 'all'
+  - pyiceberg>=0.8.1 ; extra == 'all'
+  - pymysql>=1.1.1 ; extra == 'all'
+  - pyqt5>=5.15.9 ; extra == 'all'
+  - pyreadstat>=1.2.8 ; extra == 'all'
+  - pytest>=8.3.4 ; extra == 'all'
+  - pytest-xdist>=3.6.1 ; extra == 'all'
+  - python-calamine>=0.3.0 ; extra == 'all'
+  - pytz>=2020.1 ; extra == 'all'
+  - pyxlsb>=1.0.10 ; extra == 'all'
+  - qtpy>=2.4.2 ; extra == 'all'
+  - scipy>=1.14.1 ; extra == 'all'
+  - s3fs>=2024.10.0 ; extra == 'all'
+  - sqlalchemy>=2.0.36 ; extra == 'all'
+  - tables>=3.10.1 ; extra == 'all'
+  - tabulate>=0.9.0 ; extra == 'all'
+  - xarray>=2024.10.0 ; extra == 'all'
+  - xlrd>=2.0.1 ; extra == 'all'
+  - xlsxwriter>=3.2.0 ; extra == 'all'
+  - zstandard>=0.23.0 ; extra == 'all'
+  requires_python: '>=3.11'
+- pypi: https://files.pythonhosted.org/packages/6e/7c/7b210498f9f92e1cd7855f260fa69ef056881087b199ee20c208f0e4189a/kiwisolver-1.5.1-cp312-cp312-win_amd64.whl
+  name: kiwisolver
+  version: 1.5.1
+  sha256: 06a6917674de9e0fe3f66f5430787f59a9f2ddb64af9b714eaec547e29ef5c19
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/6f/12/0ab3920643f52eb21271b952b79998b374bf2e68a651f5201b4ac8aa044e/pyfixest-0.60.0-cp312-cp312-macosx_11_0_arm64.whl
+  name: pyfixest
+  version: 0.60.0
+  sha256: 78c924713d597c28fd55193ed327022140ce3f911777695fad84ab35e17878e1
+  requires_dist:
+  - formulaic>=1.1.0
+  - joblib>=1.4.2
+  - maketables>=0.1.0
+  - narwhals>=1.13.3
+  - numpy>=1.25.2
+  - pandas>=1.1.0
+  - scipy>=1.6
+  - seaborn>=0.13.2
+  - tabulate>=0.9.0
+  - tqdm>=4.0.0
+  - linearmodels ; extra == 'benchmarks'
+  - pyarrow ; extra == 'benchmarks'
+  - statsmodels ; extra == 'benchmarks'
+  - jax>=0.4.15 ; extra == 'jax'
+  - numba>=0.58.0 ; extra == 'numba'
+  - lets-plot>=4.0.0 ; extra == 'plots'
+  - torch>=2.0 ; extra == 'torch'
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/70/b5/d2d3e9ae73362ba4229651b0ee1455cf78073a1ce585f6ff693782ce263e/pandas-3.0.5-cp312-cp312-win_amd64.whl
+  name: pandas
+  version: 3.0.5
+  sha256: 80a611068e8a3ac23f7398c6c14eb46dc974e5cc9997f653e2dcfd1da74edd41
+  requires_dist:
+  - numpy>=1.26.0 ; python_full_version < '3.14'
+  - numpy>=2.3.3 ; python_full_version >= '3.14'
+  - python-dateutil>=2.8.2
+  - tzdata ; sys_platform == 'win32'
+  - tzdata ; sys_platform == 'emscripten'
+  - hypothesis>=6.116.0 ; extra == 'test'
+  - pytest>=8.3.4,<9.1 ; extra == 'test'
+  - pytest-xdist>=3.6.1 ; extra == 'test'
+  - pyarrow>=13.0.0 ; extra == 'pyarrow'
+  - bottleneck>=1.4.2 ; extra == 'performance'
+  - numba>=0.60.0 ; extra == 'performance'
+  - numexpr>=2.10.2 ; extra == 'performance'
+  - scipy>=1.14.1 ; extra == 'computation'
+  - xarray>=2024.10.0 ; extra == 'computation'
+  - fsspec>=2024.10.0 ; extra == 'fss'
+  - s3fs>=2024.10.0 ; extra == 'aws'
+  - gcsfs>=2024.10.0 ; extra == 'gcp'
+  - odfpy>=1.4.1 ; extra == 'excel'
+  - openpyxl>=3.1.5 ; extra == 'excel'
+  - python-calamine>=0.3.0 ; extra == 'excel'
+  - pyxlsb>=1.0.10 ; extra == 'excel'
+  - xlrd>=2.0.1 ; extra == 'excel'
+  - xlsxwriter>=3.2.0 ; extra == 'excel'
+  - pyarrow>=13.0.0 ; extra == 'parquet'
+  - pyarrow>=13.0.0 ; extra == 'feather'
+  - pyiceberg>=0.8.1 ; extra == 'iceberg'
+  - tables>=3.10.1 ; extra == 'hdf5'
+  - pyreadstat>=1.2.8 ; extra == 'spss'
+  - sqlalchemy>=2.0.36 ; extra == 'postgresql'
+  - psycopg2>=2.9.10 ; extra == 'postgresql'
+  - adbc-driver-postgresql>=1.2.0 ; extra == 'postgresql'
+  - sqlalchemy>=2.0.36 ; extra == 'mysql'
+  - pymysql>=1.1.1 ; extra == 'mysql'
+  - sqlalchemy>=2.0.36 ; extra == 'sql-other'
+  - adbc-driver-postgresql>=1.2.0 ; extra == 'sql-other'
+  - adbc-driver-sqlite>=1.2.0 ; extra == 'sql-other'
+  - beautifulsoup4>=4.12.3 ; extra == 'html'
+  - html5lib>=1.1 ; extra == 'html'
+  - lxml>=5.3.0 ; extra == 'html'
+  - lxml>=5.3.0 ; extra == 'xml'
+  - matplotlib>=3.9.3 ; extra == 'plot'
+  - jinja2>=3.1.5 ; extra == 'output-formatting'
+  - tabulate>=0.9.0 ; extra == 'output-formatting'
+  - pyqt5>=5.15.9 ; extra == 'clipboard'
+  - qtpy>=2.4.2 ; extra == 'clipboard'
+  - zstandard>=0.23.0 ; extra == 'compression'
+  - pytz>=2020.1 ; extra == 'timezone'
+  - adbc-driver-postgresql>=1.2.0 ; extra == 'all'
+  - adbc-driver-sqlite>=1.2.0 ; extra == 'all'
+  - beautifulsoup4>=4.12.3 ; extra == 'all'
+  - bottleneck>=1.4.2 ; extra == 'all'
+  - fastparquet>=2024.11.0 ; extra == 'all'
+  - fsspec>=2024.10.0 ; extra == 'all'
+  - gcsfs>=2024.10.0 ; extra == 'all'
+  - html5lib>=1.1 ; extra == 'all'
+  - hypothesis>=6.116.0 ; extra == 'all'
+  - jinja2>=3.1.5 ; extra == 'all'
+  - lxml>=5.3.0 ; extra == 'all'
+  - matplotlib>=3.9.3 ; extra == 'all'
+  - numba>=0.60.0 ; extra == 'all'
+  - numexpr>=2.10.2 ; extra == 'all'
+  - odfpy>=1.4.1 ; extra == 'all'
+  - openpyxl>=3.1.5 ; extra == 'all'
+  - psycopg2>=2.9.10 ; extra == 'all'
+  - pyarrow>=13.0.0 ; extra == 'all'
+  - pyiceberg>=0.8.1 ; extra == 'all'
+  - pymysql>=1.1.1 ; extra == 'all'
+  - pyqt5>=5.15.9 ; extra == 'all'
+  - pyreadstat>=1.2.8 ; extra == 'all'
+  - pytest>=8.3.4 ; extra == 'all'
+  - pytest-xdist>=3.6.1 ; extra == 'all'
+  - python-calamine>=0.3.0 ; extra == 'all'
+  - pytz>=2020.1 ; extra == 'all'
+  - pyxlsb>=1.0.10 ; extra == 'all'
+  - qtpy>=2.4.2 ; extra == 'all'
+  - scipy>=1.14.1 ; extra == 'all'
+  - s3fs>=2024.10.0 ; extra == 'all'
+  - sqlalchemy>=2.0.36 ; extra == 'all'
+  - tables>=3.10.1 ; extra == 'all'
+  - tabulate>=0.9.0 ; extra == 'all'
+  - xarray>=2024.10.0 ; extra == 'all'
+  - xlrd>=2.0.1 ; extra == 'all'
+  - xlsxwriter>=3.2.0 ; extra == 'all'
+  - zstandard>=0.23.0 ; extra == 'all'
+  requires_python: '>=3.11'
+- pypi: https://files.pythonhosted.org/packages/71/46/17f022dd3e953bf20a04a028a21ec746d942f8d2af30fa0f124fa0e6a684/pygments-2.21.0-py3-none-any.whl
+  name: pygments
+  version: 2.21.0
+  sha256: 2363c69b61c4a97c838da3b130dcd6468f4848992b21a82f2a63ec34377137d9
+  requires_dist:
+  - colorama>=0.4.6 ; extra == 'windows-terminal'
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/73/dc/c35af5ccf8dbf3268750c54a3c0830f486b8faec38c811aff92335aa99ba/nokap-0.1.0-py3-none-any.whl
+  name: nokap
+  version: 0.1.0
+  sha256: 36f2cae8d4251945dbe311ef68916c7eddfe51da490aabe0d68c5d13294b2539
+  requires_dist:
+  - websockets>=12.0
+  - click>=8.0
+  - pillow>=10.2.0 ; extra == 'extra'
+  - mcp>=1.0 ; extra == 'mcp'
+  - pytest>=7.0 ; extra == 'dev'
+  - pytest-cov>=3.0 ; extra == 'dev'
+  - pytest-timeout>=2.0 ; extra == 'dev'
+  - pyright>=1.1 ; extra == 'dev'
+  - ruff>=0.4 ; extra == 'dev'
+  - mcp>=1.0 ; extra == 'dev'
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/77/c7/2342da9830e3e9d4870305ca5d2091d2a83284f2953079b7bdd3b5e029d8/fonttools-4.63.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+  name: fonttools
+  version: 4.63.0
+  sha256: 58dc6bb86a78d782f00f9190ca02c119cf5bbe2807536e361e18d42019f877d8
+  requires_dist:
+  - lxml>=4.0 ; extra == 'lxml'
+  - brotli>=1.0.1 ; platform_python_implementation == 'CPython' and extra == 'woff'
+  - brotlicffi>=0.8.0 ; platform_python_implementation != 'CPython' and extra == 'woff'
+  - zopfli>=0.1.4 ; extra == 'woff'
+  - unicodedata2>=17.0.0 ; python_full_version < '3.15' and extra == 'unicode'
+  - lz4>=1.7.4.2 ; extra == 'graphite'
+  - scipy ; platform_python_implementation != 'PyPy' and extra == 'interpolatable'
+  - munkres ; platform_python_implementation == 'PyPy' and extra == 'interpolatable'
+  - pycairo ; extra == 'interpolatable'
+  - matplotlib ; extra == 'plot'
+  - sympy ; extra == 'symfont'
+  - xattr ; sys_platform == 'darwin' and extra == 'type1'
+  - skia-pathops>=0.5.0 ; extra == 'pathops'
+  - uharfbuzz>=0.45.0 ; extra == 'repacker'
+  - lxml>=4.0 ; extra == 'all'
+  - brotli>=1.0.1 ; platform_python_implementation == 'CPython' and extra == 'all'
+  - brotlicffi>=0.8.0 ; platform_python_implementation != 'CPython' and extra == 'all'
+  - zopfli>=0.1.4 ; extra == 'all'
+  - unicodedata2>=17.0.0 ; python_full_version < '3.15' and extra == 'all'
+  - lz4>=1.7.4.2 ; extra == 'all'
+  - scipy ; platform_python_implementation != 'PyPy' and extra == 'all'
+  - munkres ; platform_python_implementation == 'PyPy' and extra == 'all'
+  - pycairo ; extra == 'all'
+  - matplotlib ; extra == 'all'
+  - sympy ; extra == 'all'
+  - xattr ; sys_platform == 'darwin' and extra == 'all'
+  - skia-pathops>=0.5.0 ; extra == 'all'
+  - uharfbuzz>=0.45.0 ; extra == 'all'
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl
+  name: babel
+  version: 2.18.0
+  sha256: e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35
+  requires_dist:
+  - pytz>=2015.7 ; python_full_version < '3.9'
+  - tzdata ; sys_platform == 'win32' and extra == 'dev'
+  - backports-zoneinfo ; python_full_version < '3.9' and extra == 'dev'
+  - freezegun~=1.0 ; extra == 'dev'
+  - jinja2>=3.0 ; extra == 'dev'
+  - pytest-cov ; extra == 'dev'
+  - pytest>=6.0 ; extra == 'dev'
+  - pytz ; extra == 'dev'
+  - setuptools ; extra == 'dev'
+  requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/7f/b9/87fea2769fe1c47c1b5b01d8310772c9d1a85d485de7cf386ef7a3332b02/numpy-2.5.2-cp312-cp312-win_amd64.whl
+  name: numpy
+  version: 2.5.2
+  sha256: 28ac63476ec7651484215ee7fa15a1f78b57c14621f01e392afe17b9a1390ce4
+  requires_python: '>=3.12'
+- pypi: https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl
+  name: psutil
+  version: 7.2.2
+  sha256: 1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979
+  requires_dist:
+  - psleak ; extra == 'dev'
+  - pytest ; extra == 'dev'
+  - pytest-instafail ; extra == 'dev'
+  - pytest-xdist ; extra == 'dev'
+  - setuptools ; extra == 'dev'
+  - abi3audit ; extra == 'dev'
+  - black ; extra == 'dev'
+  - check-manifest ; extra == 'dev'
+  - coverage ; extra == 'dev'
+  - packaging ; extra == 'dev'
+  - pylint ; extra == 'dev'
+  - pyperf ; extra == 'dev'
+  - pypinfo ; extra == 'dev'
+  - pytest-cov ; extra == 'dev'
+  - requests ; extra == 'dev'
+  - rstcheck ; extra == 'dev'
+  - ruff ; extra == 'dev'
+  - sphinx ; extra == 'dev'
+  - sphinx-rtd-theme ; extra == 'dev'
+  - toml-sort ; extra == 'dev'
+  - twine ; extra == 'dev'
+  - validate-pyproject[all] ; extra == 'dev'
+  - virtualenv ; extra == 'dev'
+  - vulture ; extra == 'dev'
+  - wheel ; extra == 'dev'
+  - colorama ; os_name == 'nt' and extra == 'dev'
+  - pyreadline3 ; os_name == 'nt' and extra == 'dev'
+  - pywin32 ; implementation_name != 'pypy' and os_name == 'nt' and extra == 'dev'
+  - wheel ; implementation_name != 'pypy' and os_name == 'nt' and extra == 'dev'
+  - wmi ; implementation_name != 'pypy' and os_name == 'nt' and extra == 'dev'
+  - psleak ; extra == 'test'
+  - pytest ; extra == 'test'
+  - pytest-instafail ; extra == 'test'
+  - pytest-xdist ; extra == 'test'
+  - setuptools ; extra == 'test'
+  - pywin32 ; implementation_name != 'pypy' and os_name == 'nt' and extra == 'test'
+  - wheel ; implementation_name != 'pypy' and os_name == 'nt' and extra == 'test'
+  - wmi ; implementation_name != 'pypy' and os_name == 'nt' and extra == 'test'
+  requires_python: '>=3.6'
+- pypi: https://files.pythonhosted.org/packages/83/11/00d3c3dfc25ad54e731d91449895a79e4bf2384dc3ac01809010ba88f6d5/seaborn-0.13.2-py3-none-any.whl
+  name: seaborn
+  version: 0.13.2
+  sha256: 636f8336facf092165e27924f223d3c62ca560b1f2bb5dff7ab7fad265361987
+  requires_dist:
+  - numpy>=1.20,!=1.24.0
+  - pandas>=1.2
+  - matplotlib>=3.4,!=3.6.1
+  - pytest ; extra == 'dev'
+  - pytest-cov ; extra == 'dev'
+  - pytest-xdist ; extra == 'dev'
+  - flake8 ; extra == 'dev'
+  - mypy ; extra == 'dev'
+  - pandas-stubs ; extra == 'dev'
+  - pre-commit ; extra == 'dev'
+  - flit ; extra == 'dev'
+  - numpydoc ; extra == 'docs'
+  - nbconvert ; extra == 'docs'
+  - ipykernel ; extra == 'docs'
+  - sphinx<6.0.0 ; extra == 'docs'
+  - sphinx-copybutton ; extra == 'docs'
+  - sphinx-issues ; extra == 'docs'
+  - sphinx-design ; extra == 'docs'
+  - pyyaml ; extra == 'docs'
+  - pydata-sphinx-theme==0.10.0rc2 ; extra == 'docs'
+  - scipy>=1.7 ; extra == 'stats'
+  - statsmodels>=0.12 ; extra == 'stats'
+  requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/84/21/a35af28dcc61f37ed850a2d64c65c701321dfbf25085e469d5559360cbbf/pillow-12.3.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+  name: pillow
+  version: 12.3.0
+  sha256: 78cb2c6865a35ab8ff8b75fd122f6033b92a62c82801110e48ddd6c936a45d91
+  requires_dist:
+  - furo ; extra == 'docs'
+  - olefile ; extra == 'docs'
+  - sphinx>=8.2 ; extra == 'docs'
+  - sphinx-autobuild ; extra == 'docs'
+  - sphinx-copybutton ; extra == 'docs'
+  - sphinx-inline-tabs ; extra == 'docs'
+  - sphinxext-opengraph ; extra == 'docs'
+  - olefile ; extra == 'fpx'
+  - olefile ; extra == 'mic'
+  - arro3-compute ; extra == 'test-arrow'
+  - arro3-core ; extra == 'test-arrow'
+  - nanoarrow ; extra == 'test-arrow'
+  - pyarrow ; extra == 'test-arrow'
+  - coverage>=7.4.2 ; extra == 'tests'
+  - defusedxml ; extra == 'tests'
+  - markdown2 ; extra == 'tests'
+  - olefile ; extra == 'tests'
+  - packaging ; extra == 'tests'
+  - pytest ; extra == 'tests'
+  - pytest-cov ; extra == 'tests'
+  - pytest-timeout ; extra == 'tests'
+  - pytest-xdist ; extra == 'tests'
+  - setuptools ; extra == 'tests'
+  - trove-classifiers>=2024.10.12 ; extra == 'tests'
+  - defusedxml ; extra == 'xmp'
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/84/e5/bdb34e21523e01dceda064d63713f3bdec91388af24fba1eca7ea5e85864/kiwisolver-1.5.1-cp312-cp312-macosx_11_0_arm64.whl
+  name: kiwisolver
+  version: 1.5.1
+  sha256: 1798e83840c3f627246104c4d8a9639c60fa068adf9ce92b61791781fa8a68c1
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/87/36/cccb9bc2a6ab63d1b2980374f0dca72ce95ae267c9b4cfe77455bb70d0d4/fonttools-4.63.0-cp312-cp312-win_amd64.whl
+  name: fonttools
+  version: 4.63.0
+  sha256: 59ac449f8cca9b4ffa08d2e7bbadad87ce710d69d1eda5c3c1ce579baa987272
+  requires_dist:
+  - lxml>=4.0 ; extra == 'lxml'
+  - brotli>=1.0.1 ; platform_python_implementation == 'CPython' and extra == 'woff'
+  - brotlicffi>=0.8.0 ; platform_python_implementation != 'CPython' and extra == 'woff'
+  - zopfli>=0.1.4 ; extra == 'woff'
+  - unicodedata2>=17.0.0 ; python_full_version < '3.15' and extra == 'unicode'
+  - lz4>=1.7.4.2 ; extra == 'graphite'
+  - scipy ; platform_python_implementation != 'PyPy' and extra == 'interpolatable'
+  - munkres ; platform_python_implementation == 'PyPy' and extra == 'interpolatable'
+  - pycairo ; extra == 'interpolatable'
+  - matplotlib ; extra == 'plot'
+  - sympy ; extra == 'symfont'
+  - xattr ; sys_platform == 'darwin' and extra == 'type1'
+  - skia-pathops>=0.5.0 ; extra == 'pathops'
+  - uharfbuzz>=0.45.0 ; extra == 'repacker'
+  - lxml>=4.0 ; extra == 'all'
+  - brotli>=1.0.1 ; platform_python_implementation == 'CPython' and extra == 'all'
+  - brotlicffi>=0.8.0 ; platform_python_implementation != 'CPython' and extra == 'all'
+  - zopfli>=0.1.4 ; extra == 'all'
+  - unicodedata2>=17.0.0 ; python_full_version < '3.15' and extra == 'all'
+  - lz4>=1.7.4.2 ; extra == 'all'
+  - scipy ; platform_python_implementation != 'PyPy' and extra == 'all'
+  - munkres ; platform_python_implementation == 'PyPy' and extra == 'all'
+  - pycairo ; extra == 'all'
+  - matplotlib ; extra == 'all'
+  - sympy ; extra == 'all'
+  - xattr ; sys_platform == 'darwin' and extra == 'all'
+  - skia-pathops>=0.5.0 ; extra == 'all'
+  - uharfbuzz>=0.45.0 ; extra == 'all'
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/87/4a/74d5c8ef7bc1677b5aec3b5f353b0c51917e79ee6d12d7cb7cf4ed4fb0f0/pyfixest-0.60.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  name: pyfixest
+  version: 0.60.0
+  sha256: d14c4f41a54534cbbd448e6dd87e9ec9dbe5ae79c15fed8c37e3f0eee58b349f
+  requires_dist:
+  - formulaic>=1.1.0
+  - joblib>=1.4.2
+  - maketables>=0.1.0
+  - narwhals>=1.13.3
+  - numpy>=1.25.2
+  - pandas>=1.1.0
+  - scipy>=1.6
+  - seaborn>=0.13.2
+  - tabulate>=0.9.0
+  - tqdm>=4.0.0
+  - linearmodels ; extra == 'benchmarks'
+  - pyarrow ; extra == 'benchmarks'
+  - statsmodels ; extra == 'benchmarks'
+  - jax>=0.4.15 ; extra == 'jax'
+  - numba>=0.58.0 ; extra == 'numba'
+  - lets-plot>=4.0.0 ; extra == 'plots'
+  - torch>=2.0 ; extra == 'torch'
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl
+  name: cloudpickle
+  version: 3.1.2
+  sha256: 9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a
+  requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/88/89/56649bbaa2fd12e20f3be03dbcc135b0c8676d88bac17977599e3eb442a0/matplotlib-3.11.1-cp312-cp312-win_amd64.whl
+  name: matplotlib
+  version: 3.11.1
+  sha256: 88a2a27dd9691ae448dfae4b26f59036be90c3c28757edd3553a29559d00859f
+  requires_dist:
+  - contourpy>=1.0.1
+  - cycler>=0.10
+  - fonttools>=4.28.2
+  - kiwisolver>=1.3.1
+  - numpy>=1.25
+  - packaging>=20.0
+  - pillow>=9
+  - pyparsing>=3
+  - python-dateutil>=2.7
+  requires_python: '>=3.11'
+- pypi: https://files.pythonhosted.org/packages/8a/db/55a262f3606bebcae07cc14095338471ad7c0bbcaa37707e6f0ee49725b7/importlib_resources-7.1.0-py3-none-any.whl
+  name: importlib-resources
+  version: 7.1.0
+  sha256: 1bd7b48b4088eddb2cd16382150bb515af0bd2c70128194392725f82ad2c96a1
+  requires_dist:
+  - zipp>=3.1.0 ; python_full_version < '3.10'
+  - pytest>=6,!=8.1.* ; extra == 'test'
+  - zipp>=3.17 ; extra == 'test'
+  - jaraco-test>=5.4 ; extra == 'test'
+  - sphinx>=3.5 ; extra == 'doc'
+  - jaraco-packaging>=9.3 ; extra == 'doc'
+  - rst-linker>=1.9 ; extra == 'doc'
+  - furo ; extra == 'doc'
+  - sphinx-lint ; extra == 'doc'
+  - jaraco-tidelift>=1.4 ; extra == 'doc'
+  - pytest-checkdocs>=2.14 ; extra == 'check'
+  - pytest-ruff>=0.2.1 ; sys_platform != 'cygwin' and extra == 'check'
+  - pytest-cov ; extra == 'cover'
+  - pytest-enabler>=3.4 ; extra == 'enabler'
+  - pytest-mypy>=1.0.1 ; platform_python_implementation != 'PyPy' and extra == 'type'
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl
+  name: pure-eval
+  version: 0.2.3
+  sha256: 1db8e35b67b3d218d818ae653e27f06c3aa420901fa7b081ca98cbedc874e0d0
+  requires_dist:
+  - pytest ; extra == 'tests'
+- pypi: https://files.pythonhosted.org/packages/8f/e7/df821761772beaa48c211ee0e234930b35c1473778470773823f56d3911b/websockets-17.1-cp312-cp312-macosx_11_0_arm64.whl
+  name: websockets
+  version: '17.1'
+  sha256: 87f0d5e77548b0c40c8464cdb6108792e7e53f487c6400028a4ec28a8afbe5ab
+  requires_python: '>=3.11'
+- pypi: https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl
+  name: tabulate
+  version: 0.10.0
+  sha256: f0b0622e567335c8fabaaa659f1b33bcb6ddfe2e496071b743aa113f8774f2d3
+  requires_dist:
+  - wcwidth ; extra == 'widechars'
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/99/5d/8268b644392ee874ee82a635cd0df1773de230bde356c38de28e298392cc/parso-0.8.7-py2.py3-none-any.whl
+  name: parso
+  version: 0.8.7
+  sha256: a8926eb2a1b915486941fdbd31e86a4baf88fe8c210f25f2f35ecec5b574ca1c
+  requires_dist:
+  - flake8==5.0.4 ; extra == 'qa'
+  - types-setuptools==67.2.0.1 ; extra == 'qa'
+  - zuban==0.5.1 ; extra == 'qa'
+  - docopt ; extra == 'testing'
+  - pytest ; extra == 'testing'
+  requires_python: '>=3.6'
+- pypi: https://files.pythonhosted.org/packages/9a/93/242e2eab5fe682ffcb8b0084bde703a41d51e17ee0f3a31ff0d9d813620a/jedi-0.20.0-py2.py3-none-any.whl
+  name: jedi
+  version: 0.20.0
+  sha256: 7bdd9c2634f56713299976f4cbd59cb3fa92165cc5e05ea811fb253480728b67
+  requires_dist:
+  - parso>=0.8.6,<0.9.0
+  - django ; extra == 'dev'
+  - attrs ; extra == 'dev'
+  - colorama ; extra == 'dev'
+  - docopt ; extra == 'dev'
+  - flake8==7.1.2 ; extra == 'dev'
+  - pytest<9.0.0 ; extra == 'dev'
+  - types-setuptools==80.9.0.20250529 ; extra == 'dev'
+  - typing-extensions ; extra == 'dev'
+  - zuban==0.7.0 ; extra == 'dev'
+  - jinja2==3.1.6 ; extra == 'docs'
+  - markupsafe==3.0.3 ; extra == 'docs'
+  - pygments==2.20.0 ; extra == 'docs'
+  - sphinx==9.1.0 ; extra == 'docs'
+  - alabaster==1.0.0 ; extra == 'docs'
+  - babel==2.18.0 ; extra == 'docs'
+  - certifi==2026.4.22 ; extra == 'docs'
+  - charset-normalizer==3.4.7 ; extra == 'docs'
+  - docutils==0.22.4 ; extra == 'docs'
+  - idna==3.13 ; extra == 'docs'
+  - imagesize==2.0.0 ; extra == 'docs'
+  - iniconfig==2.3.0 ; extra == 'docs'
+  - packaging==26.2 ; extra == 'docs'
+  - pluggy==1.6.0 ; extra == 'docs'
+  - pytest==9.0.3 ; extra == 'docs'
+  - requests==2.33.1 ; extra == 'docs'
+  - roman-numerals==4.1.0 ; extra == 'docs'
+  - snowballstemmer==3.0.1 ; extra == 'docs'
+  - sphinx-rtd-theme==3.1.0 ; extra == 'docs'
+  - sphinxcontrib-applehelp==2.0.0 ; extra == 'docs'
+  - sphinxcontrib-devhelp==2.0.0 ; extra == 'docs'
+  - sphinxcontrib-htmlhelp==2.1.0 ; extra == 'docs'
+  - sphinxcontrib-jquery==4.1 ; extra == 'docs'
+  - sphinxcontrib-jsmath==1.0.1 ; extra == 'docs'
+  - sphinxcontrib-qthelp==2.0.0 ; extra == 'docs'
+  - sphinxcontrib-serializinghtml==2.0.0 ; extra == 'docs'
+  - urllib3==2.6.3 ; extra == 'docs'
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/9e/c3/059298687310d527a58bb01f3b1965787ee3b40dce76752eda8b44e9a2c5/pexpect-4.9.0-py2.py3-none-any.whl
+  name: pexpect
+  version: 4.9.0
+  sha256: 7236d1e080e4936be2dc3e326cec0af72acf9212a7e1d060210e70a47e253523
+  requires_dist:
+  - ptyprocess>=0.5
+- pypi: https://files.pythonhosted.org/packages/a1/d3/20a61a248feb1249cd81f83ce731f0bdf5170ed96a08a298f7081cda9e90/interface_meta-2.0.1-py3-none-any.whl
+  name: interface-meta
+  version: 2.0.1
+  sha256: f38016bef9a4429b6d0792d809be7b65e9781820c674bf7f463999086b6e6323
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/ac/cb/7ef3503279a4d2dc6b7fed0d0c53a9d97d98f7c28166ebfcc45eef64fe29/maketables-0.1.8-py3-none-any.whl
+  name: maketables
+  version: 0.1.8
+  sha256: d79aeb0c08ae8ed7d78978b5676ff1a5236517abbbd287b04986602504b0bfb5
+  requires_dist:
+  - great-tables>=0.2.0
+  - ipython>=7.0.0
+  - numpy>=1.20.0
+  - pandas>=1.3.0
+  - python-docx>=0.8.11
+  - tabulate>=0.9.0
+  - linearmodels>=4.0 ; extra == 'dev'
+  - mypy>=1.0 ; extra == 'dev'
+  - pre-commit>=4.3.0,<5 ; extra == 'dev'
+  - pyfixest>=0.13.0 ; extra == 'dev'
+  - pytest-cov>=4.0 ; extra == 'dev'
+  - pytest>=7.0 ; extra == 'dev'
+  - quartodoc>=0.7.0 ; extra == 'dev'
+  - statsmodels>=0.13.0 ; extra == 'dev'
+  - syrupy>=4.0.0 ; extra == 'dev'
+  - ipykernel>=6.0.0,<7 ; extra == 'docs'
+  - nbconvert>=7.0.0 ; extra == 'docs'
+  - pyfixest>=0.13.0 ; extra == 'docs'
+  - pylatex>=1.4.2,<2 ; extra == 'docs'
+  - pyyaml>=6.0.0,<7 ; extra == 'docs'
+  - sphinx-rtd-theme>=1.0 ; extra == 'docs'
+  - sphinx>=5.0 ; extra == 'docs'
+  - statsmodels>=0.13.0 ; extra == 'docs'
+  - lifelines>=0.27.0 ; extra == 'lifelines'
+  - linearmodels>=4.0 ; extra == 'linearmodels'
+  - statsmodels>=0.13.0 ; extra == 'linearmodels'
+  - pystata>=0.0.1 ; extra == 'pystata'
+  - stata-setup>=0.1.0 ; extra == 'pystata'
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/ad/66/0d785f0bc5e4315a96c989bb476d0fc07ea4f85132550c7b156ca2035d52/traitlets-5.16.1-py3-none-any.whl
+  name: traitlets
+  version: 5.16.1
+  sha256: f775618166caa0396c8e337099240f2bd3e5e917d203b2e6fbe21a58d3cb1f6b
+  requires_dist:
+  - myst-parser ; extra == 'docs'
+  - pydata-sphinx-theme ; extra == 'docs'
+  - sphinx ; extra == 'docs'
+  - argcomplete>=3.0.3 ; python_full_version < '3.12' and extra == 'test'
+  - argcomplete>=3.5.2 ; python_full_version >= '3.12' and extra == 'test'
+  - mypy>=2.0 ; implementation_name != 'pypy' and extra == 'test'
+  - pre-commit ; extra == 'test'
+  - pytest-mock ; extra == 'test'
+  - pytest-mypy-testing ; implementation_name != 'pypy' and extra == 'test'
+  - pytest>=7.0,<10.0 ; extra == 'test'
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/ad/ec/a7b10705172bdb669b9687a8ff68bbe5f566437d2a49ad6d976af48b6d10/wrapt-2.4.0-cp312-cp312-win_amd64.whl
+  name: wrapt
+  version: 2.4.0
+  sha256: 8b464316489fb2fca0669ea0f8f07290054a0f26fc72982d3e4cf95469628ba9
+  requires_dist:
+  - pytest ; extra == 'dev'
+  - setuptools ; extra == 'dev'
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/b1/db/dceb9dd5b231e1da801793f8acc9f3c52a7e1afe40bb1aae37e02b0faad5/cffi-2.1.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+  name: cffi
+  version: 2.1.1
+  sha256: c1453022f490d2459a11819d83ad1d586e9ff65a12ac3e705ffebd46d3685dcf
+  requires_dist:
+  - pycparser ; implementation_name != 'PyPy'
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/b3/55/ecca97ae19075f1fac62def77731e7f535e6c1fb8f92ff08160c5e6dade8/importlib_metadata-9.0.1-py3-none-any.whl
+  name: importlib-metadata
+  version: 9.0.1
+  sha256: bba5600596a7e21f3eef53281cf28d6a5195634d2f2b78ff9501a3272c6eaab0
+  requires_dist:
+  - zipp>=3.20
+  - pytest>=6,!=8.1.* ; extra == 'test'
+  - packaging ; extra == 'test'
+  - pyfakefs ; extra == 'test'
+  - pytest-perf>=0.17 ; extra == 'test'
+  - sphinx>=3.5 ; extra == 'doc'
+  - jaraco-packaging>=9.3 ; extra == 'doc'
+  - rst-linker>=1.9 ; extra == 'doc'
+  - furo ; extra == 'doc'
+  - sphinx-lint ; extra == 'doc'
+  - jaraco-tidelift>=1.4 ; extra == 'doc'
+  - ipython ; extra == 'perf'
+  - pytest-checkdocs>=2.14 ; extra == 'check'
+  - pytest-ruff>=0.2.1 ; sys_platform != 'cygwin' and extra == 'check'
+  - pytest-cov ; extra == 'cover'
+  - pytest-enabler>=3.4 ; extra == 'enabler'
+  - pytest-mypy>=1.0.1 ; platform_python_implementation != 'PyPy' and extra == 'type'
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl
+  name: psutil
+  version: 7.2.2
+  sha256: eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988
+  requires_dist:
+  - psleak ; extra == 'dev'
+  - pytest ; extra == 'dev'
+  - pytest-instafail ; extra == 'dev'
+  - pytest-xdist ; extra == 'dev'
+  - setuptools ; extra == 'dev'
+  - abi3audit ; extra == 'dev'
+  - black ; extra == 'dev'
+  - check-manifest ; extra == 'dev'
+  - coverage ; extra == 'dev'
+  - packaging ; extra == 'dev'
+  - pylint ; extra == 'dev'
+  - pyperf ; extra == 'dev'
+  - pypinfo ; extra == 'dev'
+  - pytest-cov ; extra == 'dev'
+  - requests ; extra == 'dev'
+  - rstcheck ; extra == 'dev'
+  - ruff ; extra == 'dev'
+  - sphinx ; extra == 'dev'
+  - sphinx-rtd-theme ; extra == 'dev'
+  - toml-sort ; extra == 'dev'
+  - twine ; extra == 'dev'
+  - validate-pyproject[all] ; extra == 'dev'
+  - virtualenv ; extra == 'dev'
+  - vulture ; extra == 'dev'
+  - wheel ; extra == 'dev'
+  - colorama ; os_name == 'nt' and extra == 'dev'
+  - pyreadline3 ; os_name == 'nt' and extra == 'dev'
+  - pywin32 ; implementation_name != 'pypy' and os_name == 'nt' and extra == 'dev'
+  - wheel ; implementation_name != 'pypy' and os_name == 'nt' and extra == 'dev'
+  - wmi ; implementation_name != 'pypy' and os_name == 'nt' and extra == 'dev'
+  - psleak ; extra == 'test'
+  - pytest ; extra == 'test'
+  - pytest-instafail ; extra == 'test'
+  - pytest-xdist ; extra == 'test'
+  - setuptools ; extra == 'test'
+  - pywin32 ; implementation_name != 'pypy' and os_name == 'nt' and extra == 'test'
+  - wheel ; implementation_name != 'pypy' and os_name == 'nt' and extra == 'test'
+  - wmi ; implementation_name != 'pypy' and os_name == 'nt' and extra == 'test'
+  requires_python: '>=3.6'
+- pypi: https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl
+  name: psutil
+  version: 7.2.2
+  sha256: 076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9
+  requires_dist:
+  - psleak ; extra == 'dev'
+  - pytest ; extra == 'dev'
+  - pytest-instafail ; extra == 'dev'
+  - pytest-xdist ; extra == 'dev'
+  - setuptools ; extra == 'dev'
+  - abi3audit ; extra == 'dev'
+  - black ; extra == 'dev'
+  - check-manifest ; extra == 'dev'
+  - coverage ; extra == 'dev'
+  - packaging ; extra == 'dev'
+  - pylint ; extra == 'dev'
+  - pyperf ; extra == 'dev'
+  - pypinfo ; extra == 'dev'
+  - pytest-cov ; extra == 'dev'
+  - requests ; extra == 'dev'
+  - rstcheck ; extra == 'dev'
+  - ruff ; extra == 'dev'
+  - sphinx ; extra == 'dev'
+  - sphinx-rtd-theme ; extra == 'dev'
+  - toml-sort ; extra == 'dev'
+  - twine ; extra == 'dev'
+  - validate-pyproject[all] ; extra == 'dev'
+  - virtualenv ; extra == 'dev'
+  - vulture ; extra == 'dev'
+  - wheel ; extra == 'dev'
+  - colorama ; os_name == 'nt' and extra == 'dev'
+  - pyreadline3 ; os_name == 'nt' and extra == 'dev'
+  - pywin32 ; implementation_name != 'pypy' and os_name == 'nt' and extra == 'dev'
+  - wheel ; implementation_name != 'pypy' and os_name == 'nt' and extra == 'dev'
+  - wmi ; implementation_name != 'pypy' and os_name == 'nt' and extra == 'dev'
+  - psleak ; extra == 'test'
+  - pytest ; extra == 'test'
+  - pytest-instafail ; extra == 'test'
+  - pytest-xdist ; extra == 'test'
+  - setuptools ; extra == 'test'
+  - pywin32 ; implementation_name != 'pypy' and os_name == 'nt' and extra == 'test'
+  - wheel ; implementation_name != 'pypy' and os_name == 'nt' and extra == 'test'
+  - wmi ; implementation_name != 'pypy' and os_name == 'nt' and extra == 'test'
+  requires_python: '>=3.6'
+- pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
+  name: six
+  version: 1.17.0
+  sha256: 4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274
+  requires_python: '>=2.7,!=3.0.*,!=3.1.*,!=3.2.*'
+- pypi: https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl
+  name: executing
+  version: 2.2.1
+  sha256: 760643d3452b4d777d295bb167ccc74c64a81df23fb5e08eff250c425a4b2017
+  requires_dist:
+  - asttokens>=2.1.0 ; extra == 'tests'
+  - ipython ; extra == 'tests'
+  - pytest ; extra == 'tests'
+  - coverage ; extra == 'tests'
+  - coverage-enable-subprocess ; extra == 'tests'
+  - littleutils ; extra == 'tests'
+  - rich ; python_full_version >= '3.11' and extra == 'tests'
+  requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/c4/0e/57f6bb3024a597b2e8ec4aee710ffe62ddc95af2e2bb1ee7a7abdc22c68c/wcwidth-0.8.3-py3-none-any.whl
+  name: wcwidth
+  version: 0.8.3
+  sha256: d5b73dba6158a595ec9370350e7f2637bcac8d6c5e4fde34f30fcffb6103a5e4
+  requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/c9/cf/b4ad2cc81b6672ea29ea04e64e350a9f9b493b0908ccd884c67eeff8f7b2/matplotlib-3.11.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+  name: matplotlib
+  version: 3.11.1
+  sha256: ba8f811b8ddfac493734d6af0b2dff96919d0c28ca0d641858dab4262777c6ea
+  requires_dist:
+  - contourpy>=1.0.1
+  - cycler>=0.10
+  - fonttools>=4.28.2
+  - kiwisolver>=1.3.1
+  - numpy>=1.25
+  - packaging>=20.0
+  - pillow>=9
+  - pyparsing>=3
+  - python-dateutil>=2.7
+  requires_python: '>=3.11'
+- pypi: https://files.pythonhosted.org/packages/cc/8f/ec6289987824b29529d0dfda0d74a07cec60e54b9c92f3c9da4c0ac732de/contourpy-1.3.3-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+  name: contourpy
+  version: 1.3.3
+  sha256: 4d00e655fcef08aba35ec9610536bfe90267d7ab5ba944f7032549c55a146da1
+  requires_dist:
+  - numpy>=1.25
+  - furo ; extra == 'docs'
+  - sphinx>=7.2 ; extra == 'docs'
+  - sphinx-copybutton ; extra == 'docs'
+  - bokeh ; extra == 'bokeh'
+  - selenium ; extra == 'bokeh'
+  - contourpy[bokeh,docs] ; extra == 'mypy'
+  - bokeh ; extra == 'mypy'
+  - docutils-stubs ; extra == 'mypy'
+  - mypy==1.17.0 ; extra == 'mypy'
+  - types-pillow ; extra == 'mypy'
+  - contourpy[test-no-images] ; extra == 'test'
+  - matplotlib ; extra == 'test'
+  - pillow ; extra == 'test'
+  - pytest ; extra == 'test-no-images'
+  - pytest-cov ; extra == 'test-no-images'
+  - pytest-rerunfailures ; extra == 'test-no-images'
+  - pytest-xdist ; extra == 'test-no-images'
+  - wurlitzer ; extra == 'test-no-images'
+  requires_python: '>=3.11'
+- pypi: https://files.pythonhosted.org/packages/d0/00/1e03a4989fa5795da308cd774f05b704ace555a70f9bf9d3be057b680bcf/python_docx-1.2.0-py3-none-any.whl
+  name: python-docx
+  version: 1.2.0
+  sha256: 3fd478f3250fbbbfd3b94fe1e985955737c145627498896a8a6bf81f4baf66c7
+  requires_dist:
+  - lxml>=3.1.0
+  - typing-extensions>=4.9.0
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
+  name: colorama
+  version: 0.4.6
+  sha256: 4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6
+  requires_python: '>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*'
+- pypi: https://files.pythonhosted.org/packages/d4/2b/04b8a15f3a1c77bc79ddf5c73875327f34b4fa75982df2b76e45e402d364/asttokens-3.0.2-py3-none-any.whl
+  name: asttokens
+  version: 3.0.2
+  sha256: 9da13157f5b28becde0bd374fc677dcd3c290614264eff096f167c469cd9f933
+  requires_dist:
+  - astroid>=2,<5 ; extra == 'astroid'
+  - astroid>=2,<5 ; extra == 'test'
+  - pytest<9.0 ; extra == 'test'
+  - pytest-cov ; extra == 'test'
+  - pytest-xdist ; extra == 'test'
+  requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/d8/66/9a386a92561f402389a4fc70c18838bf6d35eb5eb5c6850b4b2dc64f5048/pillow-12.3.0-cp312-cp312-macosx_11_0_arm64.whl
+  name: pillow
+  version: 12.3.0
+  sha256: ffd0c5368496f41b0944be820fcb7a838aa6e623d250b01acf2643939c3f99d7
+  requires_dist:
+  - furo ; extra == 'docs'
+  - olefile ; extra == 'docs'
+  - sphinx>=8.2 ; extra == 'docs'
+  - sphinx-autobuild ; extra == 'docs'
+  - sphinx-copybutton ; extra == 'docs'
+  - sphinx-inline-tabs ; extra == 'docs'
+  - sphinxext-opengraph ; extra == 'docs'
+  - olefile ; extra == 'fpx'
+  - olefile ; extra == 'mic'
+  - arro3-compute ; extra == 'test-arrow'
+  - arro3-core ; extra == 'test-arrow'
+  - nanoarrow ; extra == 'test-arrow'
+  - pyarrow ; extra == 'test-arrow'
+  - coverage>=7.4.2 ; extra == 'tests'
+  - defusedxml ; extra == 'tests'
+  - markdown2 ; extra == 'tests'
+  - olefile ; extra == 'tests'
+  - packaging ; extra == 'tests'
+  - pytest ; extra == 'tests'
+  - pytest-cov ; extra == 'tests'
+  - pytest-timeout ; extra == 'tests'
+  - pytest-xdist ; extra == 'tests'
+  - setuptools ; extra == 'tests'
+  - trove-classifiers>=2024.10.12 ; extra == 'tests'
+  - defusedxml ; extra == 'xmp'
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/d9/33/1f075bf72b0b747cb3288d011319aaf64083cf2efef8354174e3ed4540e2/ipython_pygments_lexers-1.1.1-py3-none-any.whl
+  name: ipython-pygments-lexers
+  version: 1.1.1
+  sha256: a9462224a505ade19a605f71f8fa63c2048833ce50abc86768a0d81d876dc81c
+  requires_dist:
+  - pygments
+  requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/d9/79/615cc094e2fb508cade7de88d3b4f6c4ec2bab695c97bce9153dc65aadf5/cffi-2.1.1-cp312-cp312-win_amd64.whl
+  name: cffi
+  version: 2.1.1
+  sha256: f53e442b08449d42821fa4a4fba000095af9f62742a500f978a9f557ec44339a
+  requires_dist:
+  - pycparser ; implementation_name != 'PyPy'
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/df/64/ff35eb9e54894cf471ff4716abd3c81eb0a0626869217ce3e6ba4ccf17d7/scipy-1.18.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+  name: scipy
+  version: 1.18.1
+  sha256: f55fa87b6c612ecd6b058f167c53231b1d14e412efe361d3d6e38b3631c73218
+  requires_dist:
+  - numpy>=2.0.0,<2.8
+  - pytest>=8.0.0 ; extra == 'test'
+  - pytest-cov ; extra == 'test'
+  - pytest-timeout ; extra == 'test'
+  - pytest-xdist ; extra == 'test'
+  - asv ; extra == 'test'
+  - mpmath ; extra == 'test'
+  - gmpy2 ; extra == 'test'
+  - threadpoolctl ; extra == 'test'
+  - scikit-umfpack ; extra == 'test'
+  - pooch ; extra == 'test'
+  - hypothesis>=6.30 ; extra == 'test'
+  - array-api-strict>=2.3.1 ; extra == 'test'
+  - cython ; extra == 'test'
+  - meson ; extra == 'test'
+  - ninja ; sys_platform != 'emscripten' and extra == 'test'
+  - scipy-doctest>=2.0.0 ; extra == 'test'
+  - sphinx>=5.0.0,<8.2.0 ; extra == 'doc'
+  - intersphinx-registry ; extra == 'doc'
+  - pydata-sphinx-theme>=0.15.2 ; extra == 'doc'
+  - sphinx-copybutton ; extra == 'doc'
+  - sphinx-design>=0.4.0 ; extra == 'doc'
+  - matplotlib>=3.5 ; extra == 'doc'
+  - numpydoc ; extra == 'doc'
+  - jupytext ; extra == 'doc'
+  - myst-nb>=1.2.0 ; extra == 'doc'
+  - pooch ; extra == 'doc'
+  - jupyterlite-sphinx>=0.19.1 ; extra == 'doc'
+  - jupyterlite-pyodide-kernel ; extra == 'doc'
+  - linkify-it-py ; extra == 'doc'
+  - tabulate ; extra == 'doc'
+  - click<8.3.0 ; extra == 'dev'
+  - spin ; extra == 'dev'
+  - mypy==1.19.1 ; extra == 'dev'
+  - pyrefly==0.63.0 ; extra == 'dev'
+  - typing-extensions ; extra == 'dev'
+  - types-psutil ; extra == 'dev'
+  - pycodestyle ; extra == 'dev'
+  - ruff>=0.12.0 ; extra == 'dev'
+  - cython-lint>=0.12.2 ; extra == 'dev'
+  requires_python: '>=3.12'
+- pypi: https://files.pythonhosted.org/packages/e5/6d/b53b99a9f2766d095985947a5782f1702cabb129a34f7a802d7197af832f/tzdata-2026.3-py2.py3-none-any.whl
+  name: tzdata
+  version: '2026.3'
+  sha256: dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931
+  requires_python: '>=2'
+- pypi: https://files.pythonhosted.org/packages/e6/0f/5f8f31ef2fb8f3e82f07fd0567a4b0c9ab8c863a1c47aacb7eded43d607f/multimark-0.3.2-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  name: multimark
+  version: 0.3.2
+  sha256: 8a5f712d27bc376f1b56a7e124253f32ba723129dd710b14036314038a8967dc
+  requires_dist:
+  - cffi>=1.15
+  - click>=8.0
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
+  name: cycler
+  version: 0.12.1
+  sha256: 85cef7cff222d8644161529808465972e51340599459b8ac3ccbac5a854e0d30
+  requires_dist:
+  - ipython ; extra == 'docs'
+  - matplotlib ; extra == 'docs'
+  - numpydoc ; extra == 'docs'
+  - sphinx ; extra == 'docs'
+  - pytest ; extra == 'tests'
+  - pytest-cov ; extra == 'tests'
+  - pytest-xdist ; extra == 'tests'
+  requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/e9/27/cbb72acb991867ff61394895ca1652dcd4c4a0ec14f4f8fb0ac8a3f5a0b3/pyfixest-0.60.0-cp312-cp312-win_amd64.whl
+  name: pyfixest
+  version: 0.60.0
+  sha256: ad2498711231f0d1457ae14351c68f7cd87dfb5f4da63737ad945a9ab03c1efd
+  requires_dist:
+  - formulaic>=1.1.0
+  - joblib>=1.4.2
+  - maketables>=0.1.0
+  - narwhals>=1.13.3
+  - numpy>=1.25.2
+  - pandas>=1.1.0
+  - scipy>=1.6
+  - seaborn>=0.13.2
+  - tabulate>=0.9.0
+  - tqdm>=4.0.0
+  - linearmodels ; extra == 'benchmarks'
+  - pyarrow ; extra == 'benchmarks'
+  - statsmodels ; extra == 'benchmarks'
+  - jax>=0.4.15 ; extra == 'jax'
+  - numba>=0.58.0 ; extra == 'numba'
+  - lets-plot>=4.0.0 ; extra == 'plots'
+  - torch>=2.0 ; extra == 'torch'
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/eb/dc/55481808fd70ef1567cf13540ffd4702af3f74b112e35427564b03f79c2d/narwhals-2.25.0-py3-none-any.whl
+  name: narwhals
+  version: 2.25.0
+  sha256: 1f0f403e8c7e4463cde9bfe78b12fdd809e3ae3dda6d9b2f802934fb9c7a6a8f
+  requires_dist:
+  - cudf-cu12>=24.10.0 ; sys_platform == 'linux' and extra == 'cudf'
+  - dask[dataframe]>=2024.8 ; extra == 'dask'
+  - duckdb>=1.1 ; extra == 'duckdb'
+  - ibis-framework>=6.0.0 ; extra == 'ibis'
+  - packaging>=21.3 ; extra == 'ibis'
+  - pyarrow-hotfix>=0.7 ; extra == 'ibis'
+  - modin>=0.22.0 ; extra == 'modin'
+  - pandas>=1.3.4 ; extra == 'pandas'
+  - polars>=0.20.4 ; extra == 'polars'
+  - pyarrow>=13.0.0 ; extra == 'pyarrow'
+  - pyspark>=3.5.0 ; extra == 'pyspark'
+  - pyspark[connect]>=3.5.0 ; extra == 'pyspark-connect'
+  - narwhals[duckdb] ; extra == 'sql'
+  - sqlparse>=0.5.5 ; extra == 'sql'
+  - sqlframe>=3.22.0,!=3.39.3 ; extra == 'sqlframe'
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/eb/f8/6d0c312c8d9738e7d9677f09fe5c986b3239e651a7b73a2deb38b65e4a71/matplotlib-3.11.1-cp312-cp312-macosx_11_0_arm64.whl
+  name: matplotlib
+  version: 3.11.1
+  sha256: 21a67b961a6d597bca54fae826cd20695ba4a6e4d05424a08da6e13e3176fd6b
+  requires_dist:
+  - contourpy>=1.0.1
+  - cycler>=0.10
+  - fonttools>=4.28.2
+  - kiwisolver>=1.3.1
+  - numpy>=1.25
+  - packaging>=20.0
+  - pillow>=9
+  - pyparsing>=3
+  - python-dateutil>=2.7
+  requires_python: '>=3.11'
+- pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
+  name: python-dateutil
+  version: 2.9.0.post0
+  sha256: a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427
+  requires_dist:
+  - six>=1.5
+  requires_python: '>=2.7,!=3.0.*,!=3.1.*,!=3.2.*'
+- pypi: https://files.pythonhosted.org/packages/ee/a4/55eb54507073089ab27743c5da2113c84f0d0b1715b33175fdd943c9652d/lxml-6.1.2-cp312-cp312-macosx_10_13_universal2.whl
+  name: lxml
+  version: 6.1.2
+  sha256: 7d506bdba580ecb1a6ad2e2b5c49445e66d3e1f95894885739094393a1aad237
+  requires_dist:
+  - cssselect>=0.7 ; extra == 'cssselect'
+  - html5lib ; extra == 'html5'
+  - beautifulsoup4 ; extra == 'htmlsoup'
+  - lxml-html-clean ; extra == 'html-clean'
+  requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl
+  name: stack-data
+  version: 0.6.3
+  sha256: d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695
+  requires_dist:
+  - executing>=1.2.0
+  - asttokens>=2.1.0
+  - pure-eval
+  - pytest ; extra == 'tests'
+  - typeguard ; extra == 'tests'
+  - pygments ; extra == 'tests'
+  - littleutils ; extra == 'tests'
+  - cython ; extra == 'tests'
+- pypi: https://files.pythonhosted.org/packages/f8/fd/b20e3cb3cab35131b515edf18e8cd777dff680fc76fc00919481f4e536af/wrapt-2.4.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
+  name: wrapt
+  version: 2.4.0
+  sha256: d7dbbdbfdacb85c2d962fa52db791c77943fd777d600d74c95af2d53b32f5a94
+  requires_dist:
+  - pytest ; extra == 'dev'
+  - setuptools ; extra == 'dev'
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/f9/1c/01bfd571a64e7f270e6bab5e33777debe0edc56759233ce84f27dec92d14/tqdm-4.70.0-py3-none-any.whl
+  name: tqdm
+  version: 4.70.0
+  sha256: 7f585706bfddbdebf89daac705b2dfcc16890130727d3197ca62c732b4310953
+  requires_dist:
+  - colorama ; sys_platform == 'win32'
+  - requests ; extra == 'discord'
+  - envwrap ; extra == 'discord'
+  - slack-sdk ; extra == 'slack'
+  - envwrap ; extra == 'slack'
+  - requests ; extra == 'telegram'
+  - envwrap ; extra == 'telegram'
+  - ipywidgets>=6 ; extra == 'notebook'
+  requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/fb/05/9f82d090c8d2d861604147ef6dfb938a90b039f9358d5193f1df62558593/websockets-17.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
+  name: websockets
+  version: '17.1'
+  sha256: 0c863507ada5805517ca6dff1c524dcd42942efe6304dacf06700878398d21a6
+  requires_python: '>=3.11'
+- pypi: https://files.pythonhosted.org/packages/fc/75/0576b03f7889ad25b5385b4f6c69e0543713425a6f193b056c9b0a2e65ce/formulaic-1.2.2-py3-none-any.whl
+  name: formulaic
+  version: 1.2.2
+  sha256: 0f84ff49e3fc9dc0e68ab08a0a9427874021aa6c558e66b44dc634a35739b09b
+  requires_dist:
+  - interface-meta>=1.2.0
+  - narwhals>=1.17
+  - numpy>=1.20.0
+  - pandas>=1.3
+  - scipy>=1.6
+  - typing-extensions>=4.2.0
+  - wrapt>=1.0 ; python_full_version < '3.13'
+  - wrapt>=1.17.0rc1 ; python_full_version >= '3.13'
+  - pyarrow>=1 ; extra == 'arrow'
+  - sympy>=1.3,!=1.10 ; extra == 'calculus'
+  - polars>=1 ; extra == 'polars'
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/fc/f4/dadfec469313c7f428efa7e84b4aba9732f813c13ea7131a24b7b008ef57/kiwisolver-1.5.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+  name: kiwisolver
+  version: 1.5.1
+  sha256: 34633ecf50d16187ab8e5528b7a2530f2feb4e23f300db4672538b51cfc5cd38
+  requires_python: '>=3.10'

--- a/tests/snapshots/release/pixi.toml
+++ b/tests/snapshots/release/pixi.toml
@@ -1,0 +1,25 @@
+[workspace]
+name = "pyfixest-release-snapshots"
+channels = ["conda-forge"]
+platforms = ["linux-64", "win-64", "osx-arm64"]
+
+[dependencies]
+python = "~=3.12.0"
+
+[pypi-dependencies]
+pyfixest = "==0.60.0"
+
+[activation.env]
+PYTHONHASHSEED = "0"
+MPLCONFIGDIR = "$PIXI_PROJECT_ROOT/.pixi/matplotlib"
+RAYON_NUM_THREADS = "1"
+OMP_NUM_THREADS = "1"
+OPENBLAS_NUM_THREADS = "1"
+MKL_NUM_THREADS = "1"
+VECLIB_MAXIMUM_THREADS = "1"
+NUMEXPR_NUM_THREADS = "1"
+
+[tasks]
+prepare = { cmd = "python -P scripts/generate_estimation_snapshots.py", cwd = "../../..", description = "Prepare this platform's cached pyfixest 0.60.0 release contract" }
+regenerate = { cmd = "python -P scripts/generate_estimation_snapshots.py --force", cwd = "../../..", description = "Replace this platform's cached release contract" }
+provenance = { cmd = "python -P -c \"import pyfixest; print(pyfixest.__version__); print(pyfixest.__file__)\"", cwd = "../../..", description = "Print the isolated release interpreter provenance" }

--- a/tests/test_estimation_snapshots.py
+++ b/tests/test_estimation_snapshots.py
@@ -1,0 +1,223 @@
+"""Python-only numerical regression checks against the released pyfixest contract."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from _estimation_snapshot_cache import (
+    COMPLETE_MARKER,
+    snapshot_dir,
+    snapshot_fingerprint,
+)
+from _estimation_snapshot_contract import (
+    TOLERANCES,
+    build_cases,
+    extract_snapshot,
+    fast_case_ids,
+    fit_case,
+    load_json,
+)
+
+
+def _expected_cases(cache_dir: Path) -> dict[str, dict[str, object]]:
+    expected: dict[str, dict[str, object]] = {}
+    for filename in sorted(cache_dir.glob("*.json")):
+        if filename.name == "manifest.json":
+            continue
+        expected.update(load_json(filename)["cases"])
+    return expected
+
+
+CASES = build_cases()
+FAST_CASE_IDS = fast_case_ids(CASES)
+LOGIT_VCOV_DELTA_CASE_IDS = frozenset(
+    {
+        "feglm-001-family=logit-vcov=hetero",
+        "feglm-002-family=logit-vcov=crv1",
+    }
+)
+PROBIT_IID_DELTA_CASE_ID = "feglm-003-family=probit-vcov=iid"
+PARAMS = [
+    pytest.param(
+        case,
+        marks=pytest.mark.snapshot_fast if case["id"] in FAST_CASE_IDS else (),
+        id=case["id"],
+    )
+    for case in CASES
+]
+
+
+@pytest.fixture(scope="session")
+def release_contract() -> tuple[dict[str, Any], dict[str, dict[str, object]]]:
+    """Load the complete platform-local release baseline."""
+    cache_dir = snapshot_dir()
+    if not (cache_dir / COMPLETE_MARKER).exists():
+        pytest.fail(
+            "Release snapshot cache is missing. Run "
+            "`pixi run -e py312 test-estimation-snapshots` to prepare it."
+        )
+    return load_json(cache_dir / "manifest.json"), _expected_cases(cache_dir)
+
+
+def _assert_named_close(
+    actual, expected, *, tolerance: tuple[float, float], quantity: str
+) -> None:
+    assert set(actual) == set(expected), f"{quantity} names differ"
+    names = sorted(expected)
+    nonfinite_names = [name for name in names if expected[name] is None]
+    assert all(actual[name] is None for name in nonfinite_names), (
+        f"{quantity} non-finite positions differ"
+    )
+    finite_names = [name for name in names if expected[name] is not None]
+    np.testing.assert_allclose(
+        [actual[name] for name in finite_names],
+        [expected[name] for name in finite_names],
+        rtol=tolerance[0],
+        atol=tolerance[1],
+        err_msg=f"{quantity} differs from the pyfixest release contract",
+    )
+
+
+def _assert_sequence_close(
+    actual, expected, *, tolerance: tuple[float, float], quantity: str
+) -> None:
+    assert len(actual) == len(expected), f"{quantity} length differs"
+    assert [value is None for value in actual] == [
+        value is None for value in expected
+    ], f"{quantity} non-finite positions differ"
+    finite_pairs = [
+        (value, reference)
+        for value, reference in zip(actual, expected, strict=True)
+        if reference is not None
+    ]
+    np.testing.assert_allclose(
+        [value for value, _ in finite_pairs],
+        [reference for _, reference in finite_pairs],
+        rtol=tolerance[0],
+        atol=tolerance[1],
+        err_msg=f"{quantity} differs from the pyfixest release contract",
+    )
+
+
+def _assert_snapshot(
+    actual: dict[str, object], expected: dict[str, object], case: dict[str, object]
+) -> None:
+    estimator = str(case["estimator"])
+    tolerances = TOLERANCES[estimator]
+    _assert_named_close(
+        actual["coef"],
+        expected["coef"],
+        tolerance=tolerances["coef"],
+        quantity="coefficients",
+    )
+    # Keep documented release deltas tied to the exact measured cases. New
+    # FEGLM formulas, weights, or vcov variants must not inherit an omission.
+    changed_logit_vcov = str(case["id"]) in LOGIT_VCOV_DELTA_CASE_IDS
+    changed_probit_iid = str(case["id"]) == PROBIT_IID_DELTA_CASE_ID
+    # The documented GLM API/behavior change introduces new logit/probit IRLS
+    # starts (docs/changelog.qmd, "GLM API and Behavior"). Only the narrow
+    # comparisons below materially exceed normal tolerance; canonical live-R
+    # remains their authoritative correctness evidence.
+    if not changed_logit_vcov:
+        for row_name, expected_row in expected["vcov"].items():
+            _assert_named_close(
+                actual["vcov"][row_name],
+                expected_row,
+                tolerance=tolerances["vcov"],
+                quantity=f"vcov row {row_name}",
+            )
+    for quantity in ("se", "tstat"):
+        if not changed_logit_vcov and not changed_probit_iid:
+            _assert_named_close(
+                actual[quantity],
+                expected[quantity],
+                tolerance=tolerances.get(quantity, tolerances["inference"]),
+                quantity=quantity,
+            )
+    pvalue_actual = dict(actual["pvalue"])
+    pvalue_expected = dict(expected["pvalue"])
+    if changed_logit_vcov:
+        # Only the X2 p-value moves beyond tolerance in logit hetero/CRV1.
+        pvalue_actual.pop("X2")
+        pvalue_expected.pop("X2")
+    _assert_named_close(
+        pvalue_actual,
+        pvalue_expected,
+        tolerance=tolerances.get("pvalue", tolerances["inference"]),
+        quantity="pvalue",
+    )
+    if estimator != "quantreg" and not changed_logit_vcov:
+        for name, expected_interval in expected["confint"].items():
+            actual_interval = dict(actual["confint"][name])
+            expected_interval = dict(expected_interval)
+            if changed_probit_iid and name == "X2":
+                # Only the upper X2 interval bound exceeds normal tolerance.
+                actual_interval.pop("97.5%")
+                expected_interval.pop("97.5%")
+            _assert_named_close(
+                actual_interval,
+                expected_interval,
+                tolerance=tolerances.get("confint", tolerances["inference"]),
+                quantity=f"confint {name}",
+            )
+    # The documented inference-type/confint overhaul in docs/changelog.qmd now
+    # uses Quantreg's t reference distribution. Release 0.60.0 used a normal
+    # critical value despite Quantreg's t-based p-values, so only this derived
+    # interval comparison is intentionally omitted.
+    actual_metadata = dict(actual["metadata"])
+    expected_metadata = dict(expected["metadata"])
+    actual_deviance = actual_metadata.pop("deviance", None)
+    expected_deviance = expected_metadata.pop("deviance", None)
+    assert actual_metadata == expected_metadata, "structural metadata differs"
+    if expected_deviance is not None:
+        np.testing.assert_allclose(
+            actual_deviance,
+            expected_deviance,
+            rtol=tolerances["metrics"][0],
+            atol=tolerances["metrics"][1],
+            err_msg="deviance differs from the pyfixest release contract",
+        )
+    for quantity in ("resid_sample", "predict_sample"):
+        if estimator == "feglm" and quantity == "resid_sample":
+            # Current GLMs return explicit response residuals after the
+            # documented GLM API/behavior rewrite (docs/changelog.qmd, "GLM
+            # API and Behavior"); 0.60.0 exposed working residuals instead.
+            # Keep prediction checks; the canonical live-R suite validates residuals.
+            continue
+        _assert_sequence_close(
+            actual[quantity],
+            expected[quantity],
+            tolerance=tolerances["samples"],
+            quantity=quantity,
+        )
+
+
+@pytest.mark.snapshot_fast
+def test_estimation_snapshot_inventory(release_contract) -> None:
+    """Reject stale, missing, or inconsistently tiered cached artifacts."""
+    manifest, expected_cases = release_contract
+    fingerprint = snapshot_fingerprint()
+    case_ids = {case["id"] for case in CASES}
+    manifest_ids = {case["id"] for case in manifest["cases"]}
+    artifact_ids = set(expected_cases)
+    assert case_ids == manifest_ids == artifact_ids
+    assert set(manifest["fast_case_ids"]) == FAST_CASE_IDS
+    assert case_ids >= FAST_CASE_IDS
+    assert manifest["fingerprint"] == fingerprint
+    assert (snapshot_dir() / COMPLETE_MARKER).read_text().strip() == fingerprint
+
+
+@pytest.mark.parametrize("case", PARAMS)
+def test_estimation_release_contract(case, release_contract):
+    """Match the platform-local public-fit contract from pyfixest 0.60.0."""
+    _, expected_cases = release_contract
+    expected = expected_cases[case["id"]]
+    actual = extract_snapshot(fit_case(case))
+    _assert_snapshot(actual, expected, case)

--- a/tests/test_estimator_state_lifecycle.py
+++ b/tests/test_estimator_state_lifecycle.py
@@ -1,0 +1,310 @@
+"""Characterize private estimator state before the immutable-state refactor.
+
+These tests intentionally inspect implementation details. Public numerical
+behavior belongs to the release snapshots and live-R suites; this module locks
+the representation, scale, cache, and cleanup seams that those suites cannot
+observe. Refactors should replace these assertions with equivalent assertions
+about the new explicit state objects.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import pyfixest as pf
+from pyfixest.estimation.FixestMulti_ import FixestMulti
+from pyfixest.estimation.models.feols_ import Feols
+
+
+@pytest.fixture
+def lifecycle_data() -> pd.DataFrame:
+    """Return a small full-rank weighted FE/IV data set."""
+    rng = np.random.default_rng(20260831)
+    n_obs = 24
+    fixed_effect = np.repeat(["a", "b", "c", "d"], n_obs // 4)
+    group_effect = pd.Series(fixed_effect).map(
+        {"a": -1.0, "b": 0.5, "c": 1.25, "d": -0.25}
+    )
+    instrument = rng.normal(size=n_obs)
+    covariate = rng.normal(size=n_obs)
+    second_covariate = rng.normal(size=n_obs)
+    endogenous = 0.8 * instrument + 0.4 * covariate + rng.normal(size=n_obs)
+    response = (
+        1.2 * covariate
+        - 0.6 * second_covariate
+        + 1.5 * endogenous
+        + group_effect.to_numpy()
+        + rng.normal(scale=0.3, size=n_obs)
+    )
+
+    return pd.DataFrame(
+        {
+            "y": response,
+            "x": covariate,
+            "x2": second_covariate,
+            "endog": endogenous,
+            "z": instrument,
+            "fe": fixed_effect,
+            "weight": np.tile([1, 2, 4, 3, 1, 2], 4),
+        }
+    )
+
+
+def _clone_state(value: Any) -> Any:
+    if isinstance(value, (pd.DataFrame, pd.Series, np.ndarray)):
+        return value.copy()
+    return value
+
+
+def _capture_after(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    method_name: str,
+    state_name: str,
+    attributes: tuple[str, ...],
+    states: dict[str, dict[str, Any]],
+) -> None:
+    """Capture selected Feols attributes after one lifecycle method."""
+    original: Callable[..., Any] = getattr(Feols, method_name)
+
+    def wrapped(self: Feols, *args: Any, **kwargs: Any) -> Any:
+        result = original(self, *args, **kwargs)
+        states[state_name] = {
+            attribute: _clone_state(getattr(self, attribute))
+            for attribute in attributes
+        }
+        return result
+
+    monkeypatch.setattr(Feols, method_name, wrapped)
+
+
+@pytest.mark.parametrize(
+    ("weights_type", "expected_n"),
+    [("aweights", 24), ("fweights", 52)],
+)
+def test_feols_fields_change_type_and_scale_during_fit(
+    monkeypatch: pytest.MonkeyPatch,
+    lifecycle_data: pd.DataFrame,
+    weights_type: str,
+    expected_n: int,
+) -> None:
+    """Record the DataFrame -> within array -> solver array mutation."""
+    states: dict[str, dict[str, Any]] = {}
+    _capture_after(
+        monkeypatch,
+        method_name="prepare_model_matrix",
+        state_name="formula",
+        attributes=("_Y", "_X", "_weights"),
+        states=states,
+    )
+    _capture_after(
+        monkeypatch,
+        method_name="demean",
+        state_name="within_frame",
+        attributes=("_Y", "_X", "_Yd", "_Xd"),
+        states=states,
+    )
+    _capture_after(
+        monkeypatch,
+        method_name="to_array",
+        state_name="within_array",
+        attributes=("_Y", "_X"),
+        states=states,
+    )
+    _capture_after(
+        monkeypatch,
+        method_name="wls_transform",
+        state_name="solver",
+        attributes=("_Y", "_X"),
+        states=states,
+    )
+
+    fit = pf.feols(
+        "y ~ x | fe",
+        data=lifecycle_data,
+        weights="weight",
+        weights_type=weights_type,
+        vcov="iid",
+    )
+
+    assert isinstance(states["formula"]["_Y"], pd.DataFrame)
+    assert isinstance(states["formula"]["_X"], pd.DataFrame)
+    assert isinstance(states["within_frame"]["_Yd"], pd.DataFrame)
+    assert isinstance(states["within_frame"]["_Xd"], pd.DataFrame)
+    assert isinstance(states["within_array"]["_Y"], np.ndarray)
+    assert isinstance(states["within_array"]["_X"], np.ndarray)
+    assert isinstance(states["solver"]["_Y"], np.ndarray)
+    assert isinstance(states["solver"]["_X"], np.ndarray)
+
+    np.testing.assert_allclose(
+        states["within_array"]["_Y"], states["within_frame"]["_Yd"].to_numpy()
+    )
+    np.testing.assert_allclose(
+        states["within_array"]["_X"], states["within_frame"]["_Xd"].to_numpy()
+    )
+
+    sqrt_weight = np.sqrt(states["formula"]["_weights"])
+    np.testing.assert_allclose(
+        states["solver"]["_Y"], states["within_array"]["_Y"] * sqrt_weight
+    )
+    np.testing.assert_allclose(
+        states["solver"]["_X"], states["within_array"]["_X"] * sqrt_weight
+    )
+
+    weighted_group_mean = (lifecycle_data["y"] * lifecycle_data["weight"]).groupby(
+        lifecycle_data["fe"]
+    ).transform("sum") / lifecycle_data["weight"].groupby(
+        lifecycle_data["fe"]
+    ).transform("sum")
+    expected_y_within = lifecycle_data["y"] - weighted_group_mean
+    np.testing.assert_allclose(
+        states["within_frame"]["_Yd"].to_numpy().flatten(), expected_y_within
+    )
+
+    np.testing.assert_allclose(
+        fit._u_hat.flatten(), fit.resid() * np.sqrt(fit._weights.flatten())
+    )
+    assert expected_n == fit._N
+
+
+def test_weighted_iv_fields_end_on_solver_scale(
+    lifecycle_data: pd.DataFrame,
+) -> None:
+    """Characterize the retained Y/X/Z domains of a weighted FE-IV fit."""
+    fit = pf.feols(
+        "y ~ x + [endog ~ z] | fe",
+        data=lifecycle_data,
+        weights="weight",
+        weights_type="aweights",
+        vcov="iid",
+    )
+
+    assert isinstance(fit._Yd, pd.DataFrame)
+    assert isinstance(fit._Xd, pd.DataFrame)
+    assert isinstance(fit._Zd, pd.DataFrame)
+    assert isinstance(fit._Y, np.ndarray)
+    assert isinstance(fit._X, np.ndarray)
+    assert isinstance(fit._Z, np.ndarray)
+
+    sqrt_weight = np.sqrt(fit._weights)
+    np.testing.assert_allclose(fit._Y, fit._Yd.to_numpy() * sqrt_weight)
+    np.testing.assert_allclose(fit._X, fit._Xd.to_numpy() * sqrt_weight)
+    np.testing.assert_allclose(fit._Z, fit._Zd.to_numpy() * sqrt_weight)
+    np.testing.assert_allclose(
+        fit._u_hat.flatten(), fit.resid() * sqrt_weight.flatten()
+    )
+
+
+def test_multiple_estimation_shares_dataframe_demean_cache(
+    lifecycle_data: pd.DataFrame,
+) -> None:
+    """Record the shared mutable DataFrame cache used by FixestMulti."""
+    fit = pf.feols(
+        "y ~ sw(x, x2) | fe",
+        data=lifecycle_data,
+        weights="weight",
+        vcov="iid",
+    )
+
+    assert isinstance(fit, FixestMulti)
+    models = list(fit.all_fitted_models.values())
+    assert len(models) == 2
+
+    demeaned_caches = [model._demean_cache.lookup_demeaned_data for model in models]
+    preconditioner_caches = [
+        model._demean_cache.lookup_preconditioner for model in models
+    ]
+    assert demeaned_caches[0] is demeaned_caches[1]
+    assert preconditioner_caches[0] is preconditioner_caches[1]
+    assert demeaned_caches[0]
+    assert all(isinstance(value, pd.DataFrame) for value in demeaned_caches[0].values())
+    assert all(isinstance(model._Yd, pd.DataFrame) for model in models)
+    assert all(isinstance(model._Xd, pd.DataFrame) for model in models)
+    assert all(isinstance(model._Y, np.ndarray) for model in models)
+    assert all(isinstance(model._X, np.ndarray) for model in models)
+
+
+@pytest.mark.parametrize(
+    ("fit_kwargs", "missing_fields"),
+    [
+        ({}, frozenset()),
+        ({"store_data": False}, frozenset({"_data"})),
+        (
+            {"lean": True},
+            frozenset(
+                {
+                    "_data",
+                    "_X",
+                    "_Y",
+                    "_Z",
+                    "_Xd",
+                    "_Yd",
+                    "_weights",
+                    "_scores",
+                    "_u_hat",
+                }
+            ),
+        ),
+    ],
+)
+def test_storage_options_delete_expected_state(
+    lifecycle_data: pd.DataFrame,
+    fit_kwargs: dict[str, bool],
+    missing_fields: frozenset[str],
+) -> None:
+    """Distinguish data-only cleanup from lean fit-state cleanup."""
+    state_fields = frozenset(
+        {
+            "_data",
+            "_X",
+            "_Y",
+            "_Z",
+            "_Xd",
+            "_Yd",
+            "_weights",
+            "_scores",
+            "_u_hat",
+        }
+    )
+    fit = pf.feols("y ~ x | fe", data=lifecycle_data, vcov="iid", **fit_kwargs)
+
+    observed_fields = frozenset(field for field in state_fields if hasattr(fit, field))
+    assert observed_fields == state_fields - missing_fields
+    assert np.isfinite(fit.coef()).all()
+
+
+def test_feglm_overwrites_observation_weights_with_working_weights() -> None:
+    """Record the current observation/IRLS weight field collision."""
+    rng = np.random.default_rng(8675309)
+    n_obs = 160
+    covariate = rng.normal(size=n_obs)
+    probability = 1 / (1 + np.exp(-(-0.2 + 0.8 * covariate)))
+    data = pd.DataFrame(
+        {
+            "y": rng.binomial(1, probability),
+            "x": covariate,
+            "observation_weight": np.linspace(0.5, 2.0, n_obs),
+        }
+    )
+
+    fit = pf.feglm(
+        "y ~ x",
+        data=data,
+        family="logit",
+        weights="observation_weight",
+        vcov="iid",
+        iwls_tol=1e-10,
+    )
+
+    observation_weights = fit._weights_df.to_numpy()
+    assert isinstance(fit._Y_untransformed, pd.DataFrame)
+    assert isinstance(fit._X, np.ndarray)
+    assert isinstance(fit._Y, np.ndarray)
+    np.testing.assert_allclose(fit._weights.flatten(), fit._irls_weights.flatten())
+    assert not np.allclose(fit._weights.flatten(), observation_weights.flatten())
+    np.testing.assert_allclose(fit._scores, fit._u_hat[:, None] * fit._X)


### PR DESCRIPTION
## Summary

Documents the pre-refactor estimator-state lifecycle so later stack layers have a precise review baseline. It traces formula-materialized DataFrames through weighted fixed-effect projection, NumPy conversion, collinearity removal, square-root-weighted solver arrays, and GLM working state. It also defines consistent names for the formula, observation-weight, within, solver, working, and response-residual domains.

Focused characterization tests pin the existing types, numerical scales, cache reuse, cleanup, and public residual behavior. This layer changes no production behavior; it intentionally preserves the mutable implementation it describes.

## Stack

Layer 1 of 3. Base: `test/release-contract-snapshots`. Next: [#1492](https://github.com/py-econometrics/pyfixest/pull/1492).

## Verification

- `pixi run -e py312-r pytest tests/test_estimator_state_lifecycle.py -x -q --no-cov`: 8 passed on this exact head.
- `pixi run -e lint prek run ruff-check --files tests/test_estimator_state_lifecycle.py`: passed on this exact head.
