### PR TITLE
refactor(estimation): define immutable lifecycle state

### DIFF
--- a/benchmarks/weight_domain_benchmark.py
+++ b/benchmarks/weight_domain_benchmark.py
@@ -1,0 +1,675 @@
+#!/usr/bin/env python3
+"""Benchmark retained estimator state and temporary weight-domain work.
+
+The default ``smoke`` profile is intentionally modest. Use ``--profile large``
+for the review gate described in the estimator-state refactor. The harness
+times public workflows, measures incremental allocations with ``tracemalloc``,
+and counts unique NumPy buffers retained directly by the fitted result and its
+dataclass state.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import json
+import platform
+import subprocess
+import sys
+import time
+import tracemalloc
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import asdict, dataclass, fields, is_dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from statistics import median
+from typing import Any, Literal
+
+import numpy as np
+import pandas as pd
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_VERSION = 1
+
+Estimator = Literal["ols", "iv", "poisson"]
+Operation = Literal["fit", "vcov"]
+Tier = Literal["common", "inference"]
+
+
+@dataclass(frozen=True, slots=True)
+class BenchmarkScenario:
+    """One deterministic public estimation or inference workflow."""
+
+    name: str
+    estimator: Estimator
+    operation: Operation
+    tier: Tier
+    nobs: int
+    n_covariates: int
+    weighted: bool
+    fixed_effects: bool
+    vcov: str | dict[str, str] = "iid"
+    repeated_vcov_calls: int = 1
+
+
+@dataclass(frozen=True, slots=True)
+class Measurement:
+    """One measured workflow execution."""
+
+    wall_time_seconds: float
+    traced_peak_bytes: int
+    retained_ndarray_bytes: int
+
+
+def _profile_sizes(profile: str) -> dict[str, tuple[int, int]]:
+    """Return deterministic ``(nobs, n_covariates)`` sizes for a profile."""
+    if profile == "smoke":
+        return {
+            "narrow": (10_000, 5),
+            "wide": (5_000, 20),
+            "iv": (10_000, 3),
+            "poisson": (5_000, 3),
+            "inference": (10_000, 5),
+        }
+    if profile == "large":
+        return {
+            "narrow": (1_000_000, 10),
+            "wide": (100_000, 100),
+            "iv": (250_000, 8),
+            "poisson": (100_000, 5),
+            "inference": (250_000, 10),
+        }
+    raise ValueError(f"Unknown benchmark profile: {profile!r}")
+
+
+def build_scenarios(profile: str) -> tuple[BenchmarkScenario, ...]:
+    """Build the fixed scenario matrix for ``profile``."""
+    sizes = _profile_sizes(profile)
+    narrow_n, narrow_k = sizes["narrow"]
+    wide_n, wide_k = sizes["wide"]
+    iv_n, iv_k = sizes["iv"]
+    poisson_n, poisson_k = sizes["poisson"]
+    inference_n, inference_k = sizes["inference"]
+
+    scenarios = [
+        BenchmarkScenario(
+            name="ols-unweighted-narrow",
+            estimator="ols",
+            operation="fit",
+            tier="common",
+            nobs=narrow_n,
+            n_covariates=narrow_k,
+            weighted=False,
+            fixed_effects=False,
+        ),
+        BenchmarkScenario(
+            name="ols-aweights-narrow",
+            estimator="ols",
+            operation="fit",
+            tier="common",
+            nobs=narrow_n,
+            n_covariates=narrow_k,
+            weighted=True,
+            fixed_effects=False,
+        ),
+        BenchmarkScenario(
+            name="ols-aweights-fe-narrow",
+            estimator="ols",
+            operation="fit",
+            tier="common",
+            nobs=narrow_n,
+            n_covariates=narrow_k,
+            weighted=True,
+            fixed_effects=True,
+        ),
+        BenchmarkScenario(
+            name="ols-aweights-wide",
+            estimator="ols",
+            operation="fit",
+            tier="common",
+            nobs=wide_n,
+            n_covariates=wide_k,
+            weighted=True,
+            fixed_effects=False,
+        ),
+        BenchmarkScenario(
+            name="iv-aweights-narrow",
+            estimator="iv",
+            operation="fit",
+            tier="common",
+            nobs=iv_n,
+            n_covariates=iv_k,
+            weighted=True,
+            fixed_effects=False,
+        ),
+        BenchmarkScenario(
+            name="poisson-aweights-fe",
+            estimator="poisson",
+            operation="fit",
+            tier="common",
+            nobs=poisson_n,
+            n_covariates=poisson_k,
+            weighted=True,
+            fixed_effects=True,
+        ),
+    ]
+
+    inference_specs: tuple[tuple[str, str | dict[str, str], Tier], ...] = (
+        ("hc1", "HC1", "common"),
+        ("hc2", "HC2", "inference"),
+        ("hc3", "HC3", "inference"),
+        ("crv1", {"CRV1": "cluster"}, "common"),
+        ("crv3", {"CRV3": "cluster"}, "inference"),
+    )
+    scenarios.extend(
+        BenchmarkScenario(
+            name=f"vcov-{name}",
+            estimator="ols",
+            operation="vcov",
+            tier=tier,
+            nobs=inference_n,
+            n_covariates=inference_k,
+            weighted=True,
+            fixed_effects=False,
+            vcov=vcov,
+            repeated_vcov_calls=5,
+        )
+        for name, vcov, tier in inference_specs
+    )
+    return tuple(scenarios)
+
+
+def _build_data(scenario: BenchmarkScenario, seed: int) -> pd.DataFrame:
+    """Generate one deterministic data frame outside the timed region."""
+    rng = np.random.default_rng(seed)
+    X = rng.normal(size=(scenario.nobs, scenario.n_covariates))
+    xnames = [f"x{index}" for index in range(scenario.n_covariates)]
+    data = pd.DataFrame(X, columns=xnames)
+
+    beta = np.linspace(0.2, 0.8, scenario.n_covariates)
+    f1 = rng.integers(0, max(20, scenario.nobs // 100), size=scenario.nobs)
+    f2 = rng.integers(0, 25, size=scenario.nobs)
+    fixed_effect_signal = 0.02 * f1 + 0.05 * f2
+    noise = rng.normal(size=scenario.nobs)
+
+    data["w"] = 0.5 + rng.random(scenario.nobs)
+    data["f1"] = f1
+    data["f2"] = f2
+    data["cluster"] = rng.integers(0, 100, size=scenario.nobs)
+
+    linear_predictor = X @ beta + fixed_effect_signal
+    if scenario.estimator == "iv":
+        instrument = rng.normal(size=scenario.nobs)
+        endogeneity = rng.normal(size=scenario.nobs)
+        endogenous = (
+            instrument + 0.5 * endogeneity + rng.normal(scale=0.25, size=scenario.nobs)
+        )
+        data["z"] = instrument
+        data["endog"] = endogenous
+        data["y"] = linear_predictor + 0.75 * endogenous + endogeneity + noise
+    elif scenario.estimator == "poisson":
+        mean = np.exp(np.clip(-0.5 + 0.05 * linear_predictor, -3.0, 3.0))
+        data["y"] = rng.poisson(mean)
+    else:
+        data["y"] = linear_predictor + noise
+    return data
+
+
+def _formula(scenario: BenchmarkScenario) -> str:
+    """Construct the public formula for ``scenario``."""
+    covariates = " + ".join(f"x{index}" for index in range(scenario.n_covariates))
+    main = f"y ~ {covariates}"
+    fixed_effects = "f1 + f2" if scenario.fixed_effects else None
+    if scenario.estimator == "iv":
+        return (
+            f"{main} | {fixed_effects} | endog ~ z"
+            if fixed_effects is not None
+            else f"{main} | endog ~ z"
+        )
+    return f"{main} | {fixed_effects}" if fixed_effects is not None else main
+
+
+def _fit(scenario: BenchmarkScenario, data: pd.DataFrame) -> Any:
+    """Fit one scenario through the public pyfixest API."""
+    import pyfixest as pf
+
+    kwargs: dict[str, Any] = {
+        "data": data,
+        "vcov": "iid",
+    }
+    if scenario.weighted:
+        kwargs.update(weights="w", weights_type="aweights")
+    formula = _formula(scenario)
+    if scenario.estimator == "poisson":
+        return pf.fepois(
+            formula,
+            iwls_tol=1e-8,
+            iwls_maxiter=100,
+            **kwargs,
+        )
+    return pf.feols(formula, **kwargs)
+
+
+def retained_ndarray_bytes(value: object) -> int:
+    """Count bytes held by unique NumPy buffers in supported containers.
+
+    The fitted model is passed as its ``vars()`` mapping, so arbitrary nested
+    objects such as pandas frames and cache services are intentionally not
+    traversed. Frozen estimator-state dataclasses are traversed recursively.
+    Aliases and views backed by the same allocation are counted once.
+    """
+    seen_objects: set[int] = set()
+    seen_buffers: set[int] = set()
+
+    def buffer_owner(array: np.ndarray) -> tuple[object, int]:
+        owner: object = array
+        base: object | None = array.base
+        while isinstance(base, np.ndarray):
+            owner = base
+            base = base.base
+        if base is not None:
+            owner = base
+        while isinstance(owner, memoryview):
+            owner = owner.obj
+        try:
+            buffer_bytes = memoryview(owner).nbytes
+        except TypeError:
+            buffer_bytes = array.nbytes
+        return owner, int(buffer_bytes)
+
+    def walk(item: object) -> int:
+        object_id = id(item)
+        if object_id in seen_objects:
+            return 0
+        seen_objects.add(object_id)
+
+        if isinstance(item, np.ndarray):
+            owner, buffer_bytes = buffer_owner(item)
+            buffer_id = id(owner)
+            if buffer_id in seen_buffers:
+                return 0
+            seen_buffers.add(buffer_id)
+            return buffer_bytes
+        if is_dataclass(item) and not isinstance(item, type):
+            return sum(walk(getattr(item, field.name)) for field in fields(item))
+        if isinstance(item, Mapping):
+            return sum(walk(mapped_value) for mapped_value in item.values())
+        if isinstance(item, (tuple, list, set, frozenset)):
+            return sum(walk(element) for element in item)
+        return 0
+
+    return walk(value)
+
+
+def _measure_once(
+    scenario: BenchmarkScenario,
+    data: pd.DataFrame,
+) -> Measurement:
+    """Measure one fit or repeated-vcov workflow."""
+    fit = None
+    if scenario.operation == "vcov":
+        fit = _fit(scenario, data)
+
+    gc.collect()
+    tracemalloc.start(1)
+    try:
+        start = time.perf_counter()
+        if scenario.operation == "fit":
+            fit = _fit(scenario, data)
+        else:
+            assert fit is not None
+            for _ in range(scenario.repeated_vcov_calls):
+                fit.vcov(scenario.vcov)
+        wall_time = time.perf_counter() - start
+        _, peak_bytes = tracemalloc.get_traced_memory()
+    finally:
+        tracemalloc.stop()
+
+    assert fit is not None
+    retained_bytes = retained_ndarray_bytes(vars(fit))
+    return Measurement(
+        wall_time_seconds=wall_time,
+        traced_peak_bytes=int(peak_bytes),
+        retained_ndarray_bytes=retained_bytes,
+    )
+
+
+def _warm_up(scenario: BenchmarkScenario, data: pd.DataFrame) -> None:
+    """Warm imports, compiled kernels, and estimator dispatch for a scenario."""
+    fit = _fit(scenario, data)
+    if scenario.operation == "vcov":
+        fit.vcov(scenario.vcov)
+    del fit
+    gc.collect()
+
+
+def summarize_measurements(measurements: Sequence[Measurement]) -> dict[str, float]:
+    """Return median wall-time and memory metrics."""
+    if not measurements:
+        raise ValueError("At least one measurement is required.")
+    return {
+        "median_wall_time_seconds": median(
+            measurement.wall_time_seconds for measurement in measurements
+        ),
+        "median_traced_peak_bytes": median(
+            measurement.traced_peak_bytes for measurement in measurements
+        ),
+        "median_retained_ndarray_bytes": median(
+            measurement.retained_ndarray_bytes for measurement in measurements
+        ),
+    }
+
+
+def _git_revision() -> str | None:
+    """Read the current Git revision without requiring Git metadata."""
+    result = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=PROJECT_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip() if result.returncode == 0 else None
+
+
+def run_benchmarks(
+    scenarios: Iterable[BenchmarkScenario],
+    *,
+    profile: str,
+    repetitions: int,
+    warmups: int,
+    seed: int,
+) -> dict[str, Any]:
+    """Run scenarios and return a JSON-serializable benchmark document."""
+    import pyfixest as pf
+
+    if repetitions < 1:
+        raise ValueError("repetitions must be at least one")
+    if warmups < 0:
+        raise ValueError("warmups must be non-negative")
+
+    scenario_results: dict[str, Any] = {}
+    for scenario_index, scenario in enumerate(scenarios):
+        data = _build_data(scenario, seed + scenario_index)
+        for _ in range(warmups):
+            _warm_up(scenario, data)
+        measurements = [_measure_once(scenario, data) for _ in range(repetitions)]
+        scenario_results[scenario.name] = {
+            "tier": scenario.tier,
+            "config": asdict(scenario),
+            "samples": [asdict(measurement) for measurement in measurements],
+            "summary": summarize_measurements(measurements),
+        }
+        del data
+        gc.collect()
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "metadata": {
+            "created_at": datetime.now(UTC).isoformat(),
+            "profile": profile,
+            "repetitions": repetitions,
+            "warmups": warmups,
+            "seed": seed,
+            "python": platform.python_version(),
+            "platform": platform.platform(),
+            "pyfixest": pf.__version__,
+            "git_revision": _git_revision(),
+            "peak_memory_metric": "incremental tracemalloc peak during operation",
+            "retained_memory_metric": (
+                "unique NumPy buffers directly retained by fitted result/container state"
+            ),
+        },
+        "scenarios": scenario_results,
+    }
+
+
+def _relative_change(base: float, head: float) -> float | None:
+    """Return fractional change, or ``None`` for a zero baseline."""
+    if base == 0:
+        return 0.0 if head == 0 else None
+    return (head - base) / base
+
+
+def compare_benchmarks(
+    base: Mapping[str, Any],
+    head: Mapping[str, Any],
+    *,
+    common_limit: float,
+    inference_limit: float,
+    retained_growth_bytes: int,
+) -> dict[str, Any]:
+    """Compare two benchmark documents and apply the review thresholds."""
+    if common_limit < 0 or inference_limit < 0:
+        raise ValueError("Wall-time limits must be non-negative.")
+    if retained_growth_bytes < 0:
+        raise ValueError("retained_growth_bytes must be non-negative.")
+    if base.get("schema_version") != SCHEMA_VERSION:
+        raise ValueError("The base benchmark has an unsupported schema version.")
+    if head.get("schema_version") != SCHEMA_VERSION:
+        raise ValueError("The head benchmark has an unsupported schema version.")
+
+    comparison_settings = (
+        "profile",
+        "repetitions",
+        "warmups",
+        "seed",
+        "python",
+        "platform",
+        "pyfixest",
+    )
+    base_metadata = base.get("metadata", {})
+    head_metadata = head.get("metadata", {})
+    for setting in comparison_settings:
+        if base_metadata.get(setting) != head_metadata.get(setting):
+            raise ValueError(f"Benchmark metadata differs for {setting!r}.")
+
+    base_scenarios = base.get("scenarios", {})
+    head_scenarios = head.get("scenarios", {})
+    if set(base_scenarios) != set(head_scenarios):
+        missing_from_head = sorted(set(base_scenarios) - set(head_scenarios))
+        missing_from_base = sorted(set(head_scenarios) - set(base_scenarios))
+        raise ValueError(
+            "Benchmark scenarios differ: "
+            f"missing from head={missing_from_head}, "
+            f"missing from base={missing_from_base}."
+        )
+
+    comparisons: list[dict[str, Any]] = []
+    for name in sorted(base_scenarios):
+        base_scenario = base_scenarios[name]
+        head_scenario = head_scenarios[name]
+        if base_scenario["config"] != head_scenario["config"]:
+            raise ValueError(f"Scenario configuration differs for {name!r}.")
+
+        tier = base_scenario["tier"]
+        if tier not in ("common", "inference"):
+            raise ValueError(f"Unknown benchmark tier {tier!r} for {name!r}.")
+        wall_limit = common_limit if tier == "common" else inference_limit
+        base_summary = base_scenario["summary"]
+        head_summary = head_scenario["summary"]
+        base_wall = float(base_summary["median_wall_time_seconds"])
+        head_wall = float(head_summary["median_wall_time_seconds"])
+        base_peak = float(base_summary["median_traced_peak_bytes"])
+        head_peak = float(head_summary["median_traced_peak_bytes"])
+        base_retained = int(base_summary["median_retained_ndarray_bytes"])
+        head_retained = int(head_summary["median_retained_ndarray_bytes"])
+
+        wall_passed = head_wall <= base_wall * (1 + wall_limit)
+        retained_passed = head_retained <= base_retained + retained_growth_bytes
+        comparisons.append(
+            {
+                "name": name,
+                "tier": tier,
+                "wall_limit_fraction": wall_limit,
+                "base_wall_time_seconds": base_wall,
+                "head_wall_time_seconds": head_wall,
+                "wall_change_fraction": _relative_change(base_wall, head_wall),
+                "base_traced_peak_bytes": base_peak,
+                "head_traced_peak_bytes": head_peak,
+                "traced_peak_change_fraction": _relative_change(base_peak, head_peak),
+                "base_retained_ndarray_bytes": base_retained,
+                "head_retained_ndarray_bytes": head_retained,
+                "retained_ndarray_change_bytes": head_retained - base_retained,
+                "wall_passed": wall_passed,
+                "retained_passed": retained_passed,
+                "passed": wall_passed and retained_passed,
+            }
+        )
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "limits": {
+            "common_wall_fraction": common_limit,
+            "inference_wall_fraction": inference_limit,
+            "retained_growth_bytes": retained_growth_bytes,
+            "peak_memory": "reported but not gated",
+        },
+        "passed": all(comparison["passed"] for comparison in comparisons),
+        "comparisons": comparisons,
+    }
+
+
+def _write_json(document: Mapping[str, Any], output: Path | None) -> None:
+    """Write a JSON document to a path or standard output."""
+    rendered = json.dumps(document, indent=2, sort_keys=True)
+    if output is None:
+        print(rendered)
+        return
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(f"{rendered}\n", encoding="utf-8")
+
+
+def _format_mebibytes(value: float) -> str:
+    return f"{value / (1024**2):.1f}"
+
+
+def _print_run_summary(document: Mapping[str, Any]) -> None:
+    """Print a compact human-readable run summary to standard error."""
+    print(
+        "scenario                              wall(s)  peak(MiB)  retained(MiB)",
+        file=sys.stderr,
+    )
+    for name, result in document["scenarios"].items():
+        summary = result["summary"]
+        print(
+            f"{name:<37} "
+            f"{summary['median_wall_time_seconds']:>7.3f}  "
+            f"{_format_mebibytes(summary['median_traced_peak_bytes']):>9}  "
+            f"{_format_mebibytes(summary['median_retained_ndarray_bytes']):>13}",
+            file=sys.stderr,
+        )
+
+
+def _format_change(value: float | None) -> str:
+    return "n/a" if value is None else f"{value:+.1%}"
+
+
+def _print_comparison_summary(document: Mapping[str, Any]) -> None:
+    """Print a compact comparison summary to standard error."""
+    print(
+        "scenario                              wall change  peak change  arrays     status",
+        file=sys.stderr,
+    )
+    for result in document["comparisons"]:
+        status = "PASS" if result["passed"] else "FAIL"
+        print(
+            f"{result['name']:<37} "
+            f"{_format_change(result['wall_change_fraction']):>11}  "
+            f"{_format_change(result['traced_peak_change_fraction']):>11}  "
+            f"{result['retained_ndarray_change_bytes'] / (1024**2):>+7.1f} MiB  "
+            f"{status}",
+            file=sys.stderr,
+        )
+
+
+def _parser() -> argparse.ArgumentParser:
+    """Build the benchmark command-line parser."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    run_parser = subparsers.add_parser("run", help="run a benchmark profile")
+    run_parser.add_argument(
+        "--profile",
+        choices=("smoke", "large"),
+        default="smoke",
+        help="safe smoke sizes (default) or the explicit review-gate sizes",
+    )
+    run_parser.add_argument(
+        "--scenario",
+        action="append",
+        dest="scenarios",
+        help="run only this named scenario; repeat the option to select several",
+    )
+    run_parser.add_argument("--repetitions", type=int)
+    run_parser.add_argument("--warmups", type=int, default=1)
+    run_parser.add_argument("--seed", type=int, default=20260831)
+    run_parser.add_argument("--output", type=Path)
+
+    compare_parser = subparsers.add_parser(
+        "compare", help="compare base and head benchmark JSON"
+    )
+    compare_parser.add_argument("base", type=Path)
+    compare_parser.add_argument("head", type=Path)
+    compare_parser.add_argument("--common-limit", type=float, default=0.05)
+    compare_parser.add_argument("--inference-limit", type=float, default=0.10)
+    compare_parser.add_argument(
+        "--retained-growth-bytes",
+        type=int,
+        default=0,
+        help="per-scenario retained NumPy growth allowance (default: 0)",
+    )
+    compare_parser.add_argument("--output", type=Path)
+    return parser
+
+
+def _selected_scenarios(
+    profile: str, selected_names: Sequence[str] | None
+) -> tuple[BenchmarkScenario, ...]:
+    """Select requested scenarios and reject unknown names."""
+    scenarios = build_scenarios(profile)
+    if not selected_names:
+        return scenarios
+    by_name = {scenario.name: scenario for scenario in scenarios}
+    unknown = sorted(set(selected_names) - set(by_name))
+    if unknown:
+        raise ValueError(
+            f"Unknown scenarios {unknown}. Available scenarios: {sorted(by_name)}"
+        )
+    return tuple(by_name[name] for name in selected_names)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the command-line benchmark or comparison workflow."""
+    args = _parser().parse_args(argv)
+    if args.command == "run":
+        repetitions = args.repetitions
+        if repetitions is None:
+            repetitions = 3 if args.profile == "smoke" else 5
+        document = run_benchmarks(
+            _selected_scenarios(args.profile, args.scenarios),
+            profile=args.profile,
+            repetitions=repetitions,
+            warmups=args.warmups,
+            seed=args.seed,
+        )
+        _print_run_summary(document)
+        _write_json(document, args.output)
+        return 0
+
+    base = json.loads(args.base.read_text(encoding="utf-8"))
+    head = json.loads(args.head.read_text(encoding="utf-8"))
+    comparison = compare_benchmarks(
+        base,
+        head,
+        common_limit=args.common_limit,
+        inference_limit=args.inference_limit,
+        retained_growth_bytes=args.retained_growth_bytes,
+    )
+    _print_comparison_summary(comparison)
+    _write_json(comparison, args.output)
+    return 0 if comparison["passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -44,6 +44,12 @@ fit3 = pf.feols("Y ~ X1 + X2 | f1", data = df)
   including the distinct observation- and working-weight domains in GLMs. It
   also defines the vocabulary for the planned immutable estimator-state
   refactor.
+- Formula-materialized estimator inputs now have a structurally immutable
+  `FormulaData` state,
+  and the generic fit runner delegates validation, inference data, post-fit
+  work, and result expansion through a structural lifecycle protocol. This
+  keeps formula roles stable while the later within- and weight-scale cleanup
+  proceeds independently.
 
 ### Inference Types
 

--- a/docs/developer/architecture.md
+++ b/docs/developer/architecture.md
@@ -169,10 +169,35 @@ the retained matrices and several fit products. The public `vcov()` method is
 intentionally in-place and remains a post-fit mutation boundary. User input is
 copied by default, with the documented `copy_data=False` path as the exception.
 
+## Formula-state and lifecycle boundaries
+
+`ModelMatrix` is the construction helper for formula inputs. After missing,
+infinite, singleton, and other formula-level row filters have run, it produces a
+structurally immutable, slotted `FormulaData` value. Its contained Pandas frames are
+treated as read-only rather than being deeply immutable. The value keeps
+dependent, independent, fixed-effect, IV, weight, and offset roles on formula
+scale. Models populate legacy attributes from it in one direction; later
+transformations do not change the role or representation of the retained formula
+state. GLM separation returns a new filtered `FormulaData` value so its canonical
+row sample remains aligned with the data that enter IRLS. `store_data=False` and
+`lean=True` discard formula data together with the other retained input state.
+
+The generic runner operates on the structural `FittedModel` protocol. Response
+validation, inference-data selection, estimator-specific post-fit work, and
+result expansion live behind model hooks rather than estimator-name dispatch in
+the runner. Pipeline-object constructors only assemble configuration and child
+objects; for example, `QuantregMulti` prepares its children in
+`prepare_model_matrix`, not during construction.
+
+This is the representation foundation, not the final within/weight cleanup.
+The compatibility fields documented above still move through their established
+DataFrame, within-array, and solver-array states until the numerical primitives
+and inference consumers move to explicit within-scale inputs.
+
 ## Estimation-state vocabulary
 
 New shared-core work should name the transformation domain instead of relying
-on `_X`, `_Y`, `_Z`, or `_weights`. The planned immutable-state refactor uses
+on `_X`, `_Y`, `_Z`, or `_weights`. The immutable-state refactor uses
 the following vocabulary:
 
 | Term | Meaning |

--- a/pyfixest/estimation/formula/model_matrix.py
+++ b/pyfixest/estimation/formula/model_matrix.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import warnings
 from collections.abc import Mapping
-from dataclasses import dataclass
-from typing import Any, Final
+from dataclasses import dataclass, replace
+from typing import Any, Final, TypeAlias, cast
 
 import formulaic
 import numpy as np
@@ -16,6 +18,8 @@ from pyfixest.estimation.formula.parse import Formula
 from pyfixest.estimation.formula.utils import _get_weights
 from pyfixest.utils.utils import capture_context
 
+_ModelSpecMapping: TypeAlias = Mapping[str, formulaic.ModelSpec]
+
 
 @dataclass(frozen=True, kw_only=True)
 class _ModelMatrixKey:
@@ -24,6 +28,47 @@ class _ModelMatrixKey:
     instrumental_variable: str = "first_stage"
     weights: str = "weights"
     offset: str = "offset"
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class FormulaData:
+    """Post-filtering, formula-materialized estimator inputs.
+
+    The structurally immutable record fixes the role and representation of every
+    formula-derived value. Its contained DataFrames remain on formula scale and are
+    treated as read-only; estimator-specific transformations produce separate
+    within- or solver-scale arrays instead of changing this record's fields.
+    """
+
+    dependent: pd.DataFrame
+    independent: pd.DataFrame
+    fixed_effects: pd.DataFrame | None
+    endogenous: pd.DataFrame | None
+    instruments: pd.DataFrame | None
+    weights: pd.DataFrame | None
+    offset: pd.DataFrame | None
+    model_spec: _ModelSpecMapping
+    na_index: frozenset[int]
+
+    def without_rows(self, rows: list[int]) -> FormulaData:
+        """Return formula data with ``rows`` removed from every tabular role."""
+        if not rows:
+            return self
+
+        def _drop(frame: pd.DataFrame | None) -> pd.DataFrame | None:
+            return None if frame is None else frame.drop(index=rows)
+
+        return replace(
+            self,
+            dependent=self.dependent.drop(index=rows),
+            independent=self.independent.drop(index=rows),
+            fixed_effects=_drop(self.fixed_effects),
+            endogenous=_drop(self.endogenous),
+            instruments=_drop(self.instruments),
+            weights=_drop(self.weights),
+            offset=_drop(self.offset),
+            na_index=self.na_index.union(rows),
+        )
 
 
 class ModelMatrix:
@@ -56,8 +101,8 @@ class ModelMatrix:
         Instrumental variables for IV estimation.
     weights : pd.DataFrame or None
         Observation weights for weighted estimation.
-    model_spec : formulaic.ModelSpec
-        The underlying formulaic model specification.
+    model_spec : Mapping[str, formulaic.ModelSpec]
+        The underlying formulaic model specifications keyed by role.
     na_index : frozenset[int]
         Indices of rows that were dropped.
     """
@@ -70,7 +115,7 @@ class ModelMatrix:
         drop_intercept: bool = False,
     ) -> None:
         self._drop_intercept = drop_intercept
-        self._model_spec = model_matrix.model_spec
+        self._model_spec = cast(_ModelSpecMapping, model_matrix.model_spec)
         self._na_index = drop_rows
         self._collect_columns(model_matrix)
         self._collect_data(model_matrix)
@@ -286,17 +331,30 @@ class ModelMatrix:
             return self._data.loc[:, self._offset]
 
     @property
-    def model_spec(self) -> formulaic.ModelSpec:
+    def model_spec(self) -> _ModelSpecMapping:
         """
         Get the underlying formulaic model specification.
 
         Returns
         -------
-        formulaic.ModelSpec
-            The formulaic ModelSpec object containing metadata about the
-            model structure and transformations.
+        Mapping[str, formulaic.ModelSpec]
+            Formulaic specifications keyed by model-matrix role.
         """
         return self._model_spec
+
+    def to_formula_data(self) -> FormulaData:
+        """Freeze the fully filtered formula roles into canonical state."""
+        return FormulaData(
+            dependent=self.dependent,
+            independent=self.independent,
+            fixed_effects=self.fixed_effects,
+            endogenous=self.endogenous,
+            instruments=self.instruments,
+            weights=self.weights,
+            offset=self.offset,
+            model_spec=self.model_spec,
+            na_index=self.na_index,
+        )
 
     @property
     def na_index(self) -> frozenset[int]:

--- a/pyfixest/estimation/models/feglm_.py
+++ b/pyfixest/estimation/models/feglm_.py
@@ -126,7 +126,7 @@ class Feglm(Feols):
 
     def prepare_model_matrix(self):
         "Prepare model inputs for estimation."
-        super().prepare_model_matrix()
+        formula_data = super().prepare_model_matrix()
 
         # check for separation
         na_separation: list[int] = []
@@ -146,23 +146,21 @@ class Feglm(Feols):
             )
 
         if na_separation:
-            self._Y.drop(na_separation, axis=0, inplace=True)
-            self._X.drop(na_separation, axis=0, inplace=True)
-            self._fe.drop(na_separation, axis=0, inplace=True)
             self._data.drop(na_separation, axis=0, inplace=True)
-            if self._weights_df is not None:
-                self._weights_df.drop(na_separation, axis=0, inplace=True)
-            if self._offset_df is not None:
-                self._offset_df.drop(na_separation, axis=0, inplace=True)
+            formula_data = formula_data.without_rows(na_separation)
+            self._set_formula_data(formula_data)
+
+            # Preserve the established GLM sample-size convention after
+            # separation. Frequency-weight policy is handled separately.
             self._N = self._Y.shape[0]
             self._N_rows = self._N
-            # Re-set weights after dropping rows (handles both weighted and unweighted)
-            self._weights = self._set_weights()
 
             self.n_separation_na = len(na_separation)
             # possible to have dropped fixed effects level due to separation
             self._k_fe = self._fe.nunique(axis=0) if self._has_fixef else None
             self._n_fe = np.sum(self._k_fe > 1) if self._has_fixef else 0
+
+        return formula_data
 
     def to_array(self):
         "Turn estimation DataFrames to np arrays."
@@ -373,6 +371,10 @@ class Feglm(Feols):
     def _check_dependent_variable(self) -> None:
         "Validate the dependent variable according to the family's constraints."
         self._family.check_y(self._Y)
+
+    def _validate_response(self) -> None:
+        """Apply family-specific response validation after matrix preparation."""
+        self._check_dependent_variable()
 
 
 def _glm_input_checks(drop_singletons: bool, tol: float, maxiter: int):

--- a/pyfixest/estimation/models/feiv_.py
+++ b/pyfixest/estimation/models/feiv_.py
@@ -335,6 +335,10 @@ class Feiv(Feols):
 
         self.IV_weakness_test(["f_stat"])
 
+    def _finalize_fit(self) -> None:
+        """Fit and retain the first-stage model after second-stage inference."""
+        self.first_stage()
+
     def IV_Diag(self, statistics: list[str] | None = None):
         """Implement IV diagnostic tests.
 

--- a/pyfixest/estimation/models/feols_.py
+++ b/pyfixest/estimation/models/feols_.py
@@ -404,7 +404,7 @@ class Feols(ResultAccessorMixin):
         self.iplot_aggregate = _not_implemented_did
 
     def prepare_model_matrix(self):
-        "Prepare model matrices for estimation."
+        """Build and retain the canonical formula-derived estimator inputs."""
         model_matrix = model_matrix_fixest.create_model_matrix(
             formula=self.FixestFormula,
             data=self._data,
@@ -414,16 +414,29 @@ class Feols(ResultAccessorMixin):
             offset=self._offset_name,
             context=self._context,
         )
+        formula_data = model_matrix.to_formula_data()
+        self._set_formula_data(formula_data)
 
-        self._Y = model_matrix.dependent
+        # an empty drop still rebuilds the whole frame, so guard it
+        if self._na_index:
+            self._data.drop(index=list(self._na_index), inplace=True)
+
+        return formula_data
+
+    # This compatibility publisher remains deliberately untyped while the legacy
+    # aliases change representation. PR3 removes that transitional type mutation.
+    def _set_formula_data(self, formula_data):
+        """Publish one structurally immutable state through compatibility aliases."""
+        self._formula_data = formula_data
+        self._Y = formula_data.dependent
         self._Y_untransformed = self._Y.copy()
-        self._X = model_matrix.independent
-        self._fe = model_matrix.fixed_effects
-        self._endogvar = model_matrix.endogenous
-        self._Z = model_matrix.instruments
-        self._weights_df = model_matrix.weights
-        self._offset_df = model_matrix.offset
-        self._na_index = model_matrix.na_index
+        self._X = formula_data.independent
+        self._fe = formula_data.fixed_effects
+        self._endogvar = formula_data.endogenous
+        self._Z = formula_data.instruments
+        self._weights_df = formula_data.weights
+        self._offset_df = formula_data.offset
+        self._na_index = formula_data.na_index
         # TODO: set dynamically based on naming set in pyfixest.estimation.formula.factor_interaction._encode_i
         is_icovar = (
             self._X.columns.str.contains(r"^.+::.+$") if not self._X.empty else None
@@ -434,7 +447,7 @@ class Feols(ResultAccessorMixin):
             else None
         )
         self._X_is_empty = self._X.shape[0] == 0
-        self._model_spec = model_matrix.model_spec
+        self._model_spec = formula_data.model_spec
 
         self._coefnames = self._X.columns.tolist()
         self._coefnames_z = self._Z.columns.tolist() if self._Z is not None else None
@@ -450,12 +463,11 @@ class Feols(ResultAccessorMixin):
         self._k_fe = self._fe.nunique(axis=0) if self._has_fixef else None
         self._n_fe = len(self._k_fe) if self._has_fixef else 0
 
-        # an empty drop still rebuilds the whole frame, so guard it
-        if self._na_index:
-            self._data.drop(index=list(self._na_index), inplace=True)
-
         self._weights = self._set_weights()
         self._N, self._N_rows = self._set_nobs()
+
+    def _validate_response(self) -> None:
+        """Validate estimator-specific response constraints, if any."""
 
     def _set_nobs(self) -> tuple[int, int]:
         """
@@ -588,6 +600,20 @@ class Feols(ResultAccessorMixin):
             self._tZZinv = np.array([])
 
         self._get_predictors()
+
+    def _inference_data(self) -> pd.DataFrame:
+        """Return estimation data needed by covariance preparation."""
+        return self._data
+
+    def _finalize_fit(self) -> None:
+        """Compute OLS-only post-fit statistics."""
+        if self._method == "feols" and not self._is_iv:
+            self.get_performance()
+            self.wald_test()
+
+    def _iter_fitted_models(self) -> tuple[Feols, ...]:
+        """Yield this fitted result to the result container."""
+        return (self,)
 
     def vcov(
         self,
@@ -880,7 +906,7 @@ class Feols(ResultAccessorMixin):
         attributes = []
 
         if not self._store_data:
-            attributes += ["_data"]
+            attributes += ["_data", "_formula_data"]
 
         if self._lean:
             attributes += [
@@ -902,6 +928,7 @@ class Feols(ResultAccessorMixin):
                 "_Y_hat_link",
                 "_Y_hat_response",
                 "_Y_untransformed",
+                "_formula_data",
             ]
 
         for attr in attributes:

--- a/pyfixest/estimation/plan_.py
+++ b/pyfixest/estimation/plan_.py
@@ -12,12 +12,12 @@ from pyfixest.estimation.config import EstimationConfig
 from pyfixest.estimation.formula.parse import Formula as FixestFormula
 from pyfixest.estimation.internals.vcov_utils import _get_vcov_type
 from pyfixest.estimation.models.fegaussian_ import Fegaussian
-from pyfixest.estimation.models.feglm_ import Feglm
 from pyfixest.estimation.models.feiv_ import Feiv
 from pyfixest.estimation.models.felogit_ import Felogit
 from pyfixest.estimation.models.feols_ import Feols
 from pyfixest.estimation.models.fepois_ import Fepois
 from pyfixest.estimation.models.feprobit_ import Feprobit
+from pyfixest.estimation.protocols import FittedModel, ModelFactory
 from pyfixest.estimation.quantreg.quantreg_ import Quantreg
 from pyfixest.estimation.quantreg.QuantregMulti import QuantregMulti
 
@@ -33,7 +33,7 @@ class ModelEntry:
     to decide which config fields to thread through.
     """
 
-    model_cls: type
+    model_cls: ModelFactory
     needs: frozenset[str] = field(default_factory=frozenset)
 
 
@@ -62,7 +62,7 @@ MODEL_REGISTRY: dict[str, ModelEntry] = {
 }
 
 
-def _resolve_model_class(method: str, is_iv: bool) -> type:
+def _resolve_model_class(method: str, is_iv: bool) -> ModelFactory:
     """Pick the model class to instantiate for this method.
 
     The only special case is `feols` with an IV formula, which
@@ -135,7 +135,7 @@ class ModelSpec:
     """
 
     method: str
-    model_cls: type
+    model_cls: ModelFactory
     formula: FixestFormula
     fixef_key: str | None
     sample_split_value: Any
@@ -289,11 +289,6 @@ def _build_model_kwargs(
     return kwargs
 
 
-FittedModel = (
-    Feols | Feiv | Fepois | Fegaussian | Felogit | Feprobit | Quantreg | QuantregMulti
-)
-
-
 def fit_one(
     spec: ModelSpec,
     *,
@@ -318,8 +313,7 @@ def fit_one(
     FIT: FittedModel = spec.model_cls(**model_kwargs)
 
     FIT.prepare_model_matrix()
-    if isinstance(FIT, Feglm):
-        FIT._check_dependent_variable()
+    FIT._validate_response()
     FIT.get_fit()
     # if X is empty: no inference (empty X only as shorthand for demeaning)
     if not FIT._X_is_empty:
@@ -327,18 +321,11 @@ def fit_one(
         FIT.vcov(
             vcov=vcov_type,
             vcov_kwargs=vcov_kwargs,
-            data=FIT._data
-            if not isinstance(FIT, QuantregMulti)
-            else FIT.all_quantregs[FIT.quantiles[0]]._data,
-        )  # a little hacky, but works
+            data=FIT._inference_data(),
+        )
 
         FIT.get_inference()
-        if spec.method == "feols" and not FIT._is_iv:
-            FIT.get_performance()
-            if isinstance(FIT, Feols):
-                FIT.wald_test()
-        if isinstance(FIT, Feiv):
-            FIT.first_stage()
+        FIT._finalize_fit()
     # delete large attributes
     FIT._clear_attributes()
 

--- a/pyfixest/estimation/protocols.py
+++ b/pyfixest/estimation/protocols.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+from typing import TYPE_CHECKING, Any, Protocol, TypeAlias
+
+if TYPE_CHECKING:
+    from pyfixest.estimation.models.feols_ import Feols
+
+
+class FittedModel(Protocol):
+    """Structural contract consumed by the generic estimation pipeline."""
+
+    _X_is_empty: bool
+    _is_iv: bool
+
+    def prepare_model_matrix(self) -> object:
+        """Prepare and retain estimator inputs derived from the formula."""
+        ...
+
+    def _validate_response(self) -> None:
+        """Validate estimator-specific dependent-variable constraints."""
+        ...
+
+    def get_fit(self) -> object:
+        """Estimate the model parameters."""
+        ...
+
+    def vcov(
+        self,
+        vcov: str | dict[str, str],
+        vcov_kwargs: dict[str, str | int] | None = None,
+        data: Any = None,
+    ) -> object:
+        """Compute the requested covariance matrix."""
+        ...
+
+    def get_inference(self) -> object:
+        """Compute coefficient-level inference from the covariance matrix."""
+        ...
+
+    def _inference_data(self) -> Any:
+        """Return data used to construct covariance state."""
+        ...
+
+    def _finalize_fit(self) -> None:
+        """Run estimator-specific post-fit orchestration."""
+        ...
+
+    def _iter_fitted_models(self) -> Iterable[Feols]:
+        """Yield concrete fitted results produced by this pipeline object."""
+        ...
+
+    def _clear_attributes(self) -> None:
+        """Clear large state according to storage options."""
+        ...
+
+
+ModelFactory: TypeAlias = Callable[..., FittedModel]

--- a/pyfixest/estimation/quantreg/QuantregMulti.py
+++ b/pyfixest/estimation/quantreg/QuantregMulti.py
@@ -69,15 +69,17 @@ class QuantregMulti:
         self.multi_method = multi_method
         self._is_iv = False
 
-        # TODO: call model_matrix(), to_array(), drop_multicol_vars() only once for model 0
-        # and then copy the attributes to the other models (less robust? but faster)
-        [q.prepare_model_matrix() for q in self.all_quantregs.values()]
-        [q.to_array() for q in self.all_quantregs.values()]
-        [q.drop_multicol_vars() for q in self.all_quantregs.values()]
+    def prepare_model_matrix(self) -> None:
+        """Prepare the model inputs for every requested quantile."""
+        # TODO: prepare once and share immutable state across quantiles.
+        for quantreg in self.all_quantregs.values():
+            quantreg.prepare_model_matrix()
+            quantreg.to_array()
+            quantreg.drop_multicol_vars()
 
         self._X_is_empty = False
 
-    def get_fit(self):
+    def get_fit(self) -> dict[float, Quantreg]:
         "Fit multiple quantile regressions via either algo 2 or 3 of CFM."
         # sort q increasing
         q = np.sort(self.quantiles)
@@ -191,54 +193,42 @@ class QuantregMulti:
         vcov: str | dict[str, str],
         vcov_kwargs: dict[str, str | int] | None = None,
         data: DataFrameType | None = None,
-    ):
+    ) -> dict[float, Quantreg]:
         "Compute variance-covariance matrices for all models in the quantile regression process."
-        [
-            QuantReg.vcov(vcov=vcov, vcov_kwargs=vcov_kwargs, data=data)
-            for QuantReg in self.all_quantregs.values()
-        ]
+        for quantreg in self.all_quantregs.values():
+            quantreg.vcov(vcov=vcov, vcov_kwargs=vcov_kwargs, data=data)
 
         return self.all_quantregs
 
-    def get_inference(self):
+    def get_inference(self) -> dict[float, Quantreg]:
         "Compute inference for all models of the quantile regression process."
-        [QuantReg.get_inference() for QuantReg in self.all_quantregs.values()]
+        for quantreg in self.all_quantregs.values():
+            quantreg.get_inference()
 
         return self.all_quantregs
 
-    def prepare_model_matrix(self):
-        "Prepare model matrix. Placeholder, only needed due to structure of execution of FixestMulti class."
-        pass
+    def _validate_response(self) -> None:
+        """Quantile regression has no additional response constraint."""
 
-    def to_array(self):
-        "Covert to array. Placeholder, only needed due to structure of execution of FixestMulti class."
-        pass
+    def _inference_data(self) -> pd.DataFrame:
+        """Return the shared estimation data from the first quantile model."""
+        return next(iter(self.all_quantregs.values()))._data
 
-    def drop_multicol_vars(self):
-        "Drop multicollinear variables. Placeholder, only needed due to structure of execution of FixestMulti class."
-        pass
+    def _finalize_fit(self) -> None:
+        """Quantile models require no additional post-fit orchestration."""
 
-    def wls_transform(self):
-        "Apply the WLS transform. Placeholder, only needed due to structure of execution of FixestMulti class."
-        pass
+    def _iter_fitted_models(self) -> tuple[Quantreg, ...]:
+        """Yield each fitted quantile to the result container."""
+        return tuple(self.all_quantregs.values())
 
-    def demean(self):
-        "Demean the data. Placeholder, only needed due to structure of execution of FixestMulti class."
-        pass
-
-    def get_performance(self):
-        "Compute performance metrics for all models of the quantile regression process."
-        [QuantReg.get_performance() for QuantReg in self.all_quantregs.values()]
-        return self.all_quantregs
-
-    def _clear_attributes(self):
+    def _clear_attributes(self) -> None:
         "Clear all large non-necessary attributes to free memory."
-        [QuantReg._clear_attributes() for QuantReg in self.all_quantregs.values()]
-        del_attributes = ["_X", "_Y"]
-        for QuantReg in self.all_quantregs.values():
-            for attr in del_attributes:
-                if hasattr(QuantReg, attr):
-                    delattr(QuantReg, attr)
-        gc.collect()
+        for quantreg in self.all_quantregs.values():
+            quantreg._clear_attributes()
 
-        return self.all_quantregs
+        del_attributes = ["_X", "_Y"]
+        for quantreg in self.all_quantregs.values():
+            for attr in del_attributes:
+                if hasattr(quantreg, attr):
+                    delattr(quantreg, attr)
+        gc.collect()

--- a/pyfixest/estimation/runner.py
+++ b/pyfixest/estimation/runner.py
@@ -17,7 +17,6 @@ from pyfixest.estimation.plan_ import (
     expand_specs,
     fit_one,
 )
-from pyfixest.estimation.quantreg.QuantregMulti import QuantregMulti
 from pyfixest.utils.dev_utils import _narwhals_to_pandas
 from pyfixest.utils.utils import capture_context
 
@@ -99,11 +98,8 @@ def run_estimation(
             vcov_kwargs=config.vcov_kwargs,
         )
 
-        if isinstance(FIT, QuantregMulti):
-            for q_model in FIT.all_quantregs.values():
-                fixest.all_fitted_models[q_model._model_name] = q_model
-        else:
-            fixest.all_fitted_models[FIT._model_name] = FIT
+        for fitted_result in FIT._iter_fitted_models():
+            fixest.all_fitted_models[fitted_result._model_name] = fitted_result
 
     if parsed.is_multiple_estimation:
         return fixest

--- a/tests/test_estimator_state_lifecycle.py
+++ b/tests/test_estimator_state_lifecycle.py
@@ -1,4 +1,4 @@
-"""Characterize private estimator state before the immutable-state refactor.
+"""Characterize and protect private estimator-state lifecycle boundaries.
 
 These tests intentionally inspect implementation details. Public numerical
 behavior belongs to the release snapshots and live-R suites; this module locks
@@ -10,6 +10,7 @@ about the new explicit state objects.
 from __future__ import annotations
 
 from collections.abc import Callable
+from dataclasses import FrozenInstanceError
 from typing import Any
 
 import numpy as np
@@ -18,6 +19,7 @@ import pytest
 
 import pyfixest as pf
 from pyfixest.estimation.FixestMulti_ import FixestMulti
+from pyfixest.estimation.formula.model_matrix import FormulaData
 from pyfixest.estimation.models.feols_ import Feols
 
 
@@ -200,6 +202,73 @@ def test_weighted_iv_fields_end_on_solver_scale(
     )
 
 
+def test_formula_data_remains_canonical_after_linear_fit(
+    lifecycle_data: pd.DataFrame,
+) -> None:
+    """Formula roles remain tabular while compatibility aliases are transformed."""
+    fit = pf.feols(
+        "y ~ x + [endog ~ z] | fe",
+        data=lifecycle_data,
+        weights="weight",
+        vcov="iid",
+    )
+
+    formula_data = fit._formula_data
+    assert isinstance(formula_data, FormulaData)
+    assert not hasattr(formula_data, "__dict__")
+    with pytest.raises(FrozenInstanceError):
+        formula_data.na_index = frozenset()
+
+    assert isinstance(formula_data.dependent, pd.DataFrame)
+    assert isinstance(formula_data.independent, pd.DataFrame)
+    assert isinstance(formula_data.fixed_effects, pd.DataFrame)
+    assert isinstance(formula_data.instruments, pd.DataFrame)
+    assert isinstance(formula_data.weights, pd.DataFrame)
+    assert isinstance(fit._Y, np.ndarray)
+    assert isinstance(fit._X, np.ndarray)
+    assert isinstance(fit._Z, np.ndarray)
+    pd.testing.assert_frame_equal(
+        formula_data.dependent,
+        lifecycle_data.loc[:, ["y"]],
+    )
+    pd.testing.assert_frame_equal(
+        formula_data.weights,
+        lifecycle_data.loc[:, ["weight"]],
+    )
+    assert fit._model_spec is formula_data.model_spec
+
+
+def test_glm_separation_replaces_formula_data_with_filtered_state() -> None:
+    """Canonical GLM formula data describes the post-separation sample."""
+    data = pd.DataFrame(
+        {
+            "y": [0, 0, 0, 1, 2, 3],
+            "fe": ["a", "a", "b", "b", "b", "c"],
+            "x": [-1.0, 0.5, 0.25, 1.0, -0.5, 1.5],
+        }
+    )
+
+    with pytest.warns(
+        UserWarning, match="2 observations removed because of separation"
+    ):
+        fit = pf.fepois(
+            "y ~ x | fe",
+            data=data,
+            vcov="hetero",
+            separation_check=["fe"],
+        )
+
+    formula_data = fit._formula_data
+    assert formula_data.dependent.index.equals(fit._data.index)
+    assert formula_data.independent.index.equals(fit._data.index)
+    assert formula_data.fixed_effects is not None
+    assert formula_data.fixed_effects.index.equals(fit._data.index)
+    # Row 5 is a formula-stage singleton; rows 0 and 1 are separated.
+    assert formula_data.na_index == frozenset({0, 1, 5})
+    assert len(formula_data.dependent) == fit._N_rows
+    assert fit.n_separation_na == 2
+
+
 def test_multiple_estimation_shares_dataframe_demean_cache(
     lifecycle_data: pd.DataFrame,
 ) -> None:
@@ -233,7 +302,7 @@ def test_multiple_estimation_shares_dataframe_demean_cache(
     ("fit_kwargs", "missing_fields"),
     [
         ({}, frozenset()),
-        ({"store_data": False}, frozenset({"_data"})),
+        ({"store_data": False}, frozenset({"_data", "_formula_data"})),
         (
             {"lean": True},
             frozenset(
@@ -247,6 +316,7 @@ def test_multiple_estimation_shares_dataframe_demean_cache(
                     "_weights",
                     "_scores",
                     "_u_hat",
+                    "_formula_data",
                 }
             ),
         ),
@@ -269,6 +339,7 @@ def test_storage_options_delete_expected_state(
             "_weights",
             "_scores",
             "_u_hat",
+            "_formula_data",
         }
     )
     fit = pf.feols("y ~ x | fe", data=lifecycle_data, vcov="iid", **fit_kwargs)

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -15,11 +15,14 @@ from pyfixest.estimation.models.feols_ import Feols
 from pyfixest.estimation.models.fepois_ import Fepois
 from pyfixest.estimation.plan_ import (
     MODEL_REGISTRY,
+    ModelSpec,
     _resolve_model_class,
     build_all_splits,
     expand_specs,
+    fit_one,
 )
 from pyfixest.estimation.quantreg.quantreg_ import Quantreg
+from pyfixest.estimation.quantreg.QuantregMulti import QuantregMulti
 
 
 def _config(method: str, fml: str, data, **overrides) -> EstimationConfig:
@@ -299,3 +302,104 @@ def test_public_feols_matches_legacy_behavior():
     fit = pf.feols("Y ~ X1 + X2 | f1 + f2", data)
     # If the planner regressed anything, coefficients would shift.
     assert abs(fit.coef().iloc[0] - (-0.9240461507764969)) < 1e-10
+
+
+def test_fit_one_uses_the_structural_lifecycle_contract():
+    """The generic pipeline delegates estimator-specific work through hooks."""
+    events: list[str] = []
+
+    class StubModel:
+        _X_is_empty = False
+        _is_iv = False
+
+        def __init__(self, *, events, **kwargs):
+            self.events = events
+
+        def prepare_model_matrix(self):
+            self.events.append("prepare")
+
+        def _validate_response(self):
+            self.events.append("validate")
+
+        def get_fit(self):
+            self.events.append("fit")
+
+        def _inference_data(self):
+            self.events.append("inference_data")
+            return "stub-data"
+
+        def vcov(self, vcov, vcov_kwargs=None, data=None):
+            assert vcov == "iid"
+            assert data == "stub-data"
+            self.events.append("vcov")
+
+        def get_inference(self):
+            self.events.append("inference")
+
+        def _finalize_fit(self):
+            self.events.append("finalize")
+
+        def _clear_attributes(self):
+            self.events.append("clear")
+
+        def _iter_fitted_models(self):
+            return ()
+
+    formula = Formula.parse_to_dict("Y ~ X1")[None][0]
+    spec = ModelSpec(
+        method="quantreg",
+        model_cls=StubModel,
+        formula=formula,
+        fixef_key=None,
+        sample_split_value=_ALL_SAMPLE,
+        model_kwargs={"events": events},
+    )
+
+    fit_one(
+        spec,
+        lookup_demeaned_data={},
+        lookup_preconditioner={},
+        vcov=None,
+        vcov_kwargs=None,
+    )
+
+    assert events == [
+        "prepare",
+        "validate",
+        "fit",
+        "inference_data",
+        "vcov",
+        "inference",
+        "finalize",
+        "clear",
+    ]
+
+
+def test_quantreg_multi_prepares_children_in_lifecycle_hook():
+    """Multi-quantile construction is deferred to the preparation phase."""
+    events: list[str] = []
+
+    class StubQuantreg:
+        def prepare_model_matrix(self):
+            events.append("prepare")
+
+        def to_array(self):
+            events.append("to_array")
+
+        def drop_multicol_vars(self):
+            events.append("drop_multicol_vars")
+
+    fit = QuantregMulti.__new__(QuantregMulti)
+    fit.all_quantregs = {0.25: StubQuantreg(), 0.75: StubQuantreg()}
+
+    fit.prepare_model_matrix()
+
+    assert events == [
+        "prepare",
+        "to_array",
+        "drop_multicol_vars",
+        "prepare",
+        "to_array",
+        "drop_multicol_vars",
+    ]
+    assert fit._X_is_empty is False

--- a/tests/test_weight_domain_benchmark.py
+++ b/tests/test_weight_domain_benchmark.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+import pytest
+
+from benchmarks.weight_domain_benchmark import (
+    Measurement,
+    build_scenarios,
+    compare_benchmarks,
+    retained_ndarray_bytes,
+    summarize_measurements,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class _ArrayState:
+    primary: np.ndarray
+    alias: np.ndarray
+    other: tuple[np.ndarray, ...]
+
+
+def _benchmark_document(
+    *,
+    common_wall: float,
+    inference_wall: float,
+    retained: int,
+) -> dict[str, Any]:
+    def scenario(name: str, tier: str, wall: float) -> dict[str, Any]:
+        return {
+            "tier": tier,
+            "config": {"name": name},
+            "summary": {
+                "median_wall_time_seconds": wall,
+                "median_traced_peak_bytes": 100,
+                "median_retained_ndarray_bytes": retained,
+            },
+        }
+
+    return {
+        "schema_version": 1,
+        "metadata": {
+            "profile": "smoke",
+            "repetitions": 3,
+            "warmups": 1,
+            "seed": 123,
+            "python": "3.12.0",
+            "platform": "test-platform",
+            "pyfixest": "0.test",
+        },
+        "scenarios": {
+            "common": scenario("common", "common", common_wall),
+            "inference": scenario("inference", "inference", inference_wall),
+        },
+    }
+
+
+def test_retained_ndarray_bytes_deduplicates_aliases() -> None:
+    allocation = np.ones(12)
+    primary = allocation.reshape((4, 3))
+    alias = primary[:, :]
+    other = np.ones(5)
+    state = _ArrayState(primary=primary, alias=alias, other=(other,))
+
+    assert retained_ndarray_bytes({"state": state, "again": primary}) == (
+        allocation.nbytes + other.nbytes
+    )
+
+
+def test_summarize_measurements_uses_medians() -> None:
+    measurements = [
+        Measurement(3.0, 300, 30),
+        Measurement(1.0, 100, 10),
+        Measurement(2.0, 200, 20),
+    ]
+
+    assert summarize_measurements(measurements) == {
+        "median_wall_time_seconds": 2.0,
+        "median_traced_peak_bytes": 200,
+        "median_retained_ndarray_bytes": 20,
+    }
+
+
+def test_compare_benchmarks_applies_tier_limits_and_retained_gate() -> None:
+    base = _benchmark_document(common_wall=1.0, inference_wall=1.0, retained=100)
+    head = _benchmark_document(common_wall=1.04, inference_wall=1.09, retained=100)
+
+    comparison = compare_benchmarks(
+        base,
+        head,
+        common_limit=0.05,
+        inference_limit=0.10,
+        retained_growth_bytes=0,
+    )
+
+    assert comparison["passed"]
+    assert all(result["passed"] for result in comparison["comparisons"])
+
+    head["scenarios"]["common"]["summary"]["median_retained_ndarray_bytes"] = 101
+    comparison = compare_benchmarks(
+        base,
+        head,
+        common_limit=0.05,
+        inference_limit=0.10,
+        retained_growth_bytes=0,
+    )
+    assert not comparison["passed"]
+
+
+def test_compare_benchmarks_rejects_different_scenarios() -> None:
+    base = _benchmark_document(common_wall=1.0, inference_wall=1.0, retained=100)
+    head = _benchmark_document(common_wall=1.0, inference_wall=1.0, retained=100)
+    del head["scenarios"]["inference"]
+
+    with pytest.raises(ValueError, match="Benchmark scenarios differ"):
+        compare_benchmarks(
+            base,
+            head,
+            common_limit=0.05,
+            inference_limit=0.10,
+            retained_growth_bytes=0,
+        )
+
+
+def test_compare_benchmarks_rejects_different_run_settings() -> None:
+    base = _benchmark_document(common_wall=1.0, inference_wall=1.0, retained=100)
+    head = _benchmark_document(common_wall=1.0, inference_wall=1.0, retained=100)
+    metadata = head["metadata"]
+    assert isinstance(metadata, dict)
+    metadata["repetitions"] = 5
+
+    with pytest.raises(ValueError, match="metadata differs for 'repetitions'"):
+        compare_benchmarks(
+            base,
+            head,
+            common_limit=0.05,
+            inference_limit=0.10,
+            retained_growth_bytes=0,
+        )
+
+
+@pytest.mark.parametrize("setting", ["python", "platform", "pyfixest"])
+def test_compare_benchmarks_rejects_different_environments(setting: str) -> None:
+    base = _benchmark_document(common_wall=1.0, inference_wall=1.0, retained=100)
+    head = _benchmark_document(common_wall=1.0, inference_wall=1.0, retained=100)
+    metadata = head["metadata"]
+    assert isinstance(metadata, dict)
+    metadata[setting] = "different"
+
+    with pytest.raises(ValueError, match=rf"metadata differs for '{setting}'"):
+        compare_benchmarks(
+            base,
+            head,
+            common_limit=0.05,
+            inference_limit=0.10,
+            retained_growth_bytes=0,
+        )
+
+
+def test_profiles_keep_default_safe_and_expose_review_sizes() -> None:
+    smoke = {scenario.name: scenario for scenario in build_scenarios("smoke")}
+    large = {scenario.name: scenario for scenario in build_scenarios("large")}
+
+    assert max(scenario.nobs for scenario in smoke.values()) <= 10_000
+    assert large["ols-unweighted-narrow"].nobs == 1_000_000
+    assert large["ols-unweighted-narrow"].n_covariates == 10
+    assert large["ols-aweights-wide"].nobs == 100_000
+    assert large["ols-aweights-wide"].n_covariates == 100


### PR DESCRIPTION
## Summary

Introduces a structurally immutable boundary for formula-materialized estimator inputs. Frozen, slotted `FormulaData` keeps response, covariate, fixed-effect, IV, weight, and offset roles stable after row filtering; its contained DataFrames are treated as read-only rather than deeply copied.

The generic runner now delegates validation, inference-data selection, post-fit work, and result expansion through a structural fitted-model protocol. Estimator construction becomes configuration-only, including moving quantile child preparation out of `QuantregMulti.__init__`. A reproducible benchmark harness records runtime and retained-array baselines for the final representation change.

## Stack

Layer 2 of 3. Depends on [#1491](https://github.com/py-econometrics/pyfixest/pull/1491). Next: [#1493](https://github.com/py-econometrics/pyfixest/pull/1493).

## Verification

- `pixi run -e py312-r pytest tests/test_estimator_state_lifecycle.py tests/test_plan.py tests/test_weight_domain_benchmark.py -x -q --no-cov`: 43 passed on this exact head.
- Changed-file `ruff-check`: passed on this exact head.
- Changed-file `mypy`: passed on this exact head.

## Compatibility / risks

`FormulaData` is structurally immutable, while its contained DataFrames are read-only by convention. Legacy within- and solver-scale aliases deliberately remain in place until the next stack layer.
