### PR TITLE
refactor(estimation): separate weight and within domains

### DIFF
--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -224,7 +224,9 @@ We also removed:
 - Weighted fixed-effect contributions are now retained in response units.
 - `store_data=False` and `lean=True` now apply to multiple-estimation containers
   and retained IV first stages; lean fits also discard demeaning caches, GLM
-  working aliases, and quantile solver outputs.
+  working aliases, and quantile solver outputs. Multiple-model `vcov()` updates
+  can forward a common explicit estimation sample, while default multi-quantile
+  results retain the arrays needed for prediction and covariance updates.
 - CCV auxiliary fits now retain the original demeaner configuration.
 - IR separation checks now use the configured demeaner backend.
 - Fixes `confint()` when `keep` or `drop` requests coefficients in an order

--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -50,9 +50,24 @@ fit3 = pf.feols("Y ~ X1 + X2 | f1", data = df)
   work, and result expansion through a structural lifecycle protocol. This
   keeps formula roles stable while the later within- and weight-scale cleanup
   proceeds independently.
+- Estimator internals now keep formula tables, unpremultiplied within arrays,
+  user-scale observation weights, and GLM IRLS working state in separate typed
+  domains. Square-root-weighted arrays are local solver temporaries, and linear
+  residuals remain in response units; a dedicated benchmark guards runtime and
+  retained-memory regressions.
 
 ### Inference Types
 
+- Frequency-weight HC2/HC3 leverage now follows the equivalent expanded sample.
+  Weighted models now reject `ccv()` explicitly, and non-Poisson GLMs reject
+  `CRV3` instead of silently using Poisson jackknife refits. Poisson `CRV3`
+  remains supported.
+- `Feols.update()` remains available as a coefficient-only calculation, but now
+  rejects `inplace=True` instead of leaving inference, prediction, and retained
+  formula state out of sync with the updated coefficients.
+- Randomization inference now rejects non-OLS/non-Poisson results, and the wild
+  bootstrap rejects non-OLS results, rather than treating GLM working state or
+  quantile solver outputs as OLS arrays.
 - `tidy()`, `confint()`, and `summary()` gain an `inference_type` argument.
   `confint()` takes `"regular"` (pointwise, the default), `"simult"`
   (simultaneous / joint intervals), or `"savi"`; `tidy()` and `summary()` take
@@ -93,6 +108,9 @@ fit.confint(inference_type="savi", mixture_precision=mixture_precision)
 
 ### GLM API and Behavior
 
+- Poisson frequency weights, including models with fixed effects and
+  post-separation sample sizes, now follow the equivalent expanded sample.
+  Probability weights remain unsupported.
 - Poisson offsets now accept Formulaic transformations such as
   `offset="log(exposure)"` when the expression evaluates to one numeric column.
 - `feglm()` now accepts `weights`, `weights_type`, and `offset`, and supports
@@ -203,6 +221,10 @@ We also removed:
 - Fitted models and non-plotting DiD and reporting paths no longer import
   plotting dependencies eagerly. `ritest()` loads its numerical helpers on use,
   while Matplotlib, Seaborn, and Lets-Plot load only when plotting.
+- Weighted fixed-effect contributions are now retained in response units.
+- `store_data=False` and `lean=True` now apply to multiple-estimation containers
+  and retained IV first stages; lean fits also discard demeaning caches, GLM
+  working aliases, and quantile solver outputs.
 - CCV auxiliary fits now retain the original demeaner configuration.
 - IR separation checks now use the configured demeaner backend.
 - Fixes `confint()` when `keep` or `drop` requests coefficients in an order

--- a/docs/developer/architecture.md
+++ b/docs/developer/architecture.md
@@ -60,13 +60,11 @@ shared estimator API
   -> prepare_model_matrix
   -> estimator-specific get_fit
        -> feols / feiv
-            -> demean
-            -> to_array
-            -> drop_multicol_vars
-            -> wls_transform
-            -> solve OLS / 2SLS
+            -> construct within-scale arrays
+            -> drop collinear columns
+            -> solve OLS / 2SLS with local weight transforms
        -> fepois / feglm
-            -> IRLS with weighted demeaning and solving inside each iteration
+            -> IRLS with explicit observation and working weights
        -> quantreg
             -> Frisch-Newton solve (absorbed fixed effects are unsupported)
   -> vcov
@@ -77,12 +75,13 @@ shared estimator API
 `FixestMulti` is a container for fitted results. Numerical behavior belongs in
 the individual models and shared primitives, not in the container.
 
-## Current estimator-state lifecycle
+## Historical estimator-state lifecycle (pre-refactor)
 
-The fitted-model classes currently use themselves as both a work area and a
-result object. Several private attributes therefore change representation and
-numerical scale while a model is fitted. This section records that status quo;
-it is not a contract for new code.
+Before the immutable-state refactor, fitted-model classes used themselves as
+both a work area and a result object. Several private attributes therefore
+changed representation and numerical scale while a model was fitted. This
+section preserves that PR1 baseline as migration history; it is not the current
+contract for new code.
 
 For linear models, the transformations are:
 
@@ -189,10 +188,9 @@ the runner. Pipeline-object constructors only assemble configuration and child
 objects; for example, `QuantregMulti` prepares its children in
 `prepare_model_matrix`, not during construction.
 
-This is the representation foundation, not the final within/weight cleanup.
-The compatibility fields documented above still move through their established
-DataFrame, within-array, and solver-array states until the numerical primitives
-and inference consumers move to explicit within-scale inputs.
+This established the representation foundation. The within/weight cleanup
+described below completes that layer by moving numerical primitives and
+inference consumers to explicit within-scale inputs.
 
 ## Estimation-state vocabulary
 
@@ -214,6 +212,78 @@ arrays should not change type or numerical domain, and solver scratch should
 not replace canonical within data. A fitted result may still expose explicitly
 in-place post-estimation operations, but those operations must not repurpose
 estimation fields.
+
+## Implemented array and weight domains
+
+The shared linear and GLM paths now implement the vocabulary above with frozen,
+slotted state values:
+
+| State | Persisted contract |
+|---|---|
+| `FormulaData` | Formula-materialized pandas tables remain on formula scale and keep dependent, independent, fixed-effect, IV, weight, and offset roles separate. |
+| `ObservationWeights` | Canonical user-scale weights and their `aweights` or `fweights` semantics. `values=None` is the allocation-free unweighted path. |
+| `WithinLinearData` | Unpremultiplied within-scale arrays, with response, design, instruments, and endogenous variables in named roles. |
+| `GlmWorkingState` | Final within-scale working response and design, IRLS working weights, predictors, means, and response- and working-residual domains. |
+| `DemeanedData` | Array-native cache entries whose ordered column names are metadata rather than DataFrame conversions around each reuse. |
+
+Analytic weights keep the retained row count as the effective sample size;
+frequency weights use the sum of their user-scale values. Probability weights
+(`pweights`) remain unsupported. Fixed-effect projection may use observation or
+IRLS weights, but the returned arrays remain within scale. OLS, IV, and IRLS
+fit primitives create square-root-weighted design and response arrays only as
+local solver temporaries. They persist response-unit residuals and weighted
+scores or cross-products, not solver-scale copies of canonical data.
+Singleton fixed-effect detection also uses frequency totals, so an aggregate
+row with count greater than one is retained exactly as its literal expansion
+would be.
+
+GLMs keep two weight concepts deliberately separate. `ObservationWeights`
+never changes after formula preparation, while each IRLS iteration computes
+working weights and the final values live in `GlmWorkingState`. Response
+residuals and working residuals likewise have separate fields.
+
+The compatibility aliases are still available, but are published once in a
+stable post-fit domain rather than serving as cross-type workspaces. For linear
+and IV fits, `_Y`, `_X`, and `_Z` refer to within-scale arrays; for GLMs they
+refer to the final within-scale working response and design. `_weights` always
+means observation weights (and uses a ones array for the unweighted compatibility
+case), never square-root solver weights or GLM working weights. New code should
+consume the typed state values rather than infer semantics from these aliases.
+
+`ccv()` explicitly rejects weighted models. `update()` can compute and return
+coefficient-only Sherman-Morrison updates for unweighted, non-IV OLS without
+fixed effects, but rejects `inplace=True`: design rows alone cannot reconstruct
+the complete formula, prediction, inference, and performance state of a fitted
+result.
+Non-Poisson GLMs reject `CRV3` until their leave-cluster-out refits can retain
+the original family and solver configuration. Poisson keeps its dedicated,
+longstanding jackknife-refit path.
+Randomization inference rejects non-OLS/non-Poisson results, and the wild
+bootstrap rejects non-OLS results, so neither can silently reinterpret GLM
+working state or quantile solver outputs as linear-model arrays.
+Poisson CRV3 and slow randomization refits replay the original estimation
+options. A concrete LSMR preconditioner is the sole exception: because its
+factorization belongs to one fixed-effect design, refits preserve its variant
+but rebuild it for the changed row set.
+
+Storage policy follows the full result graph. Multiple-estimation containers do
+not retain their own data copy under `store_data=False` or `lean=True`; retained
+IV first stages honor `store_data=False`; and lean results discard within state,
+GLM working aliases, demeaning caches, quantile solver outputs, and large
+first-stage arrays. Array-only covariance updates remain available after
+`store_data=False`; cluster and HAC updates require the estimation sample through
+the documented `vcov(data=...)` argument. Explicit covariance data must already be
+filtered to the fitted row sample and retain its estimation order; a row-count
+check rejects misaligned inputs before covariance dispatch. Lean results reject
+post-fit covariance updates because their numerical arrays have been discarded.
+
+Keeping canonical arrays unpremultiplied favors readability without moving
+weight work out of the numerical hot path: each solver still performs the same
+vectorized square-root transform locally. The deterministic
+`benchmarks/weight_domain_benchmark.py` smoke and large profiles guard this
+tradeoff across OLS, fixed effects, IV, Poisson, and repeated covariance calls.
+Its default comparison limits common paths to 5% wall-time growth, inference
+paths to 10%, and allows no growth in retained NumPy buffers.
 
 ## Repository map and extension seams
 

--- a/docs/developer/testing.md
+++ b/docs/developer/testing.md
@@ -136,10 +136,17 @@ for example, 0.60.0 cannot parse current canonical `:` fixed-effect
 interactions. Do not create a synthetic baseline for such a path: classify it
 with the existing live-R evidence instead.
 Although 0.60.0 exposes a FEPoisson frequency-weight argument, its released
-IRLS path fails dimensionally. Current FEPoisson frequency weights remain a
-known skipped issue ([#367](https://github.com/py-econometrics/pyfixest/issues/367)),
-so they are deliberately outside this PR rather than represented by a
-synthetic release artifact or claimed live-R coverage.
+IRLS path fails dimensionally. The frozen 0.60.0 release contract therefore
+continues to exclude that path rather than inventing a synthetic artifact.
+Current FEPoisson frequency-weight behavior is instead covered by literal
+row-expansion tests in Python and against R `fixest`, including models with
+fixed effects and robust covariance ([#367](https://github.com/py-econometrics/pyfixest/issues/367)).
+Release 0.60.0 also detected fixed-effect singletons from physical row counts
+for OLS frequency weights. Current head counts the represented observations,
+matching literal expansion and R `fixest`. The snapshot contract keeps checking
+coefficients and sampled fitted quantities for the affected interaction cases,
+but narrowly omits their effective-sample metadata and derived inference; the
+literal-expansion and live-R tests are authoritative for that documented delta.
 
 `test-r-core` remains the convenient local aggregate for all canonical
 conda-forge R comparisons. CI partitions that population into

--- a/pyfixest/core/detect_singletons.py
+++ b/pyfixest/core/detect_singletons.py
@@ -4,7 +4,10 @@ from numpy.typing import NDArray
 from pyfixest.core._core_impl import _detect_singletons_rs
 
 
-def detect_singletons(ids: NDArray[np.integer]) -> NDArray[np.bool_]:
+def detect_singletons(
+    ids: NDArray[np.integer],
+    frequency_weights: NDArray[np.number] | None = None,
+) -> NDArray[np.bool_]:
     """
     Detect singleton fixed effects in a dataset.
 
@@ -19,6 +22,9 @@ def detect_singletons(ids: NDArray[np.integer]) -> NDArray[np.bool_]:
         A 2D numpy array representing fixed effects, with a shape of (n_samples,
         n_features).
         Elements should be non-negative integers representing fixed effect identifiers.
+    frequency_weights : np.ndarray or None, optional
+        Positive frequency counts for the physical rows. When provided, a fixed
+        effect is a singleton only when its active frequency total is one.
 
     Returns
     -------
@@ -59,6 +65,16 @@ def detect_singletons(ids: NDArray[np.integer]) -> NDArray[np.bool_]:
     if not np.issubdtype(ids.dtype, np.integer):
         raise TypeError("Fixed effects must be integers")
 
+    if frequency_weights is not None:
+        weights = np.asarray(frequency_weights, dtype=np.float64).reshape(-1)
+        if len(weights) != ids.shape[0]:
+            raise ValueError(
+                "Frequency weights must contain one value per fixed-effect row."
+            )
+        if not np.isfinite(weights).all() or np.any(weights <= 0):
+            raise ValueError("Frequency weights must be finite and strictly positive.")
+        return _detect_frequency_singletons(ids=ids, weights=weights)
+
     # Convert to uint32 F-contiguous array for optimal performance
     # (matches numba implementation behavior)
     # Using empty((m,n)).T gives F-order (n,m) layout
@@ -66,3 +82,35 @@ def detect_singletons(ids: NDArray[np.integer]) -> NDArray[np.bool_]:
     out: NDArray[np.uint32] = np.empty((m, n), dtype=np.uint32).T
     out[:] = ids
     return _detect_singletons_rs(out)
+
+
+def _detect_frequency_singletons(
+    *,
+    ids: NDArray[np.integer],
+    weights: NDArray[np.float64],
+) -> NDArray[np.bool_]:
+    """Detect cascading singleton groups using expanded-sample row counts."""
+    dropped = np.zeros(ids.shape[0], dtype=bool)
+
+    while True:
+        changed = False
+        for column in range(ids.shape[1]):
+            active_rows = np.flatnonzero(~dropped)
+            if active_rows.size == 0:
+                return dropped
+
+            _, inverse = np.unique(
+                ids[active_rows, column],
+                return_inverse=True,
+            )
+            group_frequency = np.bincount(
+                inverse,
+                weights=weights[active_rows],
+            )
+            newly_dropped = group_frequency[inverse] <= 1.0
+            if np.any(newly_dropped):
+                dropped[active_rows[newly_dropped]] = True
+                changed = True
+
+        if not changed:
+            return dropped

--- a/pyfixest/estimation/FixestMulti_.py
+++ b/pyfixest/estimation/FixestMulti_.py
@@ -13,6 +13,7 @@ from pyfixest.estimation.models.feiv_ import Feiv
 from pyfixest.estimation.models.feols_ import Feols
 from pyfixest.estimation.models.fepois_ import Fepois
 from pyfixest.estimation.plan_ import ParsedFormula
+from pyfixest.utils.dev_utils import DataFrameType, _narwhals_to_pandas
 
 
 class FixestMulti(TidyColumnAccessors):
@@ -120,7 +121,8 @@ class FixestMulti(TidyColumnAccessors):
         self,
         vcov: str | dict[str, str],
         vcov_kwargs: dict[str, str | int] | None = None,
-    ):
+        data: DataFrameType | None = None,
+    ) -> FixestMulti:
         """
         Update regression inference "on the fly".
 
@@ -138,13 +140,54 @@ class FixestMulti(TidyColumnAccessors):
             for CRV1 inference or {"CRV3": "clustervar"} for CRV3 inference.
         vcov_kwargs : Optional[dict[str, any]]
              Additional keyword arguments for the variance-covariance matrix.
+        data : DataFrameType, optional
+            The common, already-filtered estimation sample in its original order.
+            Required for data-dependent covariance updates when the fitted models
+            were created with `store_data=False`. Defaults to None.
 
         Returns
         -------
-            An instance of the "Fixest" class with updated inference.
+        FixestMulti
+            This result container with updated inference.
         """
+        data_to_forward = data
+        if data is not None:
+            try:
+                data_to_forward = _narwhals_to_pandas(data)
+            except TypeError as exc:
+                raise TypeError(
+                    f"The data set must be a DataFrame type. Received: {type(data)}"
+                ) from exc
+
+            models = list(self.all_fitted_models.values())
+            expected_rows = sorted({model._N_rows for model in models})
+            received_rows = len(data_to_forward)
+            if any(n_rows != received_rows for n_rows in expected_rows):
+                raise ValueError(
+                    "`data` passed to FixestMulti.vcov() must contain the common, "
+                    "already-filtered estimation sample in its original order for "
+                    "every child model; expected child row counts "
+                    f"{expected_rows}, received {received_rows}. Fetch each child "
+                    "model and call vcov(..., data=...) separately when estimation "
+                    "samples differ."
+                )
+
+            reference = models[0] if models else None
+            if reference is not None and any(
+                model._sample_split_var != reference._sample_split_var
+                or model._sample_split_value != reference._sample_split_value
+                or model._na_index != reference._na_index
+                for model in models[1:]
+            ):
+                raise ValueError(
+                    "`data` cannot be forwarded by FixestMulti.vcov() because its "
+                    "child models use different estimation samples. Fetch each "
+                    "child model and call vcov(..., data=...) with that model's "
+                    "already-filtered estimation sample instead."
+                )
+
         for fxst in self.all_fitted_models.values():
-            fxst.vcov(vcov=vcov, vcov_kwargs=vcov_kwargs)
+            fxst.vcov(vcov=vcov, vcov_kwargs=vcov_kwargs, data=data_to_forward)
         return self
 
     def tidy(self) -> pd.DataFrame:

--- a/pyfixest/estimation/FixestMulti_.py
+++ b/pyfixest/estimation/FixestMulti_.py
@@ -67,10 +67,11 @@ class FixestMulti(TidyColumnAccessors):
         context : Mapping[str, Any]
             Captured evaluation scope (from `capture_context`).
         """
-        self._config = config
         self._parsed = parsed
-        self._data = data
-        self._context = context
+        if config.store_data and not config.lean:
+            self._config = config
+            self._data = data
+            self._context = context
 
         self.all_fitted_models: dict[str, Feols | Fepois | Feiv] = {}
 

--- a/pyfixest/estimation/formula/model_matrix.py
+++ b/pyfixest/estimation/formula/model_matrix.py
@@ -16,6 +16,7 @@ from pyfixest.estimation.formula import FORMULAIC_FEATURE_FLAG, FORMULAIC_TRANSF
 from pyfixest.estimation.formula.formulaic_compat import flatten_model_matrix
 from pyfixest.estimation.formula.parse import Formula
 from pyfixest.estimation.formula.utils import _get_weights
+from pyfixest.estimation.internals.literals import WeightsTypeOptions
 from pyfixest.utils.utils import capture_context
 
 _ModelSpecMapping: TypeAlias = Mapping[str, formulaic.ModelSpec]
@@ -113,13 +114,17 @@ class ModelMatrix:
         drop_rows: frozenset[int],
         drop_singletons: bool = True,
         drop_intercept: bool = False,
+        weights_type: WeightsTypeOptions | None = None,
     ) -> None:
         self._drop_intercept = drop_intercept
         self._model_spec = cast(_ModelSpecMapping, model_matrix.model_spec)
         self._na_index = drop_rows
         self._collect_columns(model_matrix)
         self._collect_data(model_matrix)
-        self._process(drop_singletons=drop_singletons)
+        self._process(
+            drop_singletons=drop_singletons,
+            weights_type=weights_type,
+        )
 
     @staticmethod
     def _get_columns(mm: formulaic.ModelMatrix, *keys: str) -> list[str] | None:
@@ -154,7 +159,11 @@ class ModelMatrix:
         data = pd.concat(datas, ignore_index=False, axis=1)
         self._data = data.loc[:, ~data.columns.duplicated()]
 
-    def _process(self, drop_singletons: bool = False) -> None:
+    def _process(
+        self,
+        drop_singletons: bool = False,
+        weights_type: WeightsTypeOptions | None = None,
+    ) -> None:
         if self.model_spec[_ModelMatrixKey.main].lhs.factor_contrasts:
             raise TypeError("The dependent variable must be numeric.")
         elif self._dependent is None or len(self._dependent) != 1:
@@ -200,8 +209,16 @@ class ModelMatrix:
         # Drop singletons if specified
         if drop_singletons and self._fixed_effects is not None:
             fixed_effects = self._data.loc[:, self._fixed_effects]
+            frequency_weights = (
+                self._data.loc[:, self._weights].to_numpy().reshape(-1)
+                if weights_type == "fweights" and self._weights is not None
+                else None
+            )
             self._drop(
-                detect_singletons(fixed_effects.to_numpy()),
+                detect_singletons(
+                    fixed_effects.to_numpy(),
+                    frequency_weights=frequency_weights,
+                ),
                 "singleton fixed effect(s)",
             )
 
@@ -371,6 +388,8 @@ def create_model_matrix(
     drop_intercept: bool = False,
     ensure_full_rank: bool = True,
     context: int | Mapping[str, Any] = 0,
+    *,
+    weights_type: WeightsTypeOptions | None = None,
 ) -> ModelMatrix:
     """
     Create a ModelMatrix from a formula and data.
@@ -409,6 +428,9 @@ def create_model_matrix(
         Additional context variables for formulaic during model matrix creation.
         Can be an integer (stack frame depth) or a dictionary of variables to
         make available in the formula environment (e.g., custom transformations).
+    weights_type : {"aweights", "fweights"} or None, default=None
+        Weight semantics used when detecting singleton fixed effects. Frequency
+        weights count literal replications; analytic weights do not.
 
     Returns
     -------
@@ -451,6 +473,7 @@ def create_model_matrix(
         drop_rows=drop_rows,
         drop_singletons=drop_singletons,
         drop_intercept=drop_intercept,
+        weights_type=weights_type,
     )
 
 

--- a/pyfixest/estimation/internals/demean_.py
+++ b/pyfixest/estimation/internals/demean_.py
@@ -1,8 +1,25 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+
 import numpy as np
-import pandas as pd
+from numpy.typing import NDArray
 
 from pyfixest.core.demean import Preconditioner
 from pyfixest.demeaners import AnyDemeaner
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class DemeanedData:
+    """Array-native cache entry for named, demeaned columns.
+
+    ``columns`` records the insertion order of the columns in ``values``.
+    Cached arrays are treated as read-only after publication.
+    """
+
+    values: NDArray[np.float64]
+    columns: tuple[str, ...]
 
 
 class DemeanCache:
@@ -10,7 +27,7 @@ class DemeanCache:
 
     `Compute once, never forget`:
 
-    - `lookup_demeaned_data`: already-demeaned columns from previous fits.
+    - `lookup_demeaned_data`: already-demeaned named arrays from previous fits.
     - `lookup_preconditioner`: the preconditioner from the first fit on a
        data set / na index combination.
 
@@ -23,13 +40,13 @@ class DemeanCache:
 
     def __init__(
         self,
-        lookup_demeaned_data: dict[frozenset[int], pd.DataFrame] | None = None,
+        lookup_demeaned_data: dict[frozenset[int], DemeanedData] | None = None,
         lookup_preconditioner: dict[frozenset[int], Preconditioner] | None = None,
     ) -> None:
-        self.lookup_demeaned_data: dict[frozenset[int], pd.DataFrame] = (
+        self.lookup_demeaned_data = (
             {} if lookup_demeaned_data is None else lookup_demeaned_data
         )
-        self.lookup_preconditioner: dict[frozenset[int], Preconditioner] = (
+        self.lookup_preconditioner = (
             {} if lookup_preconditioner is None else lookup_preconditioner
         )
 
@@ -81,62 +98,105 @@ class DemeanCache:
 
     def demean_yx(
         self,
-        Y: pd.DataFrame,
-        X: pd.DataFrame,
-        fe: pd.DataFrame | None,
-        weights: np.ndarray | None,
+        Y: NDArray[np.float64],
+        X: NDArray[np.float64],
+        *,
+        y_names: Sequence[str],
+        x_names: Sequence[str],
+        fe: np.ndarray | None,
+        weights: NDArray[np.float64] | None,
         na_index: frozenset[int],
         demeaner: AnyDemeaner,
-    ) -> tuple[pd.DataFrame, pd.DataFrame, Preconditioner | None]:
-        """Demean a regression model: check cache, demean what's missing, update cache.
+    ) -> tuple[
+        NDArray[np.float64],
+        NDArray[np.float64],
+        Preconditioner | None,
+    ]:
+        """Demean response and design arrays and cache missing named columns.
 
-        Prior to demeaning, checks whether some of the variables have already
-        been demeaned and reuses values from `self.lookup_demeaned_data` if
-        possible. If the model has no fixed effects, the data is returned
-        undemeaned.
+        The cache stays array-native. Column names are carried separately so
+        multiple-estimation fits can reuse matching columns without converting
+        solver arrays back into DataFrames. New columns are demeaned and appended
+        in their requested order; cache hits never reorder or discard earlier
+        columns.
+
+        Parameters
+        ----------
+        Y : NDArray[np.float64]
+            Response array, shape ``(n_rows, n_responses)``.
+        X : NDArray[np.float64]
+            Design array, shape ``(n_rows, n_regressors)``.
+        y_names : Sequence[str]
+            Ordered response names corresponding to the columns of ``Y``.
+        x_names : Sequence[str]
+            Ordered regressor names corresponding to the columns of ``X``.
+        fe : np.ndarray or None
+            Encoded fixed-effect identifiers, or ``None`` for no fixed effects.
+        weights : NDArray[np.float64] or None
+            Observation weights passed to the within transformation.
+        na_index : frozenset[int]
+            Row-removal identity used to share cached data between model fits.
+        demeaner : AnyDemeaner
+            Configured within-transformation strategy.
 
         Returns
         -------
-        tuple[pd.DataFrame, pd.DataFrame, Preconditioner | None]
-            The demeaned `Y`, the demeaned `X`, and the within
-            preconditioner used during the solve (`None` for non-within
-            backends, `preconditioner='off'`, the single-FE MAP fallback,
-            or when no demeaning happened).
+        tuple[NDArray[np.float64], NDArray[np.float64], Preconditioner or None]
+            Demeaned response and design arrays, in their requested column order,
+            plus the preconditioner used when new columns were transformed.
         """
-        used: Preconditioner | None = None
-        YX = pd.concat([Y, X], axis=1)
-        yx_names = YX.columns
-        YX_array = YX.to_numpy()
-        if YX_array.dtype != np.dtype("float64"):
-            YX_array = YX_array.astype(np.float64)
-
+        Y_array = np.asarray(Y, dtype=np.float64)
+        X_array = np.asarray(X, dtype=np.float64)
         if fe is None:
-            YX_demeaned = pd.DataFrame(YX_array, columns=yx_names)
-            return YX_demeaned[Y.columns], YX_demeaned[X.columns], None
+            return Y_array, X_array, None
 
-        fe_array = fe.to_numpy()
-        cached_demeaned = self.lookup_demeaned_data.get(na_index)
-        if cached_demeaned is None:
-            arr, used = self._run_or_raise(
-                YX_array, fe_array, weights, na_index, demeaner
+        y_names_tuple = tuple(y_names)
+        x_names_tuple = tuple(x_names)
+        requested_names = y_names_tuple + x_names_tuple
+        YX_array = np.concatenate((Y_array, X_array), axis=1)
+
+        cached = self.lookup_demeaned_data.get(na_index)
+        used: Preconditioner | None = None
+        if cached is None:
+            requested_values, used = self._run_or_raise(
+                YX_array, fe, weights, na_index, demeaner
             )
-            YX_demeaned = pd.DataFrame(arr, columns=yx_names)
+            cached = DemeanedData(
+                values=requested_values,
+                columns=requested_names,
+            )
+            self.lookup_demeaned_data[na_index] = cached
         else:
-            # demean only the not-yet-demeaned columns
-            new_names = list(set(yx_names) - set(cached_demeaned.columns))
-            if new_names:
-                yx_names_list = list(yx_names)
-                new_index = [yx_names_list.index(name) for name in new_names]
-                arr, used = self._run_or_raise(
-                    YX_array[:, new_index], fe_array, weights, na_index, demeaner
+            cached_names = frozenset(cached.columns)
+            new_positions = tuple(
+                index
+                for index, name in enumerate(requested_names)
+                if name not in cached_names
+            )
+            if new_positions:
+                new_values, used = self._run_or_raise(
+                    YX_array[:, new_positions], fe, weights, na_index, demeaner
                 )
-                YX_demeaned = pd.DataFrame(
-                    np.concatenate([cached_demeaned, arr], axis=1),
-                    columns=list(cached_demeaned.columns) + new_names,
+                cached = DemeanedData(
+                    values=np.concatenate((cached.values, new_values), axis=1),
+                    columns=cached.columns
+                    + tuple(requested_names[index] for index in new_positions),
                 )
-            else:
-                # all variables already demeaned
-                YX_demeaned = cached_demeaned[yx_names]
+                self.lookup_demeaned_data[na_index] = cached
+            requested_values = self._select_columns(cached, requested_names)
 
-        self.lookup_demeaned_data[na_index] = YX_demeaned
-        return YX_demeaned[Y.columns], YX_demeaned[X.columns], used
+        n_y = len(y_names_tuple)
+        return requested_values[:, :n_y], requested_values[:, n_y:], used
+
+    @staticmethod
+    def _select_columns(
+        cached: DemeanedData,
+        requested_names: tuple[str, ...],
+    ) -> NDArray[np.float64]:
+        positions_by_name = {
+            name: position for position, name in enumerate(cached.columns)
+        }
+        positions = tuple(positions_by_name[name] for name in requested_names)
+        if positions == tuple(range(len(positions))):
+            return cached.values[:, : len(positions)]
+        return cached.values[:, positions]

--- a/pyfixest/estimation/internals/fit_.py
+++ b/pyfixest/estimation/internals/fit_.py
@@ -17,15 +17,15 @@ class OlsFit:
     beta : np.ndarray
         Coefficient estimates, shape (k,).
     residuals : np.ndarray
-        Residuals Y - X @ beta, shape (N,).
+        Response-scale residuals Y - X @ beta, shape (N,).
     scores : np.ndarray
-        Score matrix X * residuals, shape (N, k).
+        Weighted score matrix W X * residuals, shape (N, k).
     hessian : np.ndarray
-        Hessian X'X, shape (k, k).
+        Weighted Hessian X' W X, shape (k, k).
     tZX : np.ndarray
-        Z'X (= X'X for OLS), shape (k, k).
+        Z'X (= X' W X for OLS), shape (k, k).
     tZy : np.ndarray
-        Z'Y (= X'Y for OLS), shape (k, 1).
+        Z'Y (= X' W Y for OLS), shape (k, 1).
     """
 
     beta: np.ndarray
@@ -38,26 +38,26 @@ class OlsFit:
 
 @dataclass(frozen=True, slots=True)
 class IvFit:
-    """Result of a 2SLS fit.
+    """Result of a (weighted) 2SLS fit.
 
     Attributes
     ----------
     beta : np.ndarray
         Coefficient estimates, shape (k,).
     residuals : np.ndarray
-        Second-stage residuals Y - X @ beta, shape (N,).
+        Response-scale second-stage residuals Y - X @ beta, shape (N,).
     scores : np.ndarray
-        Score matrix Z * residuals, shape (N, k_z).
+        Weighted score matrix W Z * residuals, shape (N, k_z).
     hessian : np.ndarray
-        Z'Z, shape (k_z, k_z).
+        Weighted instrument cross-product Z' W Z, shape (k_z, k_z).
     tZX : np.ndarray
-        Z'X, shape (k_z, k).
+        Weighted cross-product Z' W X, shape (k_z, k).
     tXZ : np.ndarray
-        X'Z, shape (k, k_z).
+        Weighted cross-product X' W Z, shape (k, k_z).
     tZy : np.ndarray
-        Z'Y, shape (k_z, 1).
+        Weighted cross-product Z' W Y, shape (k_z, 1).
     tZZinv : np.ndarray
-        (Z'Z)^{-1}, shape (k_z, k_z).
+        (Z' W Z)^{-1}, shape (k_z, k_z).
     """
 
     beta: np.ndarray
@@ -73,24 +73,43 @@ class IvFit:
 def fit_ols(
     X: np.ndarray,
     Y: np.ndarray,
+    *,
+    weights: np.ndarray | None = None,
     solver: SolverOptions = "np.linalg.solve",
 ) -> OlsFit:
-    """Fit a least-squares model on prepared arrays.
+    """Fit OLS/WLS while keeping inputs and residuals in response scale.
 
     Parameters
     ----------
     X : np.ndarray
-        Design matrix, shape (N, k). Demeaned and WLS-transformed.
+        Design matrix, shape (N, k). Demeaned but not WLS-transformed.
     Y : np.ndarray
-        Dependent variable, shape (N, 1). Demeaned and WLS-transformed.
+        Dependent variable, shape (N, 1). Demeaned but not WLS-transformed.
+    weights : np.ndarray or None
+        Non-negative observation weights, shape (N,) or (N, 1). ``None``
+        selects the unweighted path without creating unit weights or transformed
+        copies. Otherwise, the square-root transform is local to this function.
     solver : SolverOptions
         Solver passed through to ``solve_ols``.
     """
-    tZX = X.T @ X
-    tZy = X.T @ Y
+    if weights is None:
+        X_solver = X
+        Y_solver = Y
+        weight_values = None
+    else:
+        weight_values = weights.reshape(-1)
+        sqrt_weights = np.sqrt(weight_values)[:, None]
+        X_solver = X * sqrt_weights
+        Y_solver = Y * sqrt_weights
+
+    tZX = X_solver.T @ X_solver
+    tZy = X_solver.T @ Y_solver
     beta = solve_ols(tZX, tZy, solver)
     residuals = Y.flatten() - (X @ beta).flatten()
-    scores = X * residuals[:, None]
+    if weight_values is None:
+        scores = X * residuals[:, None]
+    else:
+        scores = X * (weight_values * residuals)[:, None]
     hessian = tZX.copy()
     return OlsFit(
         beta=beta,
@@ -106,26 +125,44 @@ def fit_iv(
     X: np.ndarray,
     Z: np.ndarray,
     Y: np.ndarray,
+    *,
+    weights: np.ndarray | None = None,
     solver: SolverOptions = "np.linalg.solve",
 ) -> IvFit:
-    """Fit a 2SLS model on prepared arrays.
+    """Fit 2SLS while keeping inputs and residuals in response scale.
 
     Parameters
     ----------
     X : np.ndarray
         Design matrix (incl. endogenous regressors), shape (N, k).
-        Demeaned and WLS-transformed.
+        Demeaned but not WLS-transformed.
     Z : np.ndarray
-        Instrument matrix, shape (N, k_z). Demeaned and WLS-transformed.
+        Instrument matrix, shape (N, k_z). Demeaned but not WLS-transformed.
     Y : np.ndarray
-        Dependent variable, shape (N, 1). Demeaned and WLS-transformed.
+        Dependent variable, shape (N, 1). Demeaned but not WLS-transformed.
+    weights : np.ndarray or None
+        Non-negative observation weights, shape (N,) or (N, 1). ``None``
+        selects the unweighted path without creating unit weights or transformed
+        copies. Otherwise, the square-root transform is local to this function.
     solver : SolverOptions
         Solver passed through to ``solve_ols``.
     """
-    tZX = Z.T @ X
-    tXZ = X.T @ Z
-    tZy = Z.T @ Y
-    tZZ = Z.T @ Z
+    if weights is None:
+        X_solver = X
+        Z_solver = Z
+        Y_solver = Y
+        weight_values = None
+    else:
+        weight_values = weights.reshape(-1)
+        sqrt_weights = np.sqrt(weight_values)[:, None]
+        X_solver = X * sqrt_weights
+        Z_solver = Z * sqrt_weights
+        Y_solver = Y * sqrt_weights
+
+    tZX = Z_solver.T @ X_solver
+    tXZ = X_solver.T @ Z_solver
+    tZy = Z_solver.T @ Y_solver
+    tZZ = Z_solver.T @ Z_solver
     tZZinv = np.linalg.inv(tZZ)
 
     H = tXZ @ tZZinv
@@ -134,7 +171,10 @@ def fit_iv(
     beta = solve_ols(A, B, solver)
 
     residuals = Y.flatten() - (X @ beta).flatten()
-    scores = Z * residuals[:, None]
+    if weight_values is None:
+        scores = Z * residuals[:, None]
+    else:
+        scores = Z * (weight_values * residuals)[:, None]
     hessian = tZZ
 
     return IvFit(

--- a/pyfixest/estimation/internals/fit_glm_.py
+++ b/pyfixest/estimation/internals/fit_glm_.py
@@ -9,6 +9,7 @@ from pyfixest.errors import NonConvergenceError
 from pyfixest.estimation.internals.collinearity import drop_multicollinear_variables
 from pyfixest.estimation.internals.families import GlmFamily
 from pyfixest.estimation.internals.literals import SolverOptions
+from pyfixest.estimation.internals.model_state import GlmWorkingState
 from pyfixest.estimation.internals.solvers import solve_ols
 
 DemeanFn = Callable[
@@ -25,18 +26,9 @@ class GlmFit:
     ----------
     beta : np.ndarray
         Coefficient estimates, shape (k,).
-    eta : np.ndarray
-        Final linear predictor (link scale), shape (N,).
-    mu : np.ndarray
-        Final fitted mean (response scale), shape (N,).
-    W : np.ndarray
-        Final IRLS weights, shape (N,).
-    sqrt_W : np.ndarray
-        Square root of W, shape (N,).
-    z_tilde : np.ndarray
-        Final demeaned working response, shape (N,).
-    X_tilde : np.ndarray
-        Final demeaned design matrix, shape (N, k).
+    working_state : GlmWorkingState
+        Final within-scale IRLS inputs, weights, fitted values, and residuals.
+        Square-root-weighted solver arrays are deliberately not retained.
     X : np.ndarray
         The (un-demeaned) design matrix with collinear columns dropped, shape (N, k).
     deviance : float
@@ -55,12 +47,7 @@ class GlmFit:
     """
 
     beta: np.ndarray
-    eta: np.ndarray
-    mu: np.ndarray
-    W: np.ndarray
-    sqrt_W: np.ndarray
-    z_tilde: np.ndarray
-    X_tilde: np.ndarray
+    working_state: GlmWorkingState
     X: np.ndarray
     deviance: float
     converged: bool
@@ -178,7 +165,7 @@ def fit_glm_irls(
     Y_flat = Y.flatten()
     N = Y_flat.shape[0]
     offset_flat = offset.flatten() if offset is not None else np.zeros(N)
-    weights_flat = weights.flatten() if weights is not None else np.ones(N)
+    observation_weights_flat = weights.flatten() if weights is not None else np.ones(N)
 
     mu = family.mu_start(Y, weights)
     eta = family.link(mu)
@@ -200,8 +187,7 @@ def fit_glm_irls(
     beta_final: np.ndarray
     z_tilde_final: np.ndarray
     X_tilde_final: np.ndarray
-    W_final: np.ndarray
-    sqrt_W_final: np.ndarray
+    working_weights_final: np.ndarray
     r = 0
 
     for r in range(maxiter):
@@ -224,8 +210,8 @@ def fit_glm_irls(
                 inner_tol = inner_tol / 10
 
         gprime = family.gprime(mu)
-        W = weights_flat / (gprime**2 * family.variance(mu))
-        sqrt_W = np.sqrt(W)
+        working_weights = observation_weights_flat / (gprime**2 * family.variance(mu))
+        sqrt_working_weights = np.sqrt(working_weights)
 
         z = (eta - offset_flat) + (Y_flat - mu) * gprime
 
@@ -238,7 +224,12 @@ def fit_glm_irls(
             z_input = z
             X_input = X_eff
 
-        z_tilde, X_tilde = demean(z_input, X_input, W.flatten(), inner_tol)
+        z_tilde, X_tilde = demean(
+            z_input,
+            X_input,
+            working_weights.flatten(),
+            inner_tol,
+        )
 
         if r == 0:
             X_tilde, coefnames, collin_vars, collin_index = (
@@ -247,10 +238,14 @@ def fit_glm_irls(
             if collin_index:
                 X_eff = X_eff[:, ~np.array(collin_index)]
 
-        WX = sqrt_W.flatten()[:, None] * X_tilde
-        WZ = sqrt_W.flatten() * z_tilde
+        design_solver = sqrt_working_weights.flatten()[:, None] * X_tilde
+        response_solver = sqrt_working_weights.flatten() * z_tilde
 
-        beta = solve_ols(WX.T @ WX, WX.T @ WZ, solver)
+        beta = solve_ols(
+            design_solver.T @ design_solver,
+            design_solver.T @ response_solver,
+            solver,
+        )
 
         e_new = z_tilde - X_tilde @ beta
         eta_new = (z - e_new) + offset_flat
@@ -285,8 +280,7 @@ def fit_glm_irls(
         beta_final = beta
         z_tilde_final = z_tilde
         X_tilde_final = X_tilde
-        W_final = W
-        sqrt_W_final = sqrt_W
+        working_weights_final = working_weights
 
     if not converged:
         if not step_halved_prev:
@@ -299,14 +293,20 @@ def fit_glm_irls(
         if not converged:
             _raise_non_convergence(maxiter)
 
+    working_residuals = z_tilde_final - X_tilde_final @ beta_final
+    working_state = GlmWorkingState(
+        working_response_within=z_tilde_final,
+        design_within=X_tilde_final,
+        working_weights=working_weights_final.flatten(),
+        eta=eta.flatten(),
+        mu=mu.flatten(),
+        response_residuals=Y_flat - mu.flatten(),
+        working_residuals=working_residuals.flatten(),
+    )
+
     return GlmFit(
         beta=beta_final,
-        eta=eta,
-        mu=mu,
-        W=W_final,
-        sqrt_W=sqrt_W_final,
-        z_tilde=z_tilde_final,
-        X_tilde=X_tilde_final,
+        working_state=working_state,
         X=X_eff,
         deviance=deviance,
         converged=converged,

--- a/pyfixest/estimation/internals/model_state.py
+++ b/pyfixest/estimation/internals/model_state.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+from numpy.typing import NDArray
+
+from pyfixest.estimation.internals.literals import WeightsTypeOptions
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class ObservationWeights:
+    """Canonical observation weights retained by a fitted model.
+
+    ``values`` are always the user-scale weights, never their square roots or
+    an estimator-specific working weight.  ``None`` is the explicit unweighted
+    fast path: callers must not allocate a vector of ones merely to represent
+    an unweighted fit.
+
+    Parameters
+    ----------
+    values : NDArray[np.float64] or None
+        Flat, user-scale observation weights. ``None`` for an unweighted fit.
+    kind : {"aweights", "fweights"} or None
+        Weight semantics. ``None`` for an unweighted fit.
+    n_rows : int
+        Number of physical rows used for estimation.
+    n_effective : int or float
+        Effective observation count: ``n_rows`` for unweighted fits and
+        analytic weights, and ``sum(values)`` for frequency weights.
+    """
+
+    values: NDArray[np.float64] | None
+    kind: WeightsTypeOptions | None
+    n_rows: int
+    n_effective: int | float
+
+    def __post_init__(self) -> None:
+        if self.n_rows < 0:
+            raise ValueError("n_rows must be non-negative.")
+
+        if self.values is None:
+            if self.kind is not None:
+                raise ValueError("Unweighted observations cannot have a weight kind.")
+            if self.n_effective != self.n_rows:
+                raise ValueError(
+                    "Unweighted observations must have n_effective equal to n_rows."
+                )
+            return
+
+        if self.kind is None:
+            raise ValueError("Weighted observations must declare a weight kind.")
+        if self.kind not in ("aweights", "fweights"):
+            raise ValueError("Weight kind must be 'aweights' or 'fweights'.")
+        if self.values.ndim != 1:
+            raise ValueError("Observation weight values must be a flat array.")
+        if len(self.values) != self.n_rows:
+            raise ValueError("Observation weights must contain one value per row.")
+
+        expected_n = (
+            self.n_rows if self.kind == "aweights" else float(np.sum(self.values))
+        )
+        if self.n_effective != expected_n:
+            raise ValueError("n_effective must match the observation-weight semantics.")
+
+    @classmethod
+    def unweighted(cls, *, n_rows: int) -> ObservationWeights:
+        """Construct the allocation-free representation of an unweighted fit."""
+        return cls(
+            values=None,
+            kind=None,
+            n_rows=n_rows,
+            n_effective=n_rows,
+        )
+
+    @classmethod
+    def from_values(
+        cls,
+        values: NDArray[np.float64],
+        *,
+        kind: WeightsTypeOptions,
+    ) -> ObservationWeights:
+        """Construct canonical weighted state from user-scale values."""
+        canonical_values = np.asarray(values, dtype=np.float64).reshape(-1)
+        n_rows = len(canonical_values)
+        n_effective = n_rows if kind == "aweights" else float(np.sum(canonical_values))
+        return cls(
+            values=canonical_values,
+            kind=kind,
+            n_rows=n_rows,
+            n_effective=n_effective,
+        )
+
+    @property
+    def is_weighted(self) -> bool:
+        """Whether this state contains user-supplied observation weights."""
+        return self.values is not None
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class WithinLinearData:
+    """Linear-model arrays after within transformation, in original units.
+
+    These arrays have not been multiplied by square-root observation weights.
+    Optional IV roles are kept separate so their econometric meaning remains
+    visible throughout the estimator lifecycle.
+    """
+
+    response: NDArray[np.float64]
+    design: NDArray[np.float64]
+    instruments: NDArray[np.float64] | None = None
+    endogenous: NDArray[np.float64] | None = None
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class GlmWorkingState:
+    """Final GLM IRLS state in within scale.
+
+    ``working_weights`` are the final IRLS weights themselves.  Square-root
+    weighted arrays are solver-local temporaries and deliberately absent.
+    """
+
+    working_response_within: NDArray[np.float64]
+    design_within: NDArray[np.float64]
+    working_weights: NDArray[np.float64]
+    eta: NDArray[np.float64]
+    mu: NDArray[np.float64]
+    response_residuals: NDArray[np.float64]
+    working_residuals: NDArray[np.float64]

--- a/pyfixest/estimation/internals/vcov_.py
+++ b/pyfixest/estimation/internals/vcov_.py
@@ -30,9 +30,22 @@ def _sandwich(
     return bread @ projected_meat @ bread
 
 
-def vcov_iid_ols(residuals: np.ndarray, bread: np.ndarray, N: int) -> np.ndarray:
-    "IID Variance-Covariance Matrix for OLS."
-    sigma2 = np.sum(residuals.flatten() ** 2) / (N - 1)
+def vcov_iid_ols(
+    residuals: np.ndarray,
+    bread: np.ndarray,
+    N: int | float,
+    weights: np.ndarray | None = None,
+) -> np.ndarray:
+    """Compute IID OLS covariance from response-scale residuals.
+
+    ``weights=None`` selects the allocation-free unweighted path. Otherwise,
+    the residual sum of squares is evaluated in the weighted estimating
+    equation without materializing square-root-weighted residuals.
+    """
+    squared_residuals = residuals.flatten() ** 2
+    if weights is not None:
+        squared_residuals = weights.flatten() * squared_residuals
+    sigma2 = np.sum(squared_residuals) / (N - 1)
     return bread * sigma2
 
 
@@ -46,6 +59,7 @@ def vcov_hetero(
     X: np.ndarray,
     tZX: np.ndarray,
     weights: np.ndarray,
+    leverage_weights: np.ndarray | None,
     weights_type: WeightsTypeOptions | None,
     vcov_type_detail: HeteroVcovTypeOptions,
     bread: np.ndarray,
@@ -58,6 +72,8 @@ def vcov_hetero(
         transformed_scores = scores
     elif vcov_type_detail in ["HC2", "HC3"]:
         leverage = np.sum(X * (X @ np.linalg.inv(tZX)), axis=1)
+        if leverage_weights is not None:
+            leverage = leverage_weights.flatten() * leverage
         if weights_type == "fweights":
             leverage = leverage / weights.flatten()
         transformed_scores = (
@@ -187,20 +203,31 @@ def _jackknife_vcov(beta_jack: np.ndarray, beta_center: np.ndarray) -> np.ndarra
 def vcov_crv3_fast(
     X: np.ndarray,
     Y: np.ndarray,
+    weights: np.ndarray | None,
     beta_hat: np.ndarray,
     clustid: np.ndarray,
     cluster_col: np.ndarray,
 ) -> np.ndarray:
-    "Unscaled CRV3 vcov via the closed-form cluster jackknife (no fixed effects)."
+    """Compute unscaled CRV3 from within-scale arrays without retaining WLS data."""
     beta_jack = np.zeros((len(clustid), X.shape[1]))
 
-    tXX = X.T @ X
-    tXy = X.T @ Y
+    if weights is None:
+        X_solver = X
+        Y_solver = Y.reshape(-1, 1)
+    else:
+        sqrt_weights = np.sqrt(weights).reshape(-1, 1)
+        X_solver = X * sqrt_weights
+        Y_solver = Y.reshape(-1, 1) * sqrt_weights
+
+    tXX = X_solver.T @ X_solver
+    tXy = X_solver.T @ Y_solver
 
     for ixg, g in enumerate(clustid):
-        Xg = X[np.equal(g, cluster_col)]
-        Yg = Y[np.equal(g, cluster_col)]
+        group = np.equal(g, cluster_col)
+        Xg = X_solver[group]
+        Yg = Y_solver[group]
         tXgXg = Xg.T @ Xg
-        beta_jack[ixg, :] = (np.linalg.pinv(tXX - tXgXg) @ (tXy - Xg.T @ Yg)).flatten()
+        tXgyg = Xg.T @ Yg
+        beta_jack[ixg, :] = (np.linalg.pinv(tXX - tXgXg) @ (tXy - tXgyg)).flatten()
 
     return _jackknife_vcov(beta_jack=beta_jack, beta_center=beta_hat)

--- a/pyfixest/estimation/models/_result_accessor_mixin.py
+++ b/pyfixest/estimation/models/_result_accessor_mixin.py
@@ -10,6 +10,10 @@ from pyfixest.errors import EmptyVcovError
 
 if TYPE_CHECKING:
     from pyfixest.estimation.internals.families import InferenceDist
+    from pyfixest.estimation.internals.model_state import (
+        ObservationWeights,
+        WithinLinearData,
+    )
 from pyfixest.estimation.internals.literals import (
     InferenceType,
     _validate_literal_argument,
@@ -129,8 +133,10 @@ class ResultAccessorMixin(TidyColumnAccessors):
     _conf_int: np.ndarray
     _u_hat: np.ndarray
     _weights: np.ndarray
+    _observation_weights: "ObservationWeights"
+    _within_data: "WithinLinearData"
     _Y: np.ndarray
-    _Y_untransformed: pd.Series
+    _Y_untransformed: pd.DataFrame
     _coefnames: list[str]
     _method: str
     _drop_intercept: bool
@@ -138,7 +144,8 @@ class ResultAccessorMixin(TidyColumnAccessors):
     _has_weights: bool
     _is_iv: bool
     _k_fe: pd.Series
-    _N: int
+    _N: int | float
+    _N_rows: int
     _k: int
     _df_t: int
     _inference_dist: "InferenceDist"
@@ -303,8 +310,9 @@ class ResultAccessorMixin(TidyColumnAccessors):
         fit._r2, fit._adj_r2, fit._r2_within
         ```
         """
-        Y_within = self._Y
+        Y_within = self._within_data.response
         Y = self._Y_untransformed.to_numpy()
+        observation_weights = self._observation_weights.values
 
         has_intercept = not self._drop_intercept
 
@@ -315,14 +323,25 @@ class ResultAccessorMixin(TidyColumnAccessors):
         else:
             adj_factor = (self._N - has_intercept) / (self._N - self._k)
 
-        ssu = np.sum(self._u_hat**2)
-        ssy = np.sum(self._weights * (Y - np.average(Y, weights=self._weights)) ** 2)
+        if observation_weights is None:
+            ssu = np.sum(self._u_hat**2)
+            y_center = np.mean(Y)
+            ssy = np.sum((Y - y_center) ** 2)
+        else:
+            weights = observation_weights.reshape((-1, 1))
+            ssu = np.sum(weights.flatten() * self._u_hat**2)
+            y_center = np.average(Y, weights=weights)
+            ssy = np.sum(weights * (Y - y_center) ** 2)
         self._rmse = np.sqrt(ssu / self._N)
         self._r2 = 1 - (ssu / ssy)
         self._adj_r2 = 1 - (ssu / ssy) * adj_factor
 
         if self._has_fixef:
-            ssy_within = np.sum(Y_within**2)
+            ssy_within = (
+                np.sum(Y_within**2)
+                if observation_weights is None
+                else np.sum(weights * Y_within**2)
+            )
             self._r2_within = 1 - (ssu / ssy_within)
             self._adj_r2_within = 1 - (ssu / ssy_within) * adj_factor_within
 
@@ -567,8 +586,9 @@ class ResultAccessorMixin(TidyColumnAccessors):
         """
         Fitted model residuals.
 
-        For weighted models the residuals are rescaled by the square root of the
-        weights, so they are on the scale of the original dependent variable.
+        Residuals are stored and returned on the scale of the original dependent
+        variable. Observation weights are applied only where an estimating
+        equation or diagnostic requires them.
 
         Returns
         -------
@@ -584,4 +604,4 @@ class ResultAccessorMixin(TidyColumnAccessors):
         fit.resid()[:5]
         ```
         """
-        return self._u_hat.flatten() / np.sqrt(self._weights.flatten())
+        return self._u_hat.flatten()

--- a/pyfixest/estimation/models/fegaussian_.py
+++ b/pyfixest/estimation/models/fegaussian_.py
@@ -6,6 +6,7 @@ import pandas as pd
 from pyfixest.core.demean import Preconditioner
 from pyfixest.demeaners import AnyDemeaner
 from pyfixest.estimation.formula.parse import Formula as FixestFormula
+from pyfixest.estimation.internals.demean_ import DemeanedData
 from pyfixest.estimation.internals.families import GAUSSIAN
 from pyfixest.estimation.internals.vcov_ import vcov_iid_ols
 from pyfixest.estimation.models.feglm_ import Feglm
@@ -24,7 +25,7 @@ class Fegaussian(Feglm):
         weights: str | None,
         weights_type: str | None,
         collin_tol: float,
-        lookup_demeaned_data: dict[frozenset[int], pd.DataFrame],
+        lookup_demeaned_data: dict[frozenset[int], DemeanedData],
         tol: float,
         maxiter: int,
         solver: Literal[
@@ -74,4 +75,9 @@ class Fegaussian(Feglm):
 
     def _vcov_iid(self):
         # we set gaussian glms to match pf.feols exactly
-        return vcov_iid_ols(residuals=self._u_hat, bread=self._bread, N=self._N)
+        return vcov_iid_ols(
+            residuals=self._u_hat,
+            bread=self._bread,
+            N=self._N,
+            weights=self._leverage_weights(),
+        )

--- a/pyfixest/estimation/models/feglm_.py
+++ b/pyfixest/estimation/models/feglm_.py
@@ -8,7 +8,9 @@ import pandas as pd
 
 from pyfixest.core.demean import Preconditioner
 from pyfixest.demeaners import AnyDemeaner
+from pyfixest.estimation.formula.model_matrix import FormulaData
 from pyfixest.estimation.formula.parse import Formula as FixestFormula
+from pyfixest.estimation.internals.demean_ import DemeanedData
 from pyfixest.estimation.internals.families import GlmFamily
 from pyfixest.estimation.internals.fit_glm_ import fit_glm_irls
 from pyfixest.estimation.internals.separation import check_for_separation
@@ -56,7 +58,7 @@ class Feglm(Feols):
         weights: str | None,
         weights_type: str | None,
         collin_tol: float,
-        lookup_demeaned_data: dict[frozenset[int], pd.DataFrame],
+        lookup_demeaned_data: dict[frozenset[int], DemeanedData],
         tol: float,
         maxiter: int,
         solver: Literal[
@@ -76,7 +78,7 @@ class Feglm(Feols):
         separation_check: list[str] | None = None,
         context: int | Mapping[str, Any] = 0,
         accelerate: bool = True,
-    ):
+    ) -> None:
         super().__init__(
             FixestFormula=FixestFormula,
             data=data,
@@ -110,21 +112,24 @@ class Feglm(Feols):
         self.separation_check = separation_check
         self._accelerate = accelerate
 
-        self._support_crv3_inference = True
+        # The inherited slow jackknife refits with the linear/Poisson APIs and
+        # cannot yet preserve a generic GLM family's estimation contract.
+        self._support_crv3_inference = False
         self._support_iid_inference = True
         self._support_hac_inference = True
+        self._supports_wildboottest = False
         self._supports_cluster_causal_variance = False
         self._support_decomposition = False
 
         self._Y_hat_response = np.empty(0)
         self.deviance = None
-        self._Xbeta = np.empty(0)
+        self._Xbeta = np.empty((0, 1))
 
         self._method = "feglm"
         self._family = family
         self._inference_dist = family.inference_dist
 
-    def prepare_model_matrix(self):
+    def prepare_model_matrix(self) -> FormulaData:
         "Prepare model inputs for estimation."
         formula_data = super().prepare_model_matrix()
 
@@ -136,9 +141,9 @@ class Feglm(Feols):
             and self.separation_check  # not an empty list
         ):
             na_separation = check_for_separation(
-                Y=self._Y,
-                X=self._X,
-                fe=self._fe,
+                Y=formula_data.dependent,
+                X=formula_data.independent,
+                fe=formula_data.fixed_effects,
                 fml=self._fml,
                 data=self._data,
                 demeaner=self._demeaner,
@@ -150,51 +155,50 @@ class Feglm(Feols):
             formula_data = formula_data.without_rows(na_separation)
             self._set_formula_data(formula_data)
 
-            # Preserve the established GLM sample-size convention after
-            # separation. Frequency-weight policy is handled separately.
-            self._N = self._Y.shape[0]
-            self._N_rows = self._N
-
             self.n_separation_na = len(na_separation)
             # possible to have dropped fixed effects level due to separation
-            self._k_fe = self._fe.nunique(axis=0) if self._has_fixef else None
             self._n_fe = np.sum(self._k_fe > 1) if self._has_fixef else 0
 
         return formula_data
 
-    def to_array(self):
-        "Turn estimation DataFrames to np arrays."
-        self._Y, self._X, self._Z = (
-            self._Y.to_numpy(),
-            self._X.to_numpy(),
-            self._X.to_numpy(),
-        )
-        if self._offset_df is not None:
-            self._offset = self._offset_df.to_numpy().reshape((-1, 1))
-        if self._fe is not None:
-            self._fe = self._fe.to_numpy()
-            if self._fe.ndim == 1:
-                self._fe = self._fe.reshape((self._N, 1))
-
-    def get_fit(self):
+    def get_fit(self) -> None:
         "Fit the GLM via IRLS and write results onto self.* attributes."
-        self.to_array()
+        formula_data = self._formula_data
+        response = formula_data.dependent.to_numpy()
+        design = formula_data.independent.to_numpy()
+        fixed_effects = (
+            None
+            if formula_data.fixed_effects is None
+            else formula_data.fixed_effects.to_numpy()
+        )
+        offset = (
+            None
+            if formula_data.offset is None
+            else formula_data.offset.to_numpy().reshape((-1, 1))
+        )
+        self._offset = offset
 
         def _demean(
             v: np.ndarray, X: np.ndarray, weights: np.ndarray, tol: float
         ) -> tuple[np.ndarray, np.ndarray]:
-            return self.residualize(v=v, X=X, flist=self._fe, weights=weights, tol=tol)
+            return self.residualize(
+                v=v,
+                X=X,
+                flist=fixed_effects,
+                weights=weights,
+                tol=tol,
+            )
 
         fit = fit_glm_irls(
-            X=self._X,
-            Y=self._Y,
+            X=design,
+            Y=response,
             family=self._family,
             demean=_demean,
             coefnames=self._coefnames,
             collin_tol=self._collin_tol,
-            accelerate=self._accelerate and self._fe is not None,
-            offset=self._offset,
-            weights=self._weights if self._has_weights else None,
+            accelerate=self._accelerate and fixed_effects is not None,
+            offset=offset,
+            weights=self._observation_weights.values,
             solver=self._solver,
             maxiter=self.maxiter,
             tol=self.tol,
@@ -204,50 +208,65 @@ class Feglm(Feols):
         self._coefnames = fit.coefnames
         self._collin_vars = fit.collin_vars
         self._collin_index = fit.collin_index
-        self._X = fit.X
-        self._X_is_empty = self._X.shape[1] == 0
-        self._k = self._X.shape[1]
+        self._working_state = fit.working_state
+        self._X = self._working_state.design_within
+        self._Y = self._working_state.working_response_within
+        self._Z = self._X
+        self._X_is_empty = self._working_state.design_within.shape[1] == 0
+        self._k = self._working_state.design_within.shape[1]
 
         self._beta_hat = fit.beta
-        self._Y_hat_response = fit.mu.flatten()
-        self._Y_hat_link = fit.eta.flatten()
+        self._Y_hat_response = self._working_state.mu
+        self._Y_hat_link = self._working_state.eta
+        self._irls_weights = self._working_state.working_weights
 
-        self._weights = fit.W
-        self._irls_weights = fit.W
-        if self._weights.ndim == 1:
-            self._weights = self._weights.reshape((self._N, 1))
+        self._u_hat_response = self._working_state.response_residuals
+        self._u_hat_working = self._working_state.working_residuals
+        self._u_hat = self._u_hat_working
 
-        self._u_hat_response = (self._Y.flatten() - fit.mu).flatten()
-        e_final = fit.z_tilde - fit.X_tilde @ self._beta_hat
-        self._u_hat_working = (
-            self._u_hat_response
-            if self._method == "feglm-gaussian"
-            else e_final.flatten()
+        self._scores_response = self._u_hat_response[:, None] * fit.X
+        self._scores_working = self._u_hat_working[:, None] * fit.X
+
+        weighted_working_residuals = (
+            self._working_state.working_weights * self._u_hat_working
         )
+        self._scores = self._X * weighted_working_residuals[:, None]
 
-        self._scores_response = self._u_hat_response[:, None] * self._X
-        self._scores_working = self._u_hat_working[:, None] * self._X
-
-        sqrt_W_vec = fit.sqrt_W.flatten()
-        X_wls = sqrt_W_vec[:, None] * fit.X_tilde
-        z_wls = sqrt_W_vec * fit.z_tilde
-
-        self._u_hat = (z_wls - X_wls @ self._beta_hat).flatten()
-        self._Y = z_wls
-        self._X = X_wls
-        self._Z = self._X
-
-        self._scores = self._u_hat[:, None] * self._X
-
-        self._tZX = self._Z.T @ self._X
+        weighted_design = self._working_state.working_weights[:, None] * self._X
+        self._tZX = self._Z.T @ weighted_design
         self._tZXinv = np.linalg.inv(self._tZX)
-        self._Xbeta = fit.eta.reshape(-1, 1)
+        self._Xbeta = self._working_state.eta.reshape(-1, 1)
 
-        self._hessian = X_wls.T @ X_wls
+        self._hessian = self._tZX.copy()
         self.deviance = fit.deviance
         self.convergence = fit.converged
         if self.convergence:
             self._convergence = True
+
+    def _leverage_weights(self) -> np.ndarray:
+        """Return final GLM working weights for HC2/HC3 leverage."""
+        return self._working_state.working_weights
+
+    def _fixef_weights(self) -> np.ndarray | None:
+        """Return working weights when weighted FE recovery historically used them."""
+        return self._working_state.working_weights if self._has_weights else None
+
+    def _clear_attributes(self) -> None:
+        """Apply base cleanup and discard large GLM fit arrays when lean."""
+        super()._clear_attributes()
+        if self._lean:
+            for attr in (
+                "_working_state",
+                "_irls_weights",
+                "_u_hat_response",
+                "_u_hat_working",
+                "_scores_response",
+                "_scores_working",
+                "_Xbeta",
+                "_offset",
+            ):
+                if hasattr(self, attr):
+                    delattr(self, attr)
 
     def _vcov_iid(self):
         return vcov_iid_glm(bread=self._bread)
@@ -267,17 +286,23 @@ class Feglm(Feols):
         np.ndarray
             A flat array with the requested residuals.
         """
+        if type not in ("response", "working"):
+            raise ValueError("type must be one of 'response' or 'working'.")
+        if self._lean:
+            raise RuntimeError(
+                "resid() is unavailable after fitting with lean=True because the "
+                "response and working residual arrays were discarded. Refit with "
+                "lean=False to access residuals."
+            )
         if type == "response":
             return self._u_hat_response.flatten()
-        if type == "working":
-            return self._u_hat_working.flatten()
-        raise ValueError("type must be one of 'response' or 'working'.")
+        return self._u_hat_working.flatten()
 
     def residualize(
         self,
         v: np.ndarray,
         X: np.ndarray,
-        flist: np.ndarray,
+        flist: np.ndarray | None,
         weights: np.ndarray,
         tol: float,
     ) -> tuple[np.ndarray, np.ndarray]:
@@ -370,14 +395,14 @@ class Feglm(Feols):
 
     def _check_dependent_variable(self) -> None:
         "Validate the dependent variable according to the family's constraints."
-        self._family.check_y(self._Y)
+        self._family.check_y(self._formula_data.dependent)
 
     def _validate_response(self) -> None:
         """Apply family-specific response validation after matrix preparation."""
         self._check_dependent_variable()
 
 
-def _glm_input_checks(drop_singletons: bool, tol: float, maxiter: int):
+def _glm_input_checks(drop_singletons: bool, tol: float, maxiter: int) -> None:
     if not isinstance(drop_singletons, bool):
         raise TypeError("drop_singletons must be logical.")
     if not isinstance(tol, (int, float)):

--- a/pyfixest/estimation/models/feiv_.py
+++ b/pyfixest/estimation/models/feiv_.py
@@ -542,12 +542,6 @@ class Feiv(Feols):
         # If vcov is iid, redo first stage regression
 
         if self._vcov_type_detail == "iid":
-            if not hasattr(self._model_1st_stage, "_data"):
-                raise RuntimeError(
-                    "The effective F statistic cannot recompute heteroskedastic "
-                    "first-stage inference when store_data=False. Fit with a "
-                    "heteroskedastic vcov at estimation time or retain the data."
-                )
             self._model_1st_stage.vcov("hetero")
 
         # Compute Effective F stat by Olea and Pflueger 2013

--- a/pyfixest/estimation/models/feiv_.py
+++ b/pyfixest/estimation/models/feiv_.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import warnings
 from collections.abc import Mapping
 from dataclasses import replace
@@ -11,7 +13,9 @@ from pyfixest.core.demean import Preconditioner
 from pyfixest.demeaners import AnyDemeaner, LsmrDemeaner
 from pyfixest.estimation.formula.parse import Formula as FixestFormula
 from pyfixest.estimation.internals.collinearity import drop_multicollinear_variables
+from pyfixest.estimation.internals.demean_ import DemeanedData
 from pyfixest.estimation.internals.fit_ import fit_iv
+from pyfixest.estimation.internals.model_state import WithinLinearData
 from pyfixest.estimation.models.feols_ import Feols
 
 
@@ -20,10 +24,9 @@ class Feiv(Feols):
     Non user-facing class to estimate an IV model using a 2SLS estimator.
 
     Inherits from the Feols class. Users should not directly instantiate this class,
-    but rather use the [feols()](/reference/estimation.api.feols.feols.qmd) function. Note that
-    no demeaning is performed in this class: demeaning is performed in the
-    FixestMulti class (to allow for caching of demeaned variables for multiple
-    estimation).
+    but rather use the [feols()](/reference/estimation.api.feols.feols.qmd)
+    function. This class constructs the second-stage and instrument within
+    arrays through the shared ``DemeanCache`` supplied by the estimation runner.
 
     Parameters
     ----------
@@ -167,7 +170,7 @@ class Feiv(Feols):
         weights: str | None,
         weights_type: str | None,
         collin_tol: float,
-        lookup_demeaned_data: dict[frozenset[int], pd.DataFrame],
+        lookup_demeaned_data: dict[frozenset[int], DemeanedData],
         solver: Literal[
             "np.linalg.lstsq",
             "np.linalg.solve",
@@ -210,59 +213,77 @@ class Feiv(Feols):
         self._supports_cluster_causal_variance = False
         self._support_decomposition = False
 
-    def wls_transform(self) -> None:
-        "Transform variables for WLS estimation."
-        super().wls_transform()
-        if self._has_weights:
-            w = np.sqrt(self._weights)
-            self._endogvar = self._endogvar * w
-            self._Z = self._Z * w
+    def _prepare_within_data(self) -> WithinLinearData:
+        """Return second-stage and instrument arrays on within scale."""
+        linear_data = super()._prepare_within_data()
+        endogenous_frame = self._formula_data.endogenous
+        instrument_frame = self._formula_data.instruments
+        assert endogenous_frame is not None
+        assert instrument_frame is not None
 
-    def to_array(self) -> None:
-        "Transform estimation DataFrames to arrays."
-        super().to_array()
-        self._Z = self._Zd.to_numpy()
-        self._endogvar = self._endogvar.to_numpy()
-
-    def demean(self) -> None:
-        "Demean instruments and endogeneous variable."
-        super().demean()
-        if self._has_fixef:
-            self._endogvard, self._Zd, _ = self._demean_cache.demean_yx(
-                self._endogvar,
-                self._Z,
-                self._fe,
-                self._weights.flatten(),
-                self._na_index,
-                self._demeaner,
+        endogenous = endogenous_frame.to_numpy(dtype=np.float64)
+        instruments = instrument_frame.to_numpy(dtype=np.float64)
+        if self._formula_data.fixed_effects is not None:
+            endogenous, instruments, _ = self._demean_cache.demean_yx(
+                endogenous,
+                instruments,
+                y_names=endogenous_frame.columns,
+                x_names=instrument_frame.columns,
+                fe=self._formula_data.fixed_effects.to_numpy(),
+                weights=self._observation_weights.values,
+                na_index=self._na_index,
+                demeaner=self._demeaner,
             )
-        else:
-            self._endogvard = self._endogvar
-            self._Zd = self._Z
 
-    def drop_multicol_vars(self) -> None:
-        "Drop multicollinear variables in matrix of instruments Z."
-        super().drop_multicol_vars()
+        return WithinLinearData(
+            response=linear_data.response,
+            design=linear_data.design,
+            instruments=instruments,
+            endogenous=endogenous,
+        )
+
+    def _drop_multicollinear_within_data(
+        self, within_data: WithinLinearData
+    ) -> WithinLinearData:
+        """Drop collinear second-stage and instrument columns on within scale."""
+        within_data = super()._drop_multicollinear_within_data(within_data)
+        assert within_data.instruments is not None
+        assert self._coefnames_z is not None
         (
-            self._Z,
+            instruments,
             self._coefnames_z,
             self._collin_vars_z,
             self._collin_index_z,
         ) = drop_multicollinear_variables(
-            self._Z,
+            within_data.instruments,
             self._coefnames_z,
             self._collin_tol,
         )
+        return WithinLinearData(
+            response=within_data.response,
+            design=within_data.design,
+            instruments=instruments,
+            endogenous=within_data.endogenous,
+        )
+
+    def _set_within_data(self, within_data: WithinLinearData) -> None:
+        """Publish IV within state and stable array compatibility aliases."""
+        super()._set_within_data(within_data)
+        self._endogvar = within_data.endogenous
 
     def get_fit(self) -> None:
         """Fit a IV model using a 2SLS estimator."""
-        self.demean()
-        self.to_array()
-        self.drop_multicol_vars()
-        self.wls_transform()
+        within_data = self._drop_multicollinear_within_data(self._prepare_within_data())
+        self._set_within_data(within_data)
+        assert within_data.instruments is not None
 
-        # Second stage (2SLS) on prepared arrays
-        fit = fit_iv(X=self._X, Z=self._Z, Y=self._Y, solver=self._solver)
+        fit = fit_iv(
+            X=within_data.design,
+            Z=within_data.instruments,
+            Y=within_data.response,
+            weights=self._observation_weights.values,
+            solver=self._solver,
+        )
 
         self._tZX = fit.tZX
         self._tXZ = fit.tXZ
@@ -276,6 +297,12 @@ class Feiv(Feols):
 
     def first_stage(self) -> None:
         """Implement First stage regression."""
+        if not hasattr(self, "_data"):
+            raise RuntimeError(
+                "first_stage() is unavailable when store_data=False or lean=True "
+                "because the estimation data were discarded."
+            )
+
         # Store names of instruments from Z matrix
         self._non_exo_instruments = list(set(self._coefnames_z) - set(self._coefnames))
 
@@ -312,6 +339,7 @@ class Feiv(Feols):
             collin_tol=self._collin_tol,
             solver=self._solver,
             demeaner=demeaner,
+            store_data=self._store_data,
         )
 
         # Ensure model1 is of type Feols
@@ -338,6 +366,14 @@ class Feiv(Feols):
     def _finalize_fit(self) -> None:
         """Fit and retain the first-stage model after second-stage inference."""
         self.first_stage()
+
+    def _clear_attributes(self) -> None:
+        """Clear main and retained first-stage fit data under lean storage."""
+        super()._clear_attributes()
+        if self._lean:
+            for attr in ("_model_1st_stage", "_X_hat", "_v_hat", "_endogvar"):
+                if hasattr(self, attr):
+                    delattr(self, attr)
 
     def IV_Diag(self, statistics: list[str] | None = None):
         """Implement IV diagnostic tests.
@@ -419,6 +455,12 @@ class Feiv(Feols):
 
             ```
         """
+        if not hasattr(self, "_model_1st_stage"):
+            raise RuntimeError(
+                "IV_Diag() is unavailable when lean=True because the retained "
+                "first-stage fit state was discarded."
+            )
+
         # Set default statistics
         iv_diag_stat = ["f_stat", "effective_f"]
 
@@ -500,7 +542,12 @@ class Feiv(Feols):
         # If vcov is iid, redo first stage regression
 
         if self._vcov_type_detail == "iid":
-            self._vcov_type_detail = "hetero"
+            if not hasattr(self._model_1st_stage, "_data"):
+                raise RuntimeError(
+                    "The effective F statistic cannot recompute heteroskedastic "
+                    "first-stage inference when store_data=False. Fit with a "
+                    "heteroskedastic vcov at estimation time or retain the data."
+                )
             self._model_1st_stage.vcov("hetero")
 
         # Compute Effective F stat by Olea and Pflueger 2013
@@ -523,8 +570,14 @@ class Feiv(Feols):
         ]
         Z = self._model_1st_stage._X[:, iv_positions]
 
-        # Calculate the cross-product of the instrument matrix
-        Q_zz = Z.T @ Z
+        # Calculate the same weighted cross-product used by the first-stage fit
+        # without relying on a persisted square-root-weighted design.
+        first_stage_weights = self._model_1st_stage._observation_weights.values
+        Q_zz = (
+            Z.T @ Z
+            if first_stage_weights is None
+            else Z.T @ (first_stage_weights[:, None] * Z)
+        )
 
         # Extract the robust variance-covariance matrix
         vcv = self._model_1st_stage._vcov

--- a/pyfixest/estimation/models/felogit_.py
+++ b/pyfixest/estimation/models/felogit_.py
@@ -6,6 +6,7 @@ import pandas as pd
 from pyfixest.core.demean import Preconditioner
 from pyfixest.demeaners import AnyDemeaner
 from pyfixest.estimation.formula.parse import Formula as FixestFormula
+from pyfixest.estimation.internals.demean_ import DemeanedData
 from pyfixest.estimation.internals.families import LOGIT
 from pyfixest.estimation.models.feglm_ import Feglm
 
@@ -23,7 +24,7 @@ class Felogit(Feglm):
         weights: str | None,
         weights_type: str | None,
         collin_tol: float,
-        lookup_demeaned_data: dict[frozenset[int], pd.DataFrame],
+        lookup_demeaned_data: dict[frozenset[int], DemeanedData],
         tol: float,
         maxiter: int,
         solver: Literal[

--- a/pyfixest/estimation/models/feols_.py
+++ b/pyfixest/estimation/models/feols_.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import re
 import warnings
 from collections.abc import Mapping
+from dataclasses import replace
+from functools import partial
 from importlib import import_module
 from typing import Any, Literal, cast
 
@@ -13,7 +15,7 @@ from scipy.sparse import csc_matrix, diags, spmatrix
 from scipy.sparse.linalg import lsqr
 from scipy.stats import chi2, f, t
 
-from pyfixest.core.demean import Preconditioner
+from pyfixest.core.demean import Preconditioner, WithinPreconditionerName
 from pyfixest.demeaners import AnyDemeaner, LsmrDemeaner, MapDemeaner
 from pyfixest.errors import VcovTypeNotSupportedError
 from pyfixest.estimation.api.utils import _ALL_SAMPLE, _AllSampleSentinel
@@ -25,14 +27,19 @@ from pyfixest.estimation.formula.formulaic_compat import (
 from pyfixest.estimation.formula.model_matrix import _ModelMatrixKey
 from pyfixest.estimation.formula.parse import Formula as FixestFormula
 from pyfixest.estimation.internals.collinearity import drop_multicollinear_variables
-from pyfixest.estimation.internals.demean_ import DemeanCache
+from pyfixest.estimation.internals.demean_ import DemeanCache, DemeanedData
 from pyfixest.estimation.internals.families import T_DIST, InferenceDist
 from pyfixest.estimation.internals.fit_ import fit_ols
 from pyfixest.estimation.internals.literals import (
     PredictionErrorOptions,
     PredictionType,
     SolverOptions,
+    WeightsTypeOptions,
     _validate_literal_argument,
+)
+from pyfixest.estimation.internals.model_state import (
+    ObservationWeights,
+    WithinLinearData,
 )
 from pyfixest.estimation.internals.vcov_ import (
     vcov_crv1,
@@ -80,10 +87,10 @@ class Feols(ResultAccessorMixin):
     Non user-facing class to estimate a linear regression via OLS.
 
     Users should not directly instantiate this class,
-    but rather use the [feols()](/reference/estimation.api.feols.feols.qmd) function. Note that
-    no demeaning is performed in this class: demeaning is performed in the
-    FixestMulti class (to allow for caching of demeaned variables for multiple
-    estimation).
+    but rather use the [feols()](/reference/estimation.api.feols.feols.qmd)
+    function. This class constructs within-scale arrays through a shared
+    ``DemeanCache``; the estimation runner supplies that cache for reuse across
+    multiple fits.
 
     Parameters
     ----------
@@ -259,7 +266,7 @@ class Feols(ResultAccessorMixin):
         weights: str | None,
         weights_type: str | None,
         collin_tol: float,
-        lookup_demeaned_data: dict[frozenset[int], pd.DataFrame],
+        lookup_demeaned_data: dict[frozenset[int], DemeanedData],
         solver: SolverOptions = "np.linalg.solve",
         demeaner: AnyDemeaner | None = None,
         lookup_preconditioner: dict[frozenset[int], Preconditioner] | None = None,
@@ -411,6 +418,7 @@ class Feols(ResultAccessorMixin):
             drop_singletons=self._drop_singletons,
             drop_intercept=self._drop_intercept,
             weights=self._weights_name,
+            weights_type=self._weights_type if self._has_weights else None,
             offset=self._offset_name,
             context=self._context,
         )
@@ -424,34 +432,37 @@ class Feols(ResultAccessorMixin):
         return formula_data
 
     # This compatibility publisher remains deliberately untyped while the legacy
-    # aliases change representation. PR3 removes that transitional type mutation.
+    # formula payload contains pandas objects whose concrete Formulaic types vary.
     def _set_formula_data(self, formula_data):
-        """Publish one structurally immutable state through compatibility aliases."""
+        """Publish structurally immutable formula and observation-weight state."""
         self._formula_data = formula_data
-        self._Y = formula_data.dependent
-        self._Y_untransformed = self._Y.copy()
-        self._X = formula_data.independent
+        self._Y_untransformed = formula_data.dependent.copy()
         self._fe = formula_data.fixed_effects
-        self._endogvar = formula_data.endogenous
-        self._Z = formula_data.instruments
         self._weights_df = formula_data.weights
         self._offset_df = formula_data.offset
         self._na_index = formula_data.na_index
         # TODO: set dynamically based on naming set in pyfixest.estimation.formula.factor_interaction._encode_i
+        independent = formula_data.independent
         is_icovar = (
-            self._X.columns.str.contains(r"^.+::.+$") if not self._X.empty else None
+            independent.columns.str.contains(r"^.+::.+$")
+            if not independent.empty
+            else None
         )
         self._icovars = (
-            self._X.columns[is_icovar].tolist()
+            independent.columns[is_icovar].tolist()
             if is_icovar is not None and is_icovar.any()
             else None
         )
-        self._X_is_empty = self._X.shape[0] == 0
+        self._X_is_empty = independent.shape[1] == 0
         self._model_spec = formula_data.model_spec
 
-        self._coefnames = self._X.columns.tolist()
-        self._coefnames_z = self._Z.columns.tolist() if self._Z is not None else None
-        self._depvar = self._Y.columns[0]
+        self._coefnames = independent.columns.tolist()
+        self._coefnames_z = (
+            formula_data.instruments.columns.tolist()
+            if formula_data.instruments is not None
+            else None
+        )
+        self._depvar = formula_data.dependent.columns[0]
 
         self._has_fixef = self._fe is not None
         self._fixef = (
@@ -463,63 +474,54 @@ class Feols(ResultAccessorMixin):
         self._k_fe = self._fe.nunique(axis=0) if self._has_fixef else None
         self._n_fe = len(self._k_fe) if self._has_fixef else 0
 
-        self._weights = self._set_weights()
-        self._N, self._N_rows = self._set_nobs()
+        self._observation_weights = self._set_observation_weights()
+        self._N = self._observation_weights.n_effective
+        self._N_rows = self._observation_weights.n_rows
+        # Compatibility alias: always observation weights, never solver or
+        # GLM working weights. Canonical code uses `_observation_weights`.
+        values = self._observation_weights.values
+        self._weights = (
+            np.ones((self._N_rows, 1), dtype=np.float64)
+            if values is None
+            else values.reshape((-1, 1))
+        )
 
     def _validate_response(self) -> None:
         """Validate estimator-specific response constraints, if any."""
 
-    def _set_nobs(self) -> tuple[int, int]:
-        """
-        Fetch the number of observations used in fitting the regression model.
+    def _set_observation_weights(self) -> ObservationWeights:
+        """Build canonical user-scale observation weights for this row sample."""
+        n_rows = len(self._formula_data.dependent)
+        if self._formula_data.weights is None:
+            return ObservationWeights.unweighted(n_rows=n_rows)
 
-        Returns
-        -------
-        tuple[int, int]
-            A tuple containing the total number of observations and the number of rows
-            in the dependent variable array.
-        """
-        N_rows = len(self._Y)
-        if self._weights_type == "aweights":
-            N = N_rows
-        elif self._weights_type == "fweights":
-            N = np.sum(self._weights)
+        assert self._weights_type in ("aweights", "fweights")
+        weights_kind = cast(WeightsTypeOptions, self._weights_type)
+        return ObservationWeights.from_values(
+            self._formula_data.weights.to_numpy().reshape(-1),
+            kind=weights_kind,
+        )
 
-        return N, N_rows
+    def _prepare_within_data(self) -> WithinLinearData:
+        """Return fixed-effect-residualized arrays in their original units."""
+        response_frame = self._formula_data.dependent
+        design_frame = self._formula_data.independent
+        response = response_frame.to_numpy(dtype=np.float64)
+        design = design_frame.to_numpy(dtype=np.float64)
 
-    def _set_weights(self) -> np.ndarray:
-        """
-        Return the weights used in the regression model.
-
-        Returns
-        -------
-        np.ndarray
-            The weights used in the regression model.
-            If no weights are used, returns an array of ones
-            with the same length as the dependent variable array.
-        """
-        N = len(self._Y)
-
-        if self._weights_df is not None:
-            _weights = self._weights_df.to_numpy()
-        else:
-            _weights = np.ones(N)
-
-        return _weights.reshape((N, 1))
-
-    def demean(self):
-        "Demean the dependent variable and covariates by the fixed effect(s)."
-        if self._has_fixef:
-            self._Yd, self._Xd, _ = self._demean_cache.demean_yx(
-                self._Y,
-                self._X,
-                self._fe,
-                self._weights.flatten(),
-                self._na_index,
-                self._demeaner,
+        if self._formula_data.fixed_effects is not None:
+            response, design, _ = self._demean_cache.demean_yx(
+                response,
+                design,
+                y_names=response_frame.columns,
+                x_names=design_frame.columns,
+                fe=self._formula_data.fixed_effects.to_numpy(),
+                weights=self._observation_weights.values,
+                na_index=self._na_index,
+                demeaner=self._demeaner,
             )
-        else:
-            self._Yd, self._Xd = self._Y, self._X
+
+        return WithinLinearData(response=response, design=design)
 
     @property
     def preconditioner(self) -> Preconditioner | None:
@@ -534,36 +536,42 @@ class Feols(ResultAccessorMixin):
         """
         return self._demean_cache.lookup_preconditioner.get(self._na_index)
 
-    def to_array(self):
-        "Convert estimation data frames to np arrays."
-        self._Y, self._X = (
-            self._Yd.to_numpy(),
-            self._Xd.to_numpy(),
-        )
-
-    def wls_transform(self):
-        "Transform model matrices for WLS Estimation."
-        if self._has_weights:
-            w = np.sqrt(self._weights)
-            self._Y = self._Y * w
-            self._X = self._X * w
-
-    def drop_multicol_vars(self):
-        "Detect and drop multicollinear variables."
-        if self._X.shape[1] > 0:
+    def _drop_multicollinear_within_data(
+        self, within_data: WithinLinearData
+    ) -> WithinLinearData:
+        """Return within data after the established unweighted rank check."""
+        design = within_data.design
+        if design.shape[1] > 0:
             (
-                self._X,
+                design,
                 self._coefnames,
                 self._collin_vars,
                 self._collin_index,
             ) = drop_multicollinear_variables(
-                self._X,
+                design,
                 self._coefnames,
                 self._collin_tol,
             )
-        # update X_is_empty
-        self._X_is_empty = self._X.shape[1] == 0
-        self._k = self._X.shape[1] if not self._X_is_empty else 0
+
+        return WithinLinearData(
+            response=within_data.response,
+            design=design,
+            instruments=within_data.instruments,
+            endogenous=within_data.endogenous,
+        )
+
+    def _set_within_data(self, within_data: WithinLinearData) -> None:
+        """Publish canonical within data and stable array compatibility aliases."""
+        self._within_data = within_data
+        self._Y = within_data.response
+        self._X = within_data.design
+        self._Z = (
+            within_data.design
+            if within_data.instruments is None
+            else within_data.instruments
+        )
+        self._X_is_empty = within_data.design.shape[1] == 0
+        self._k = within_data.design.shape[1]
 
     def _get_predictors(self) -> None:
         self._Y_hat_link = self._Y_untransformed.to_numpy().flatten() - self.resid()
@@ -577,17 +585,19 @@ class Feols(ResultAccessorMixin):
         -------
         None
         """
-        self.demean()
-        self.to_array()
-        self.drop_multicol_vars()
-        self.wls_transform()
+        within_data = self._drop_multicollinear_within_data(self._prepare_within_data())
+        self._set_within_data(within_data)
 
         if self._X_is_empty:
-            self._u_hat = self._Y
+            self._u_hat = within_data.response.flatten()
         else:
-            fit = fit_ols(X=self._X, Y=self._Y, solver=self._solver)
+            fit = fit_ols(
+                X=within_data.design,
+                Y=within_data.response,
+                weights=self._observation_weights.values,
+                solver=self._solver,
+            )
 
-            self._Z = self._X
             self._tZX = fit.tZX
             self._tZy = fit.tZy
             self._beta_hat = fit.beta
@@ -637,8 +647,10 @@ class Feols(ResultAccessorMixin):
         vcov_kwargs : Optional[dict[str, any]]
              Additional keyword arguments for the variance-covariance matrix.
         data: Optional[DataFrameType], optional
-            The data used for estimation. If None, tries to fetch the data from the
-            model object. Defaults to None.
+            The already-filtered estimation sample in its original estimation order.
+            This is required for data-dependent covariance updates when the fitted
+            model does not retain its input data. If None, tries to fetch the data
+            from the model object. Defaults to None.
 
 
         Returns
@@ -666,20 +678,34 @@ class Feols(ResultAccessorMixin):
         See [On Small Sample Corrections](/explanation/ssc.qmd) for how the
         `ssc` adjustments interact with each estimator.
         """
-        # Assuming `data` is the DataFrame in question
+        if not hasattr(self, "_X"):
+            raise RuntimeError(
+                "vcov() is unavailable after fitting with lean=True because the "
+                "required estimation arrays were discarded. Set vcov at estimation "
+                "time or refit with lean=False."
+            )
 
-        data_to_check = data if data is not None else self._data
-        try:
-            data_to_check = _narwhals_to_pandas(data_to_check)
-        except TypeError as e:
-            raise TypeError(
-                f"The data set must be a DataFrame type. Received: {type(data)}"
-            ) from e
+        data_to_check: pd.DataFrame | None
+        if data is None:
+            data_to_check = getattr(self, "_data", None)
+        else:
+            try:
+                data_to_check = _narwhals_to_pandas(data)
+            except TypeError as e:
+                raise TypeError(
+                    f"The data set must be a DataFrame type. Received: {type(data)}"
+                ) from e
+            if len(data_to_check) != self._N_rows:
+                raise ValueError(
+                    "`data` passed to vcov() must contain exactly the already-filtered "
+                    "estimation sample in its original estimation order; expected "
+                    f"{self._N_rows} rows, received {len(data_to_check)}."
+                )
 
         # assign estimated fixed effects, and fixed effects nested within cluster.
 
         # deparse vcov input
-        _check_vcov_input(vcov=vcov, vcov_kwargs=vcov_kwargs, data=self._data)
+        _check_vcov_input(vcov=vcov, vcov_kwargs=vcov_kwargs, data=data_to_check)
 
         (
             self._vcov_type,
@@ -687,6 +713,13 @@ class Feols(ResultAccessorMixin):
             self._is_clustered,
             self._clustervar,
         ) = _deparse_vcov_input(vcov, self._has_fixef, self._is_iv)
+
+        if self._vcov_type in {"HAC", "CRV"} and data_to_check is None:
+            raise RuntimeError(
+                "This vcov update requires estimation data, but the result was fit "
+                "with store_data=False. Pass the estimation sample via data= or refit "
+                "with store_data=True."
+            )
 
         self._bread = _compute_bread(
             self._is_iv, self._tXZ, self._tZZinv, self._tZX, self._hessian
@@ -706,6 +739,7 @@ class Feols(ResultAccessorMixin):
             self._vcov = self._ssc * self._vcov_hetero()
 
         elif self._vcov_type == "HAC":
+            assert data_to_check is not None
             kw = vcov_kwargs or {}
             self._lag = kw.get("lag")
             self._time_id = kw.get("time_id")
@@ -713,10 +747,10 @@ class Feols(ResultAccessorMixin):
             self._ssc, self._df_k, self._df_t = get_ssc(
                 **self._make_ssc_kwargs(
                     vcov_type="HAC",
-                    G=np.unique(self._data[self._time_id]).shape[0],
+                    G=np.unique(data_to_check[self._time_id]).shape[0],
                 )  # number of unique time periods T used
             )
-            self._vcov = self._ssc * self._vcov_hac()
+            self._vcov = self._ssc * self._vcov_hac(data=data_to_check)
 
         elif self._vcov_type == "nid":
             self._ssc, self._df_k, self._df_t = get_ssc(
@@ -725,8 +759,9 @@ class Feols(ResultAccessorMixin):
             self._vcov = self._ssc * self._vcov_nid()
 
         elif self._vcov_type == "CRV":
+            assert data_to_check is not None
             prep = prepare_cluster_state(
-                data=data if data is not None else self._data,
+                data=data_to_check,
                 clustervar=self._clustervar,
                 ssc_dict=self._ssc_dict,
                 fixef=self._fixef,
@@ -739,7 +774,10 @@ class Feols(ResultAccessorMixin):
                 prep=prep,
                 k=self._k,
                 make_ssc_kwargs=self._make_ssc_kwargs,
-                cluster_vcov=self._vcov_crv_cluster,
+                cluster_vcov=partial(
+                    self._vcov_crv_cluster,
+                    data=data_to_check,
+                ),
             )
         # update p-value, t-stat, standard error, confint
         self.get_inference()
@@ -750,7 +788,7 @@ class Feols(ResultAccessorMixin):
         self,
         *,
         vcov_type: str,
-        G: int | list[int],
+        G: int | float | list[int],
         vcov_sign: int = 1,
         k_fe_nested: int = 0,
         n_fe_fully_nested: int = 0,
@@ -770,7 +808,11 @@ class Feols(ResultAccessorMixin):
         }
 
     def _vcov_crv_cluster(
-        self, clustid: np.ndarray, cluster_col: np.ndarray
+        self,
+        clustid: np.ndarray,
+        cluster_col: np.ndarray,
+        *,
+        data: pd.DataFrame,
     ) -> np.ndarray:
         "Pick CRV1 / CRV3-fast / CRV3-slow for one cluster column."
         if self._vcov_type_detail == "CRV1":
@@ -781,11 +823,29 @@ class Feols(ResultAccessorMixin):
                 f"CRV3 inference is not for models of type '{self._method}'."
             )
         use_fast = not self._has_fixef and self._method == "feols" and not self._is_iv
-        crv3 = self._vcov_crv3_fast if use_fast else self._vcov_crv3_slow
-        return crv3(clustid=clustid, cluster_col=cluster_col)
+        if use_fast:
+            return self._vcov_crv3_fast(clustid=clustid, cluster_col=cluster_col)
+        return self._vcov_crv3_slow(
+            clustid=clustid,
+            cluster_col=cluster_col,
+            data=data,
+        )
 
     def _vcov_iid(self):
-        return vcov_iid_ols(residuals=self._u_hat, bread=self._bread, N=self._N)
+        return vcov_iid_ols(
+            residuals=self._u_hat,
+            bread=self._bread,
+            N=self._N,
+            weights=self._observation_weights.values,
+        )
+
+    def _leverage_weights(self) -> np.ndarray | None:
+        """Return weights used by the fitted normal equations."""
+        return self._observation_weights.values
+
+    def _fixef_weights(self) -> np.ndarray | None:
+        """Return weights used by fixed-effect coefficient recovery."""
+        return self._observation_weights.values
 
     def _vcov_hetero(self):
         return vcov_hetero(
@@ -793,6 +853,7 @@ class Feols(ResultAccessorMixin):
             X=self._X,
             tZX=self._tZX,
             weights=self._weights,
+            leverage_weights=self._leverage_weights(),
             weights_type=self._weights_type,
             vcov_type_detail=self._vcov_type_detail,
             bread=self._bread,
@@ -801,10 +862,9 @@ class Feols(ResultAccessorMixin):
             tZZinv=self._tZZinv,
         )
 
-    def _vcov_hac(self):
+    def _vcov_hac(self, *, data: pd.DataFrame):
         _time_id = self._time_id
         _panel_id = self._panel_id
-        _data = self._data
 
         if not self._support_hac_inference:
             raise NotImplementedError(
@@ -819,22 +879,22 @@ class Feols(ResultAccessorMixin):
 
         # some data checks on input pandas df
         # time needs to be numeric or date else we cannot sort by time
-        if not np.issubdtype(_data[_time_id], np.number) and not np.issubdtype(
-            _data[_time_id], np.datetime64
+        if not np.issubdtype(data[_time_id], np.number) and not np.issubdtype(
+            data[_time_id], np.datetime64
         ):
             raise ValueError(
                 "The time variable must be numeric or date, else we cannot sort by time."
             )
 
-        _time_arr = _data[_time_id].to_numpy()
-        _panel_arr = _data[_panel_id].to_numpy() if _panel_id is not None else None
+        _time_arr = data[_time_id].to_numpy()
+        _panel_arr = data[_panel_id].to_numpy() if _panel_id is not None else None
 
         return vcov_hac(
             scores=self._scores,
             time_arr=_time_arr,
             panel_arr=_panel_arr,
-            lag=self._lag,
-            vcov_type_detail=self._vcov_type_detail,
+            lag=cast(int | None, self._lag),
+            vcov_type_detail=cast(Literal["NW", "DK"], self._vcov_type_detail),
             bread=self._bread,
             is_iv=self._is_iv,
             tXZ=self._tXZ,
@@ -863,28 +923,62 @@ class Feols(ResultAccessorMixin):
         return vcov_crv3_fast(
             X=self._X,
             Y=self._Y,
+            weights=self._observation_weights.values,
             beta_hat=self._beta_hat,
             clustid=clustid,
             cluster_col=cluster_col,
         )
 
-    def _vcov_crv3_slow(self, clustid, cluster_col):
-        beta_jack = np.zeros((len(clustid), self._k))
+    def _estimation_refit_kwargs(self) -> dict[str, Any]:
+        """Return options needed to replay this estimator on modified data."""
+        demeaner = self._demeaner
+        if isinstance(demeaner, LsmrDemeaner) and isinstance(
+            demeaner.preconditioner, Preconditioner
+        ):
+            # A prebuilt factorization belongs to the original FE design. Keep
+            # its algorithmic variant, but rebuild it for the changed row set.
+            preconditioner = cast(
+                WithinPreconditionerName,
+                demeaner.preconditioner.variant.lower(),
+            )
+            demeaner = replace(demeaner, preconditioner=preconditioner)
 
+        return {
+            "weights": self._weights_name,
+            "weights_type": self._weights_type,
+            "ssc": dict(self._ssc_dict),
+            "fixef_rm": "singleton" if self._drop_singletons else "none",
+            "solver": self._solver,
+            "demeaner": demeaner,
+            "drop_intercept": self._drop_intercept,
+            "collin_tol": self._collin_tol,
+            "context": self._context,
+        }
+
+    def _crv3_refit(self, data: pd.DataFrame) -> Feols:
+        """Replay OLS for one leave-one-cluster-out sample."""
         # lazy loading to avoid circular import
         fixest_module = import_module("pyfixest.estimation")
-        fit_ = fixest_module.feols if self._method == "feols" else fixest_module.fepois
+        return fixest_module.feols(
+            fml=self._fml,
+            data=data,
+            vcov="iid",
+            **self._estimation_refit_kwargs(),
+        )
+
+    def _vcov_crv3_slow(
+        self,
+        clustid: np.ndarray,
+        cluster_col: np.ndarray,
+        *,
+        data: pd.DataFrame,
+    ) -> np.ndarray:
+        beta_jack = np.zeros((len(clustid), self._k))
 
         for ixg, g in enumerate(clustid):
             # direct leave one cluster out implementation
-            data = self._data[~np.equal(g, cluster_col)]
-            fit = fit_(
-                fml=self._fml,
-                data=data,
-                vcov="iid",
-                weights=self._weights_name,
-                weights_type=self._weights_type,
-            )
+            refit_data = data[~np.equal(g, cluster_col)]
+            fit = self._crv3_refit(data=refit_data)
             beta_jack[ixg, :] = fit.coef().to_numpy()
 
         # optional: beta_bar in MNW (2022)
@@ -911,12 +1005,18 @@ class Feols(ResultAccessorMixin):
         if self._lean:
             attributes += [
                 "_data",
+                "_formula_data",
+                "_model_spec",
+                "_context",
+                "_fe",
+                "_weights_df",
+                "_offset_df",
+                "_within_data",
+                "_observation_weights",
+                "_demean_cache",
                 "_X",
                 "_Y",
                 "_Z",
-                "_Xd",
-                "_Yd",
-                "_Zd",
                 "_cluster_df",
                 "_tXZ",
                 "_tZy",
@@ -928,7 +1028,6 @@ class Feols(ResultAccessorMixin):
                 "_Y_hat_link",
                 "_Y_hat_response",
                 "_Y_untransformed",
-                "_formula_data",
             ]
 
         for attr in attributes:
@@ -1146,6 +1245,9 @@ class Feols(ResultAccessorMixin):
                 raise NotImplementedError(
                     "Wild cluster bootstrap is not supported for WLS estimation."
                 )
+            raise NotImplementedError(
+                "Wild cluster bootstrap is only supported for unweighted OLS models."
+            )
 
         cluster_list = []
 
@@ -1329,6 +1431,10 @@ class Feols(ResultAccessorMixin):
             raise NotImplementedError(
                 "The causal cluster variance estimator is currently not supported for models with fixed effects."
             )
+        if self._has_weights:
+            raise NotImplementedError(
+                "The causal cluster variance estimator is currently not supported for models with weights."
+            )
 
         if treatment not in self._coefnames:
             raise ValueError(
@@ -1469,8 +1575,8 @@ class Feols(ResultAccessorMixin):
             X = csc_matrix(X) if output == "sparse" else X
 
         else:
-            Y = self._Y.flatten() / np.sqrt(self._weights.flatten())
-            X = self._X / np.sqrt(self._weights)
+            Y = self._Y.flatten()
+            X = self._X
             xnames = self._coefnames
 
         X = csc_matrix(X) if output == "sparse" else X
@@ -1655,7 +1761,7 @@ class Feols(ResultAccessorMixin):
         med.fit(
             X=X,
             Y=Y,
-            weights=self._weights,
+            weights=self._observation_weights.values,
             store=True,
         )
 
@@ -1702,7 +1808,7 @@ class Feols(ResultAccessorMixin):
         fixed_effects.head()
         ```
         """
-        weights_sqrt = np.sqrt(self._weights).flatten()
+        fixef_weights = self._fixef_weights()
 
         if not self._has_fixef:
             raise ValueError("The regression model does not have fixed effects.")
@@ -1747,13 +1853,15 @@ class Feols(ResultAccessorMixin):
                 _ModelMatrixKey.fixed_effects
             ].transform_state,
         )
-        D2 = contrast_coding.matrix
-        if self._has_weights:
+        fixed_effect_design = contrast_coding.matrix
+        solve_design = fixed_effect_design
+        if fixef_weights is not None:
+            weights_sqrt = np.sqrt(fixef_weights).flatten()
             uhat *= weights_sqrt
             weights_diag = diags(weights_sqrt, 0)
-            D2 = weights_diag.dot(D2)
+            solve_design = weights_diag.dot(fixed_effect_design)
 
-        alpha = lsqr(D2, uhat, atol=atol, btol=btol)[0]
+        alpha = lsqr(solve_design, uhat, atol=atol, btol=btol)[0]
 
         self._fixef_coefficients = build_fixed_effects(
             fixed_effect_coefficients=alpha,
@@ -1763,7 +1871,7 @@ class Feols(ResultAccessorMixin):
             ].transform_state,
         )
         self._alpha = alpha
-        self._sumFE = D2.dot(alpha)
+        self._sumFE = fixed_effect_design.dot(alpha)
 
         return fixed_effects_to_frame(self._fixef_coefficients)
 
@@ -1863,14 +1971,13 @@ class Feols(ResultAccessorMixin):
         if newdata is None:
             # note: no need to worry about fixed effects, as not supported with
             # prediction errors; will throw error later;
-            # divide by sqrt(weights) as self._X is "weighted"
             X = self._X
             y_hat = (
                 self._Y_hat_link
                 if type == "link" or self._method == "feols"
                 else self._Y_hat_response
             )
-            n_observations = self._N
+            n_observations = self._N_rows
         else:
             newdata = _narwhals_to_pandas(newdata).reset_index(drop=True)
             n_observations = newdata.shape[0]
@@ -2037,6 +2144,10 @@ class Feols(ResultAccessorMixin):
             raise NotImplementedError(
                 "Randomization Inference is not supported for IV models."
             )
+        if self._method not in {"feols", "fepois"}:
+            raise NotImplementedError(
+                "Randomization Inference is only supported for OLS and Poisson models."
+            )
 
         # check that resampvar in _coefnames
         if resampvar_ not in self._coefnames:
@@ -2115,6 +2226,7 @@ class Feols(ResultAccessorMixin):
                 type=type,
                 rng=rng,
                 model=self._method,
+                refit_kwargs=self._estimation_refit_kwargs(),
             )
 
         else:
@@ -2218,7 +2330,8 @@ class Feols(ResultAccessorMixin):
         y_new : np.ndarray
             Outcome values for new data points.
         inplace : bool, optional
-            Whether to update the model object in place. Defaults to False.
+            Must be `False`. In-place updates are unsupported because appending
+            design rows cannot reconstruct the complete fitted-result state.
 
         Returns
         -------
@@ -2229,7 +2342,8 @@ class Feols(ResultAccessorMixin):
         -----
         Updates the coefficients in closed form via the Sherman-Morrison
         identity instead of refitting on the full sample. `X_new` has to include
-        the intercept column. Models with fixed effects are not supported.
+        the intercept column. The returned coefficients do not mutate the fitted
+        result. Models with fixed effects are not supported.
 
         Examples
         --------
@@ -2255,18 +2369,30 @@ class Feols(ResultAccessorMixin):
             raise NotImplementedError(
                 "The update() method is currently not supported for models with fixed effects."
             )
+        if self._method != "feols":
+            raise NotImplementedError(
+                "The update() method is currently only supported for OLS models."
+            )
+        if self._is_iv:
+            raise NotImplementedError(
+                "The update() method is currently not supported for IV models."
+            )
+        if self._has_weights:
+            raise NotImplementedError(
+                "The update() method is currently not supported for models with weights."
+            )
+        if inplace:
+            raise NotImplementedError(
+                "update(..., inplace=True) is not supported because appending design "
+                "rows cannot safely update the complete fitted-result state; use the "
+                "returned coefficients instead."
+            )
         if not np.all(X_new[:, 0] == 1):
             X_new = np.column_stack((np.ones(len(X_new)), X_new))
         X_n_plus_1 = np.vstack((self._X, X_new))
         epsi_n_plus_1 = y_new - X_new @ self._beta_hat
         gamma_n_plus_1 = np.linalg.inv(X_n_plus_1.T @ X_n_plus_1) @ X_new.T
         beta_n_plus_1 = self._beta_hat + gamma_n_plus_1 @ epsi_n_plus_1
-        if inplace:
-            self._X = X_n_plus_1
-            self._Y = np.append(self._Y, y_new)
-            self._beta_hat = beta_n_plus_1
-            self._u_hat = self._Y - self._X @ self._beta_hat
-            self._N += X_new.shape[0]
 
         return beta_n_plus_1
 
@@ -2274,7 +2400,7 @@ class Feols(ResultAccessorMixin):
 def _check_vcov_input(
     vcov: str | dict[str, str],
     vcov_kwargs: dict[str, Any] | None,
-    data: pd.DataFrame,
+    data: pd.DataFrame | None,
 ):
     """
     Check the input for the vcov argument in the Feols class.
@@ -2306,6 +2432,11 @@ def _check_vcov_input(
 
     if isinstance(vcov, list):
         assert all(isinstance(v, str) for v in vcov), "vcov list must contain strings"
+        if data is None:
+            raise RuntimeError(
+                "A vcov column list requires estimation data. Pass data= or fit "
+                "with store_data=True."
+            )
         assert all(v in data.columns for v in vcov), (
             "vcov list must contain columns in the data"
         )

--- a/pyfixest/estimation/models/feols_.py
+++ b/pyfixest/estimation/models/feols_.py
@@ -707,19 +707,21 @@ class Feols(ResultAccessorMixin):
         # deparse vcov input
         _check_vcov_input(vcov=vcov, vcov_kwargs=vcov_kwargs, data=data_to_check)
 
-        (
-            self._vcov_type,
-            self._vcov_type_detail,
-            self._is_clustered,
-            self._clustervar,
-        ) = _deparse_vcov_input(vcov, self._has_fixef, self._is_iv)
+        vcov_type, vcov_type_detail, is_clustered, clustervar = _deparse_vcov_input(
+            vcov, self._has_fixef, self._is_iv
+        )
 
-        if self._vcov_type in {"HAC", "CRV"} and data_to_check is None:
+        if vcov_type in {"HAC", "CRV"} and data_to_check is None:
             raise RuntimeError(
                 "This vcov update requires estimation data, but the result was fit "
                 "with store_data=False. Pass the estimation sample via data= or refit "
                 "with store_data=True."
             )
+
+        self._vcov_type = vcov_type
+        self._vcov_type_detail = vcov_type_detail
+        self._is_clustered = is_clustered
+        self._clustervar = clustervar
 
         self._bread = _compute_bread(
             self._is_iv, self._tXZ, self._tZZinv, self._tZX, self._hessian

--- a/pyfixest/estimation/models/feols_.py
+++ b/pyfixest/estimation/models/feols_.py
@@ -1717,6 +1717,11 @@ class Feols(ResultAccessorMixin):
             only_coef=only_coef,
         )
 
+        if not self._support_decomposition:
+            raise NotImplementedError(
+                "Decomposition is currently only supported for OLS models."
+            )
+
         nthreads_int = -1 if nthreads is None else nthreads
 
         rng = (

--- a/pyfixest/estimation/models/fepois_.py
+++ b/pyfixest/estimation/models/fepois_.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from importlib import import_module
 from typing import Any
 
 import numpy as np
@@ -10,6 +11,7 @@ from scipy.special import gammaln
 from pyfixest.core.demean import Preconditioner
 from pyfixest.demeaners import AnyDemeaner
 from pyfixest.estimation.formula.parse import Formula as FixestFormula
+from pyfixest.estimation.internals.demean_ import DemeanedData
 from pyfixest.estimation.internals.families import POISSON
 from pyfixest.estimation.internals.literals import (
     SolverOptions,
@@ -31,21 +33,25 @@ class Fepois(Feglm):
 
     Inherits from the Feglm class. Users should not directly instantiate this class,
     but rather use the [fepois()](/reference/estimation.api.fepois.fepois.qmd) function.
-    Note that no demeaning is performed in this class: demeaning is performed in the
-    FixestMulti class (to allow for caching of demeaned variables for multiple estimation).
+    IRLS residualization is orchestrated by ``Feglm`` through the shared
+    ``DemeanCache`` supplied by the estimation runner.
 
     The method implements the algorithm from Stata's `ppmlhdfe` module.
 
     Attributes
     ----------
     _Y : np.ndarray
-        The demeaned dependent variable, a two-dimensional numpy array.
+        Final within-scale IRLS working response. It is not multiplied by the
+        square root of the working weights.
     _X : np.ndarray
-        The demeaned independent variables, a two-dimensional numpy array.
-    _fe : np.ndarray
-        Fixed effects, a two-dimensional numpy array or None.
-    weights : np.ndarray
-        Weights, a one-dimensional numpy array or None.
+        Final within-scale IRLS design. It is not multiplied by the square root
+        of the working weights.
+    _fe : pd.DataFrame or None
+        Formula-scale fixed effects.
+    _weights : np.ndarray
+        Compatibility alias containing observation weights only.
+    _irls_weights : np.ndarray
+        Final IRLS working weights.
     coefnames : list[str]
         Names of the coefficients in the design matrix X.
     drop_singletons : bool
@@ -104,7 +110,7 @@ class Fepois(Feglm):
         weights: str | None,
         weights_type: str | None,
         collin_tol: float,
-        lookup_demeaned_data: dict[frozenset[int], pd.DataFrame],
+        lookup_demeaned_data: dict[frozenset[int], DemeanedData],
         tol: float,
         maxiter: int,
         solver: SolverOptions = "np.linalg.solve",
@@ -118,7 +124,7 @@ class Fepois(Feglm):
         sample_split_value: str | int | None = None,
         separation_check: list[str] | None = None,
         offset: str | None = None,
-    ):
+    ) -> None:
         super().__init__(
             FixestFormula=FixestFormula,
             data=data,
@@ -147,13 +153,21 @@ class Fepois(Feglm):
         # Poisson-specific overrides on top of the Feglm-set defaults.
         self._method = "fepois"
         self._offset_name = offset
+        # The inherited jackknife refit dispatch is valid for Poisson and is a
+        # longstanding public capability. Other GLM families keep this disabled.
+        self._support_crv3_inference = True
         self._supports_cluster_causal_variance = False
         self._support_decomposition = False
 
     def get_fit(self) -> None:
         "Fit via Feglm IRLS, then add Poisson-specific post-fit summary stats."
-        y_orig = np.asarray(self._Y).flatten()
-        user_weights = self._weights.flatten().copy()
+        y_orig = self._formula_data.dependent.to_numpy().flatten()
+        observation_weights = self._observation_weights.values
+        user_weights = (
+            np.ones_like(y_orig, dtype=np.float64)
+            if observation_weights is None
+            else observation_weights
+        )
 
         super().get_fit()
 
@@ -191,6 +205,40 @@ class Fepois(Feglm):
         self.deviance = self._family.deviance(
             y_orig, self._Y_hat_response, user_weights
         )
+
+    def _estimation_refit_kwargs(self) -> dict[str, Any]:
+        """Return the full Poisson estimation contract for data-changing refits."""
+        kwargs = super()._estimation_refit_kwargs()
+        kwargs.update(
+            {
+                "offset": self._offset_name,
+                "iwls_tol": self.tol,
+                "iwls_maxiter": self.maxiter,
+                "separation_check": (
+                    None
+                    if self.separation_check is None
+                    else list(self.separation_check)
+                ),
+            }
+        )
+        return kwargs
+
+    def _crv3_refit(self, data: pd.DataFrame) -> Fepois:
+        """Replay Poisson estimation for one leave-one-cluster-out sample."""
+        # lazy loading to avoid circular import
+        fixest_module = import_module("pyfixest.estimation")
+        return fixest_module.fepois(
+            fml=self._fml,
+            data=data,
+            vcov="iid",
+            **self._estimation_refit_kwargs(),
+        )
+
+    def _clear_attributes(self) -> None:
+        """Apply GLM cleanup and discard the Poisson null-fit array when lean."""
+        super()._clear_attributes()
+        if self._lean and hasattr(self, "_y_hat_null"):
+            del self._y_hat_null
 
     def predict(
         self,

--- a/pyfixest/estimation/models/feprobit_.py
+++ b/pyfixest/estimation/models/feprobit_.py
@@ -6,6 +6,7 @@ import pandas as pd
 from pyfixest.core.demean import Preconditioner
 from pyfixest.demeaners import AnyDemeaner
 from pyfixest.estimation.formula.parse import Formula as FixestFormula
+from pyfixest.estimation.internals.demean_ import DemeanedData
 from pyfixest.estimation.internals.families import PROBIT
 from pyfixest.estimation.models.feglm_ import Feglm
 
@@ -23,7 +24,7 @@ class Feprobit(Feglm):
         weights: str | None,
         weights_type: str | None,
         collin_tol: float,
-        lookup_demeaned_data: dict[frozenset[int], pd.DataFrame],
+        lookup_demeaned_data: dict[frozenset[int], DemeanedData],
         tol: float,
         maxiter: int,
         solver: Literal[

--- a/pyfixest/estimation/plan_.py
+++ b/pyfixest/estimation/plan_.py
@@ -10,6 +10,7 @@ from pyfixest.core.demean import Preconditioner
 from pyfixest.estimation.api.utils import _ALL_SAMPLE, _AllSampleSentinel
 from pyfixest.estimation.config import EstimationConfig
 from pyfixest.estimation.formula.parse import Formula as FixestFormula
+from pyfixest.estimation.internals.demean_ import DemeanedData
 from pyfixest.estimation.internals.vcov_utils import _get_vcov_type
 from pyfixest.estimation.models.fegaussian_ import Fegaussian
 from pyfixest.estimation.models.feiv_ import Feiv
@@ -292,7 +293,7 @@ def _build_model_kwargs(
 def fit_one(
     spec: ModelSpec,
     *,
-    lookup_demeaned_data: dict[frozenset[int], pd.DataFrame],
+    lookup_demeaned_data: dict[frozenset[int], DemeanedData],
     lookup_preconditioner: dict[frozenset[int], Preconditioner],
     vcov: str | dict[str, str] | None,
     vcov_kwargs: dict[str, str | int] | None,

--- a/pyfixest/estimation/post_estimation/ritest.py
+++ b/pyfixest/estimation/post_estimation/ritest.py
@@ -36,6 +36,7 @@ def _get_ritest_stats_slow(
     model: str,
     rng: np.random.Generator,
     vcov: str | dict[str, str],
+    refit_kwargs: dict | None = None,
     clustervar_arr: np.ndarray | None = None,
 ) -> np.ndarray:
     """
@@ -62,6 +63,9 @@ def _get_ritest_stats_slow(
         The random number generator.
     vcov : str or dict[str, str]
         The type of covarianc estimator. See `feols` or `fepois` for details.
+    refit_kwargs : dict, optional
+        Estimator options from the original fit that must be replayed on each
+        resampled data set. Defaults to no additional options.
     clustervar_arr : np.ndarray, optional
         Array containing the cluster variable. Defaults to None.
 
@@ -77,6 +81,7 @@ def _get_ritest_stats_slow(
 
     fixest_module = import_module("pyfixest.estimation")
     fit_ = getattr(fixest_module, model)
+    fit_kwargs = {} if refit_kwargs is None else refit_kwargs
 
     resampvar_arr = data_resampled[resampvar].to_numpy()
 
@@ -92,7 +97,12 @@ def _get_ritest_stats_slow(
 
         data_resampled[f"{resampvar}_resampled"] = D_treat
 
-        fixest_fit = fit_(fml_update, data=data_resampled, vcov=vcov)
+        fixest_fit = fit_(
+            fml_update,
+            data=data_resampled,
+            vcov=vcov,
+            **fit_kwargs,
+        )
         if type == "randomization-c":
             ri_stats[i] = fixest_fit.coef().xs(f"{resampvar}_resampled")
         else:

--- a/pyfixest/estimation/quantreg/QuantregMulti.py
+++ b/pyfixest/estimation/quantreg/QuantregMulti.py
@@ -112,11 +112,11 @@ class QuantregMulti:
             fit_kwargs["rng"] = rng
         beta_hat = self.all_quantregs[q[q_median_idx]]._fit(**fit_kwargs)[0]
 
-        self.all_quantregs[q[q_median_idx]]._beta_hat = beta_hat
-        self.all_quantregs[q[q_median_idx]]._u_hat = (
-            Y.flatten() - (X @ beta_hat).flatten()
+        self._publish_fit_state(
+            quantreg=self.all_quantregs[q[q_median_idx]],
+            beta_hat=beta_hat,
+            hessian=hessian,
         )
-        self.all_quantregs[q[q_median_idx]]._hessian = hessian
 
         def _direction_helper(i, direction):
             if direction == "left":
@@ -139,9 +139,11 @@ class QuantregMulti:
                 beta_hat = self.all_quantregs[q[i]].fit_qreg_pfn(
                     X=X, Y=Y, q=q[i], beta_init=beta_hat_prev, eta=0.5
                 )[0]
-                self.all_quantregs[q[i]]._beta_hat = beta_hat
-                self.all_quantregs[q[i]]._u_hat = Y.flatten() - (X @ beta_hat).flatten()
-                self.all_quantregs[q[i]]._hessian = hessian
+                self._publish_fit_state(
+                    quantreg=self.all_quantregs[q[i]],
+                    beta_hat=beta_hat,
+                    hessian=hessian,
+                )
 
             for i in range(q_median_idx - 1, -1, -1):
                 _cfm1_fun(i, "left")
@@ -165,12 +167,11 @@ class QuantregMulti:
                 M = X.T @ (q[i] - (u_hat_prev < 0))[:, None]
                 beta_new = beta_hat_prev + np.linalg.solve(J, M).flatten()
 
-                self.all_quantregs[q[i]]._beta_hat = beta_new
-                self.all_quantregs[q[i]]._u_hat = (
-                    self.all_quantregs[q[i]]._Y.flatten()
-                    - self.all_quantregs[q[i]]._X @ beta_new
+                self._publish_fit_state(
+                    quantreg=self.all_quantregs[q[i]],
+                    beta_hat=beta_new,
+                    hessian=hessian,
                 )
-                self.all_quantregs[q[i]]._hessian = hessian
 
             for i in range(q_median_idx - 1, -1, -1):
                 _cfm2_fun(i, "left")
@@ -188,6 +189,18 @@ class QuantregMulti:
             sorted(self.all_quantregs.items(), key=lambda item: item[0])
         )
         return self.all_quantregs
+
+    @staticmethod
+    def _publish_fit_state(
+        *, quantreg: Quantreg, beta_hat: np.ndarray, hessian: np.ndarray
+    ) -> None:
+        """Publish canonical child state after a multi-quantile solver step."""
+        y_hat = quantreg._X @ beta_hat
+        quantreg._beta_hat = beta_hat
+        quantreg._Y_hat_link = y_hat
+        quantreg._Y_hat_response = y_hat
+        quantreg._u_hat = quantreg._Y.flatten() - y_hat
+        quantreg._hessian = hessian
 
     def vcov(
         self,
@@ -226,10 +239,4 @@ class QuantregMulti:
         "Clear all large non-necessary attributes to free memory."
         for quantreg in self.all_quantregs.values():
             quantreg._clear_attributes()
-
-        del_attributes = ["_X", "_Y"]
-        for quantreg in self.all_quantregs.values():
-            for attr in del_attributes:
-                if hasattr(quantreg, attr):
-                    delattr(quantreg, attr)
         gc.collect()

--- a/pyfixest/estimation/quantreg/QuantregMulti.py
+++ b/pyfixest/estimation/quantreg/QuantregMulti.py
@@ -11,6 +11,7 @@ from scipy.stats import norm
 
 from pyfixest.demeaners import AnyDemeaner
 from pyfixest.estimation.formula.parse import Formula as FixestFormula
+from pyfixest.estimation.internals.demean_ import DemeanedData
 from pyfixest.estimation.internals.literals import (
     QuantregMethodOptions,
     QuantregMultiOptions,
@@ -35,7 +36,7 @@ class QuantregMulti:
         weights: str | None,
         weights_type: str | None,
         collin_tol: float,
-        lookup_demeaned_data: dict[frozenset[int], pd.DataFrame],
+        lookup_demeaned_data: dict[frozenset[int], DemeanedData],
         solver: SolverOptions = "np.linalg.solve",
         demeaner: AnyDemeaner | None = None,
         store_data: bool = True,

--- a/pyfixest/estimation/quantreg/quantreg_.py
+++ b/pyfixest/estimation/quantreg/quantreg_.py
@@ -9,6 +9,8 @@ from scipy.linalg import cho_factor, solve_triangular
 
 from pyfixest.demeaners import AnyDemeaner
 from pyfixest.estimation.formula.parse import Formula as FixestFormula
+from pyfixest.estimation.internals.collinearity import drop_multicollinear_variables
+from pyfixest.estimation.internals.demean_ import DemeanedData
 from pyfixest.estimation.internals.literals import (
     QuantregMethodOptions,
     SolverOptions,
@@ -69,7 +71,7 @@ class Quantreg(Feols):
         weights: str | None,
         weights_type: str | None,
         collin_tol: float,
-        lookup_demeaned_data: dict[frozenset[int], pd.DataFrame],
+        lookup_demeaned_data: dict[frozenset[int], DemeanedData],
         solver: SolverOptions = "np.linalg.solve",
         demeaner: AnyDemeaner | None = None,
         store_data: bool = True,
@@ -177,12 +179,29 @@ class Quantreg(Feols):
             raise ValueError(f"`method` must be one of {{{valid}}}") from exc
 
     def to_array(self):
-        "Turn estimation DataFrames to np arrays."
-        self._Y, self._X, self._Z = (
-            self._Y.to_numpy(),
-            self._X.to_numpy(),
-            self._X.to_numpy(),
-        )
+        "Publish quantile-regression arrays from the immutable formula state."
+        response = self._formula_data.dependent.to_numpy(dtype=np.float64)
+        design = self._formula_data.independent.to_numpy(dtype=np.float64)
+        self._Y = response
+        self._X = design
+        self._Z = design
+
+    def drop_multicol_vars(self):
+        "Detect and drop multicollinear quantile-regression covariates."
+        if self._X.shape[1] > 0:
+            (
+                self._X,
+                self._coefnames,
+                self._collin_vars,
+                self._collin_index,
+            ) = drop_multicollinear_variables(
+                self._X,
+                self._coefnames,
+                self._collin_tol,
+            )
+        self._Z = self._X
+        self._X_is_empty = self._X.shape[1] == 0
+        self._k = self._X.shape[1]
 
     def prepare_model_matrix(self):
         "Prepare model inputs for estimation."
@@ -215,6 +234,20 @@ class Quantreg(Feols):
         self._u_hat = self._Y.flatten() - self._X @ self._beta_hat
         self._hessian = self._X.T @ self._X
         self._bread = np.linalg.inv(self._hessian)
+
+    def _clear_attributes(self) -> None:
+        """Apply base cleanup and discard quantile solver arrays when lean."""
+        super()._clear_attributes()
+        if self._lean:
+            for attr in (
+                "_x_final",
+                "_s_final",
+                "_z_final",
+                "_w_final",
+                "_y_final",
+            ):
+                if hasattr(self, attr):
+                    delattr(self, attr)
 
     def fit_qreg_fn(
         self,
@@ -393,12 +426,20 @@ class Quantreg(Feols):
 
     def _vcov_iid(self):
         return vcov_iid_qreg(
-            X=self._X, Y=self._Y, u_hat=self._u_hat, q=self._quantile, N=self._N
+            X=self._X,
+            Y=self._Y,
+            u_hat=self._u_hat,
+            q=self._quantile,
+            N=self._N_rows,
         )
 
     def _vcov_hetero(self):
         return vcov_hetero_qreg(
-            X=self._X, Y=self._Y, u_hat=self._u_hat, q=self._quantile, N=self._N
+            X=self._X,
+            Y=self._Y,
+            u_hat=self._u_hat,
+            q=self._quantile,
+            N=self._N_rows,
         )
 
     def _vcov_nid(self) -> np.ndarray:
@@ -414,7 +455,7 @@ class Quantreg(Feols):
             Y=self._Y,
             beta_hat=self._beta_hat,
             q=self._quantile,
-            N=self._N,
+            N=self._N_rows,
             method=cast(QuantregMethodOptions, self._method),
             fit=self._fit,
         )

--- a/pyfixest/estimation/quantreg/quantreg_.py
+++ b/pyfixest/estimation/quantreg/quantreg_.py
@@ -118,6 +118,7 @@ class Quantreg(Feols):
         self._support_crv3_inference = False
         self._supports_cluster_causal_variance = False
         self._support_hac_inference = False
+        self._support_decomposition = False
 
         self._quantile = quantile
         self._method = f"quantreg_{method}"

--- a/pyfixest/estimation/runner.py
+++ b/pyfixest/estimation/runner.py
@@ -8,6 +8,7 @@ import pandas as pd
 from pyfixest.core.demean import Preconditioner
 from pyfixest.estimation.config import EstimationConfig
 from pyfixest.estimation.FixestMulti_ import FixestMulti
+from pyfixest.estimation.internals.demean_ import DemeanedData
 from pyfixest.estimation.models.feiv_ import Feiv
 from pyfixest.estimation.models.feols_ import Feols
 from pyfixest.estimation.models.fepois_ import Fepois
@@ -81,7 +82,7 @@ def run_estimation(
 
     _NO_CACHE_KEY: Any = object()
     prev_cache_key: Any = _NO_CACHE_KEY
-    lookup_demeaned_data: dict[frozenset[int], pd.DataFrame] = {}
+    lookup_demeaned_data: dict[frozenset[int], DemeanedData] = {}
     lookup_preconditioner: dict[frozenset[int], Preconditioner] = {}
 
     for spec in specs:

--- a/tests/test_demean.py
+++ b/tests/test_demean.py
@@ -9,7 +9,7 @@ import pyfixest as pf
 from pyfixest.core import demean as demean_rs
 from pyfixest.core.demean import demean_within
 from pyfixest.demeaners import LsmrDemeaner, MapDemeaner, _resolve_preconditioner
-from pyfixest.estimation.internals.demean_ import DemeanCache
+from pyfixest.estimation.internals.demean_ import DemeanCache, DemeanedData
 from pyfixest.estimation.numba.demean_nb import demean as demean_numba
 from tests._torch_test_utils import HAS_TORCH, torch_param
 
@@ -622,16 +622,19 @@ def test_demean_model_no_fixed_effects(benchmark, demeaner):
     """Test DemeanCache.demean_yx when there are no fixed effects."""
     # Create sample data
     N = 1000
-    Y = pd.DataFrame({"y": np.random.randn(N)})
-    X = pd.DataFrame({"x1": np.random.randn(N), "x2": np.random.randn(N)})
+    rng = np.random.default_rng(42)
+    Y = pd.DataFrame({"y": rng.normal(size=N)})
+    X = pd.DataFrame({"x1": rng.normal(size=N), "x2": rng.normal(size=N)})
     weights = np.ones(N)
     cache = DemeanCache()
 
     # Test without fixed effects
     Yd, Xd, _ = benchmark(
         cache.demean_yx,
-        Y=Y,
-        X=X,
+        Y=Y.to_numpy(),
+        X=X.to_numpy(),
+        y_names=Y.columns,
+        x_names=X.columns,
         fe=None,
         weights=weights,
         na_index=frozenset(),
@@ -639,10 +642,9 @@ def test_demean_model_no_fixed_effects(benchmark, demeaner):
     )
 
     # When no fixed effects, output should equal input
-    assert np.allclose(Y.values, Yd.values)
-    assert np.allclose(X.values, Xd.values)
-    assert Yd.columns.equals(Y.columns)
-    assert Xd.columns.equals(X.columns)
+    assert np.allclose(Y.values, Yd)
+    assert np.allclose(X.values, Xd)
+    assert cache.lookup_demeaned_data == {}
 
 
 @pytest.mark.parametrize("demeaner", MODEL_DEMEANERS)
@@ -662,27 +664,27 @@ def test_demean_model_with_fixed_effects(benchmark, demeaner):
     # Run demean_yx
     Yd, Xd, _ = benchmark(
         cache.demean_yx,
-        Y=Y,
-        X=X,
-        fe=fe,
+        Y=Y.to_numpy(),
+        X=X.to_numpy(),
+        y_names=Y.columns,
+        x_names=X.columns,
+        fe=fe.to_numpy(),
         weights=weights,
         na_index=frozenset(),
         demeaner=demeaner,
     )
 
     # Verify results are different from input (since we're demeaning)
-    assert not np.allclose(Y.values, Yd.values)
-    assert not np.allclose(X.values, Xd.values)
-
-    # Verify column names are preserved
-    assert Yd.columns.equals(Y.columns)
-    assert Xd.columns.equals(X.columns)
+    assert not np.allclose(Y.values, Yd)
+    assert not np.allclose(X.values, Xd)
 
     # Verify results are cached in lookup_dict
     assert frozenset() in lookup_dict
     cached_data = lookup_dict[frozenset()]
-    assert np.allclose(cached_data[Y.columns].values, Yd.values)
-    assert np.allclose(cached_data[X.columns].values, Xd.values)
+    assert isinstance(cached_data, DemeanedData)
+    assert cached_data.columns == ("y", "x1", "x2")
+    assert np.allclose(cached_data.values[:, :1], Yd)
+    assert np.allclose(cached_data.values[:, 1:], Xd)
 
 
 @pytest.mark.parametrize("demeaner", MODEL_DEMEANERS)
@@ -700,27 +702,31 @@ def test_demean_model_with_weights(benchmark, demeaner):
     # Run with weights
     Yd, Xd, _ = benchmark(
         cache.demean_yx,
-        Y=Y,
-        X=X,
-        fe=fe,
+        Y=Y.to_numpy(),
+        X=X.to_numpy(),
+        y_names=Y.columns,
+        x_names=X.columns,
+        fe=fe.to_numpy(),
         weights=weights,
         na_index=frozenset(),
         demeaner=demeaner,
     )
 
-    # Run without weights for comparison (fresh cache to avoid cache hit)
+    # Run the explicit unweighted fast path (fresh cache to avoid cache hit)
     Yd_unweighted, Xd_unweighted, _ = DemeanCache().demean_yx(
-        Y=Y,
-        X=X,
-        fe=fe,
-        weights=np.ones(N),
+        Y=Y.to_numpy(),
+        X=X.to_numpy(),
+        y_names=Y.columns,
+        x_names=X.columns,
+        fe=fe.to_numpy(),
+        weights=None,
         na_index=frozenset(),
         demeaner=demeaner,
     )
 
     # Results should be different with weights vs without
-    assert not np.allclose(Yd.values, Yd_unweighted.values)
-    assert not np.allclose(Xd.values, Xd_unweighted.values)
+    assert not np.allclose(Yd, Yd_unweighted)
+    assert not np.allclose(Xd, Xd_unweighted)
 
 
 @pytest.mark.parametrize("demeaner", MODEL_DEMEANERS)
@@ -734,49 +740,78 @@ def test_demean_model_caching(benchmark, demeaner):
     fe = pd.DataFrame({"fe1": rng.integers(0, 10, N)})
     weights = np.ones(N)
     lookup_dict = {}
+    first_cache = DemeanCache(lookup_dict)
+    assert first_cache.lookup_demeaned_data is lookup_dict
 
     # First run - should compute and cache
-    Yd1, Xd1, _ = DemeanCache(lookup_dict).demean_yx(
-        Y=Y,
-        X=X,
-        fe=fe,
+    Yd1, Xd1, _ = first_cache.demean_yx(
+        Y=Y.to_numpy(),
+        X=X.to_numpy(),
+        y_names=Y.columns,
+        x_names=X.columns,
+        fe=fe.to_numpy(),
         weights=weights,
         na_index=frozenset(),
         demeaner=demeaner,
     )
 
     # Second run - should use cache (shared lookup, fresh per-model cache)
+    second_cache = DemeanCache(lookup_dict)
+    assert second_cache.lookup_demeaned_data is lookup_dict
     Yd2, Xd2, _ = benchmark(
-        DemeanCache(lookup_dict).demean_yx,
-        Y=Y,
-        X=X,
-        fe=fe,
+        second_cache.demean_yx,
+        Y=Y.to_numpy(),
+        X=X.to_numpy(),
+        y_names=Y.columns,
+        x_names=X.columns,
+        fe=fe.to_numpy(),
         weights=weights,
         na_index=frozenset(),
         demeaner=demeaner,
     )
 
     # Results should be identical
-    assert np.allclose(Yd1.values, Yd2.values)
-    assert np.allclose(Xd1.values, Xd2.values)
+    assert np.allclose(Yd1, Yd2)
+    assert np.allclose(Xd1, Xd2)
 
     # Add new variable and verify partial caching
-    X_new = X.copy()
-    X_new["x3"] = rng.normal(0, 1, N)
+    X_new = pd.DataFrame(
+        {
+            "x4": rng.normal(0, 1, N),
+            "x1": X["x1"],
+            "x3": rng.normal(0, 1, N),
+            "x2": X["x2"],
+        }
+    )
 
     _, Xd3, _ = DemeanCache(lookup_dict).demean_yx(
-        Y=Y,
-        X=X_new,
-        fe=fe,
+        Y=Y.to_numpy(),
+        X=X_new.to_numpy(),
+        y_names=Y.columns,
+        x_names=X_new.columns,
+        fe=fe.to_numpy(),
+        weights=weights,
+        na_index=frozenset(),
+        demeaner=demeaner,
+    )
+    _, Xd3_fresh, _ = DemeanCache().demean_yx(
+        Y=Y.to_numpy(),
+        X=X_new.to_numpy(),
+        y_names=Y.columns,
+        x_names=X_new.columns,
+        fe=fe.to_numpy(),
         weights=weights,
         na_index=frozenset(),
         demeaner=demeaner,
     )
 
-    # Original columns should match previous results
-    assert np.allclose(Xd3[["x1", "x2"]].values, Xd2.values)
-    # New column should be different
-    assert "x3" in Xd3.columns
+    # Requested output order matches an independent solve, while the shared
+    # cache keeps first-seen insertion order and all earlier columns.
+    assert np.allclose(Xd3, Xd3_fresh)
+    assert np.allclose(Xd3[:, [1, 3]], Xd2)
+    cached_data = lookup_dict[frozenset()]
+    assert isinstance(cached_data, DemeanedData)
+    assert cached_data.columns == ("y", "x1", "x2", "x4", "x3")
 
 
 @pytest.mark.parametrize(
@@ -806,9 +841,11 @@ def test_demean_model_maxiter_convergence_failure(demeaner):
     # Should fail with very small maxiter
     with pytest.raises(ValueError, match="Demeaning failed after 1 iterations"):
         DemeanCache().demean_yx(
-            Y=Y,
-            X=X,
-            fe=fe,
+            Y=Y.to_numpy(),
+            X=X.to_numpy(),
+            y_names=Y.columns,
+            x_names=X.columns,
+            fe=fe.to_numpy(),
             weights=weights,
             na_index=frozenset(),
             demeaner=demeaner,

--- a/tests/test_detect_singletons.py
+++ b/tests/test_detect_singletons.py
@@ -3,6 +3,35 @@ import pytest
 
 from pyfixest.core.detect_singletons import detect_singletons
 
+
+def test_frequency_counts_prevent_false_singletons_and_still_cascade():
+    """Frequency totals, not physical row counts, define expanded singletons."""
+    fixed_effects = np.array(
+        [
+            [0, 0],
+            [1, 0],
+            [1, 1],
+            [2, 1],
+        ]
+    )
+    weights = np.array([2, 1, 1, 1])
+
+    np.testing.assert_array_equal(
+        detect_singletons(fixed_effects, frequency_weights=weights),
+        np.array([False, True, True, True]),
+    )
+
+
+@pytest.mark.parametrize("invalid_weight", [np.nan, np.inf, 0.0, -1.0])
+def test_frequency_counts_must_be_finite_and_strictly_positive(invalid_weight):
+    """Direct callers receive the same weight-domain validation as estimators."""
+    fixed_effects = np.array([[0], [0]])
+    weights = np.array([1.0, invalid_weight])
+
+    with pytest.raises(ValueError, match="finite and strictly positive"):
+        detect_singletons(fixed_effects, frequency_weights=weights)
+
+
 input1 = np.array([[0, 2, 1], [0, 2, 1], [0, 1, 3], [0, 1, 2], [0, 1, 2]])
 solution1 = np.array([False, False, True, False, False])
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -934,6 +934,23 @@ def test_gelbach_errors():
         )
 
 
+@pytest.mark.parametrize("model_type", ["feglm", "quantreg"])
+def test_decomposition_rejects_unsupported_models(model_type):
+    data = gelbach_data(nobs=100)
+
+    if model_type == "feglm":
+        data["binary_y"] = (data["y"] > data["y"].median()).astype(int)
+        fit = pf.feglm("binary_y ~ x1 + x21", data=data, family="logit")
+    else:
+        fit = pf.quantreg("y ~ x1 + x21", data=data, quantile=0.5)
+
+    with pytest.raises(
+        NotImplementedError,
+        match=r"Decomposition is currently only supported for OLS models\.",
+    ):
+        fit.decompose(decomp_var="x1", only_coef=True)
+
+
 def test_glm_errors():
     "Test that dependent variable must be binary for probit and logit models."
     data = pf.get_data()

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -56,11 +56,11 @@ def test_cluster_na():
         feols(fml="Y ~ X1", data=data, vcov={"CRV1": "f3"})
 
 
-def test_cluster_but_no_data():
-    """Test if AttributeError if self._data is not stored."""
+def test_cluster_vcov_without_stored_or_explicit_data_is_informative():
+    """Data-dependent vcov updates explain how to supply stripped data."""
     data = get_data()
     fit = feols("Y ~ X1", data=data, store_data=False)
-    with pytest.raises(AttributeError):
+    with pytest.raises(RuntimeError, match=r"store_data=False.*Pass.*data="):
         fit.vcov({"CRV1": "f2"})
 
 
@@ -423,7 +423,13 @@ def test_errors_ccv():
 
     # error when fixed effects in estimation
     fit = feols("Y ~ D | f1", data=data)
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(NotImplementedError, match=r"not supported.*fixed effects"):
+        fit.ccv(treatment="D", pk=0.05, qk=0.5, n_splits=10, seed=929)
+
+    # weighted CCV needs a separately defined estimating equation
+    data["observation_weight"] = np.linspace(0.5, 2.0, len(data))
+    fit = feols("Y ~ D", data=data, weights="observation_weight")
+    with pytest.raises(NotImplementedError, match=r"not supported.*weights"):
         fit.ccv(treatment="D", pk=0.05, qk=0.5, n_splits=10, seed=929)
 
     # error when treatment not found
@@ -456,6 +462,38 @@ def test_errors_ccv():
     fit = feols("Y ~ 1 | D ~ Z1", data=data)
     with pytest.raises(AssertionError):
         fit.ccv(treatment="D", pk=0.05, qk=0.5, n_splits=10, seed=929)
+
+
+def test_weighted_update_is_explicitly_unsupported():
+    data = get_data().dropna(subset=["Y", "X1", "weights"])
+    fit = feols("Y ~ X1", data=data, weights="weights")
+
+    with pytest.raises(NotImplementedError, match=r"update.*not supported.*weights"):
+        fit.update(X_new=np.ones((1, 2)), y_new=np.ones(1))
+
+
+def test_iv_update_is_explicitly_unsupported():
+    data = get_data().dropna(subset=["Y", "X1", "Z1"])
+    fit = feols("Y ~ 1 + [X1 ~ Z1]", data=data)
+
+    with pytest.raises(NotImplementedError, match=r"update.*not supported.*IV"):
+        fit.update(X_new=np.ones((1, fit._k)), y_new=np.ones(1))
+
+
+def test_non_ols_update_is_explicitly_unsupported():
+    poisson_data = get_data(model="Fepois").dropna()
+    linear_data = get_data().dropna()
+    binary_data = poisson_data.copy()
+    binary_data["Y"] = (binary_data["Y"] > binary_data["Y"].median()).astype(int)
+    models = (
+        pf.fepois("Y ~ X1", data=poisson_data),
+        pf.feglm("Y ~ X1", data=binary_data, family="logit"),
+        pf.quantreg("Y ~ X1", data=linear_data),
+    )
+
+    for fit in models:
+        with pytest.raises(NotImplementedError, match=r"update.*only supported.*OLS"):
+            fit.update(X_new=np.ones((1, fit._k)), y_new=np.ones(1))
 
 
 def test_errors_confint():
@@ -532,6 +570,46 @@ def test_ritest_error(data):
         fit = pf.feols("Y ~ X1", data=data)
         fit.ritest(resampvar="X1", reps=100)
         fit.plot_ritest()
+
+
+@pytest.mark.parametrize("estimator", ["feglm", "quantreg"])
+def test_ritest_rejects_non_ols_working_domains(estimator):
+    """RI must not interpret GLM or quantile arrays as OLS solver inputs."""
+    data = pd.DataFrame(
+        {
+            "y": [0, 1, 0, 1, 1, 0, 1, 0],
+            "x": np.linspace(-1.0, 1.0, 8),
+        }
+    )
+    if estimator == "feglm":
+        fit = pf.feglm("y ~ x", data=data, family="logit")
+    else:
+        with pytest.warns(FutureWarning, match="experimental"):
+            fit = pf.quantreg("y ~ x", data=data, maxiter=100)
+
+    with pytest.raises(
+        NotImplementedError, match=r"only supported for OLS and Poisson"
+    ):
+        fit.ritest(resampvar="x", reps=1)
+
+
+@pytest.mark.parametrize("estimator", ["feglm", "quantreg"])
+def test_wildboottest_rejects_non_ols_working_domains(estimator):
+    """Wild bootstrap must reject estimator-specific non-OLS array domains."""
+    data = pd.DataFrame(
+        {
+            "y": [0, 1, 0, 1, 1, 0, 1, 0],
+            "x": np.linspace(-1.0, 1.0, 8),
+        }
+    )
+    if estimator == "feglm":
+        fit = pf.feglm("y ~ x", data=data, family="logit")
+    else:
+        with pytest.warns(FutureWarning, match="experimental"):
+            fit = pf.quantreg("y ~ x", data=data, maxiter=100)
+
+    with pytest.raises(NotImplementedError, match=r"only supported for unweighted OLS"):
+        fit.wildboottest(param="x", reps=1)
 
 
 def test_wald_test_invalid_distribution():
@@ -910,6 +988,39 @@ def test_prediction_errors_glm():
             NotImplementedError, match="Prediction with standard errors"
         ):
             model.predict(se_fit=True)
+
+
+@pytest.mark.parametrize("family", ["gaussian", "logit", "probit"])
+def test_glm_crv3_is_explicitly_unsupported(family):
+    """Do not silently run Poisson jackknife refits for other GLM families."""
+    data = pf.get_data(model="Fepois").dropna().copy()
+    if family in ("logit", "probit"):
+        data["Y"] = (data["Y"] > data["Y"].median()).astype(int)
+
+    with pytest.raises(VcovTypeNotSupportedError, match="CRV3 inference"):
+        pf.feglm(
+            "Y ~ X1",
+            data=data,
+            family=family,
+            vcov={"CRV3": "f1"},
+        )
+
+
+def test_poisson_crv3_remains_supported():
+    """Keep the longstanding Poisson jackknife path across both public APIs."""
+    data = pf.get_data(model="Fepois").dropna().iloc[:120].copy()
+    data["cluster"] = np.arange(len(data)) % 6
+
+    direct_fit = pf.fepois("Y ~ X1", data=data, vcov={"CRV3": "cluster"})
+    glm_fit = pf.feglm(
+        "Y ~ X1",
+        data=data,
+        family="poisson",
+        vcov={"CRV3": "cluster"},
+    )
+
+    np.testing.assert_allclose(direct_fit.coef(), glm_fit.coef())
+    np.testing.assert_allclose(direct_fit._vcov, glm_fit._vcov)
 
 
 def test_empty_vcov_error():

--- a/tests/test_estimation_snapshots.py
+++ b/tests/test_estimation_snapshots.py
@@ -44,6 +44,14 @@ LOGIT_VCOV_DELTA_CASE_IDS = frozenset(
     }
 )
 PROBIT_IID_DELTA_CASE_ID = "feglm-003-family=probit-vcov=iid"
+FWEIGHTS_SINGLETON_DELTA_CASE_IDS = frozenset(
+    str(case["id"])
+    for case in CASES
+    if case["estimator"] == "feols"
+    and case["formula"] == "Y ~ X1 + X2 | f1^f2"
+    and case["kwargs"].get("weights") == "fweights"
+    and "group=ssc" in str(case["id"])
+)
 PARAMS = [
     pytest.param(
         case,
@@ -121,11 +129,18 @@ def _assert_snapshot(
     # FEGLM formulas, weights, or vcov variants must not inherit an omission.
     changed_logit_vcov = str(case["id"]) in LOGIT_VCOV_DELTA_CASE_IDS
     changed_probit_iid = str(case["id"]) == PROBIT_IID_DELTA_CASE_ID
+    changed_fweight_singletons = str(case["id"]) in FWEIGHTS_SINGLETON_DELTA_CASE_IDS
     # The documented GLM API/behavior change introduces new logit/probit IRLS
     # starts (docs/changelog.qmd, "GLM API and Behavior"). Only the narrow
     # comparisons below materially exceed normal tolerance; canonical live-R
     # remains their authoritative correctness evidence.
-    if not changed_logit_vcov:
+    # Release 0.60.0 treated a physically unique FE row as a singleton even
+    # when its frequency weight represented repeated observations. Current
+    # head follows literal expansion (and R fixest), which changes effective
+    # sample/FE degrees of freedom and derived inference for precisely the
+    # interaction cases enumerated above. Coefficients and prediction/residual
+    # samples remain checked against the frozen artifact.
+    if not changed_logit_vcov and not changed_fweight_singletons:
         for row_name, expected_row in expected["vcov"].items():
             _assert_named_close(
                 actual["vcov"][row_name],
@@ -134,7 +149,11 @@ def _assert_snapshot(
                 quantity=f"vcov row {row_name}",
             )
     for quantity in ("se", "tstat"):
-        if not changed_logit_vcov and not changed_probit_iid:
+        if (
+            not changed_logit_vcov
+            and not changed_probit_iid
+            and not changed_fweight_singletons
+        ):
             _assert_named_close(
                 actual[quantity],
                 expected[quantity],
@@ -147,13 +166,18 @@ def _assert_snapshot(
         # Only the X2 p-value moves beyond tolerance in logit hetero/CRV1.
         pvalue_actual.pop("X2")
         pvalue_expected.pop("X2")
-    _assert_named_close(
-        pvalue_actual,
-        pvalue_expected,
-        tolerance=tolerances.get("pvalue", tolerances["inference"]),
-        quantity="pvalue",
-    )
-    if estimator != "quantreg" and not changed_logit_vcov:
+    if not changed_fweight_singletons:
+        _assert_named_close(
+            pvalue_actual,
+            pvalue_expected,
+            tolerance=tolerances.get("pvalue", tolerances["inference"]),
+            quantity="pvalue",
+        )
+    if (
+        estimator != "quantreg"
+        and not changed_logit_vcov
+        and not changed_fweight_singletons
+    ):
         for name, expected_interval in expected["confint"].items():
             actual_interval = dict(actual["confint"][name])
             expected_interval = dict(expected_interval)
@@ -175,6 +199,10 @@ def _assert_snapshot(
     expected_metadata = dict(expected["metadata"])
     actual_deviance = actual_metadata.pop("deviance", None)
     expected_deviance = expected_metadata.pop("deviance", None)
+    if changed_fweight_singletons:
+        for name in ("nobs", "df_k", "df_t"):
+            actual_metadata.pop(name)
+            expected_metadata.pop(name)
     assert actual_metadata == expected_metadata, "structural metadata differs"
     if expected_deviance is not None:
         np.testing.assert_allclose(
@@ -212,6 +240,9 @@ def test_estimation_snapshot_inventory(release_contract) -> None:
     assert case_ids >= FAST_CASE_IDS
     assert manifest["fingerprint"] == fingerprint
     assert (snapshot_dir() / COMPLETE_MARKER).read_text().strip() == fingerprint
+    # Freeze the scope of the documented fweight-singleton release delta. A
+    # new formula, vcov, or SSC case must not silently inherit this omission.
+    assert len(FWEIGHTS_SINGLETON_DELTA_CASE_IDS) == 108
 
 
 @pytest.mark.parametrize("case", PARAMS)

--- a/tests/test_estimator_state_lifecycle.py
+++ b/tests/test_estimator_state_lifecycle.py
@@ -1,17 +1,8 @@
-"""Characterize and protect private estimator-state lifecycle boundaries.
-
-These tests intentionally inspect implementation details. Public numerical
-behavior belongs to the release snapshots and live-R suites; this module locks
-the representation, scale, cache, and cleanup seams that those suites cannot
-observe. Refactors should replace these assertions with equivalent assertions
-about the new explicit state objects.
-"""
+"""Protect estimator representation, scale, cache, and cleanup boundaries."""
 
 from __future__ import annotations
 
-from collections.abc import Callable
 from dataclasses import FrozenInstanceError
-from typing import Any
 
 import numpy as np
 import pandas as pd
@@ -20,7 +11,12 @@ import pytest
 import pyfixest as pf
 from pyfixest.estimation.FixestMulti_ import FixestMulti
 from pyfixest.estimation.formula.model_matrix import FormulaData
-from pyfixest.estimation.models.feols_ import Feols
+from pyfixest.estimation.internals.demean_ import DemeanedData
+from pyfixest.estimation.internals.model_state import (
+    GlmWorkingState,
+    ObservationWeights,
+    WithinLinearData,
+)
 
 
 @pytest.fixture
@@ -57,75 +53,16 @@ def lifecycle_data() -> pd.DataFrame:
     )
 
 
-def _clone_state(value: Any) -> Any:
-    if isinstance(value, (pd.DataFrame, pd.Series, np.ndarray)):
-        return value.copy()
-    return value
-
-
-def _capture_after(
-    monkeypatch: pytest.MonkeyPatch,
-    *,
-    method_name: str,
-    state_name: str,
-    attributes: tuple[str, ...],
-    states: dict[str, dict[str, Any]],
-) -> None:
-    """Capture selected Feols attributes after one lifecycle method."""
-    original: Callable[..., Any] = getattr(Feols, method_name)
-
-    def wrapped(self: Feols, *args: Any, **kwargs: Any) -> Any:
-        result = original(self, *args, **kwargs)
-        states[state_name] = {
-            attribute: _clone_state(getattr(self, attribute))
-            for attribute in attributes
-        }
-        return result
-
-    monkeypatch.setattr(Feols, method_name, wrapped)
-
-
 @pytest.mark.parametrize(
     ("weights_type", "expected_n"),
     [("aweights", 24), ("fweights", 52)],
 )
-def test_feols_fields_change_type_and_scale_during_fit(
-    monkeypatch: pytest.MonkeyPatch,
+def test_feols_keeps_formula_within_and_weight_domains_distinct(
     lifecycle_data: pd.DataFrame,
     weights_type: str,
     expected_n: int,
 ) -> None:
-    """Record the DataFrame -> within array -> solver array mutation."""
-    states: dict[str, dict[str, Any]] = {}
-    _capture_after(
-        monkeypatch,
-        method_name="prepare_model_matrix",
-        state_name="formula",
-        attributes=("_Y", "_X", "_weights"),
-        states=states,
-    )
-    _capture_after(
-        monkeypatch,
-        method_name="demean",
-        state_name="within_frame",
-        attributes=("_Y", "_X", "_Yd", "_Xd"),
-        states=states,
-    )
-    _capture_after(
-        monkeypatch,
-        method_name="to_array",
-        state_name="within_array",
-        attributes=("_Y", "_X"),
-        states=states,
-    )
-    _capture_after(
-        monkeypatch,
-        method_name="wls_transform",
-        state_name="solver",
-        attributes=("_Y", "_X"),
-        states=states,
-    )
-
+    """A weighted FE fit retains within arrays and response-scale residuals."""
     fit = pf.feols(
         "y ~ x | fe",
         data=lifecycle_data,
@@ -134,29 +71,21 @@ def test_feols_fields_change_type_and_scale_during_fit(
         vcov="iid",
     )
 
-    assert isinstance(states["formula"]["_Y"], pd.DataFrame)
-    assert isinstance(states["formula"]["_X"], pd.DataFrame)
-    assert isinstance(states["within_frame"]["_Yd"], pd.DataFrame)
-    assert isinstance(states["within_frame"]["_Xd"], pd.DataFrame)
-    assert isinstance(states["within_array"]["_Y"], np.ndarray)
-    assert isinstance(states["within_array"]["_X"], np.ndarray)
-    assert isinstance(states["solver"]["_Y"], np.ndarray)
-    assert isinstance(states["solver"]["_X"], np.ndarray)
+    assert isinstance(fit._formula_data, FormulaData)
+    assert isinstance(fit._formula_data.dependent, pd.DataFrame)
+    assert isinstance(fit._observation_weights, ObservationWeights)
+    assert isinstance(fit._within_data, WithinLinearData)
+    assert fit._Y is fit._within_data.response
+    assert fit._X is fit._within_data.design
+    assert fit._Z is fit._within_data.design
+    assert not hasattr(fit, "_Yd")
+    assert not hasattr(fit, "_Xd")
 
-    np.testing.assert_allclose(
-        states["within_array"]["_Y"], states["within_frame"]["_Yd"].to_numpy()
-    )
-    np.testing.assert_allclose(
-        states["within_array"]["_X"], states["within_frame"]["_Xd"].to_numpy()
-    )
-
-    sqrt_weight = np.sqrt(states["formula"]["_weights"])
-    np.testing.assert_allclose(
-        states["solver"]["_Y"], states["within_array"]["_Y"] * sqrt_weight
-    )
-    np.testing.assert_allclose(
-        states["solver"]["_X"], states["within_array"]["_X"] * sqrt_weight
-    )
+    weights = lifecycle_data["weight"].to_numpy(dtype=np.float64)
+    np.testing.assert_array_equal(fit._observation_weights.values, weights)
+    np.testing.assert_array_equal(fit._weights.flatten(), weights)
+    assert fit._observation_weights.kind == weights_type
+    assert expected_n == fit._N
 
     weighted_group_mean = (lifecycle_data["y"] * lifecycle_data["weight"]).groupby(
         lifecycle_data["fe"]
@@ -164,20 +93,29 @@ def test_feols_fields_change_type_and_scale_during_fit(
         lifecycle_data["fe"]
     ).transform("sum")
     expected_y_within = lifecycle_data["y"] - weighted_group_mean
-    np.testing.assert_allclose(
-        states["within_frame"]["_Yd"].to_numpy().flatten(), expected_y_within
+    np.testing.assert_allclose(fit._within_data.response.flatten(), expected_y_within)
+    assert not np.allclose(
+        fit._within_data.response.flatten(),
+        expected_y_within * np.sqrt(weights),
     )
 
+    residuals = fit._within_data.response.flatten() - fit._X @ fit._beta_hat
+    np.testing.assert_allclose(fit._u_hat, residuals)
+    np.testing.assert_allclose(fit.resid(), residuals)
     np.testing.assert_allclose(
-        fit._u_hat.flatten(), fit.resid() * np.sqrt(fit._weights.flatten())
+        fit._scores,
+        fit._X * (weights * residuals)[:, None],
     )
-    assert expected_n == fit._N
+    np.testing.assert_allclose(fit._hessian, fit._X.T @ (weights[:, None] * fit._X))
+
+    with pytest.raises(FrozenInstanceError):
+        fit._within_data.response = fit._within_data.design  # type: ignore[misc]
 
 
-def test_weighted_iv_fields_end_on_solver_scale(
+def test_weighted_iv_keeps_each_econometric_role_on_within_scale(
     lifecycle_data: pd.DataFrame,
 ) -> None:
-    """Characterize the retained Y/X/Z domains of a weighted FE-IV fit."""
+    """IV state names response, design, endogenous, and instrument roles."""
     fit = pf.feols(
         "y ~ x + [endog ~ z] | fe",
         data=lifecycle_data,
@@ -186,26 +124,35 @@ def test_weighted_iv_fields_end_on_solver_scale(
         vcov="iid",
     )
 
-    assert isinstance(fit._Yd, pd.DataFrame)
-    assert isinstance(fit._Xd, pd.DataFrame)
-    assert isinstance(fit._Zd, pd.DataFrame)
-    assert isinstance(fit._Y, np.ndarray)
-    assert isinstance(fit._X, np.ndarray)
-    assert isinstance(fit._Z, np.ndarray)
+    within = fit._within_data
+    assert isinstance(within, WithinLinearData)
+    assert within.instruments is not None
+    assert within.endogenous is not None
+    assert fit._Y is within.response
+    assert fit._X is within.design
+    assert fit._Z is within.instruments
+    assert fit._endogvar is within.endogenous
+    assert not hasattr(fit, "_Yd")
+    assert not hasattr(fit, "_Xd")
+    assert not hasattr(fit, "_Zd")
+    assert not hasattr(fit, "_endogvard")
 
-    sqrt_weight = np.sqrt(fit._weights)
-    np.testing.assert_allclose(fit._Y, fit._Yd.to_numpy() * sqrt_weight)
-    np.testing.assert_allclose(fit._X, fit._Xd.to_numpy() * sqrt_weight)
-    np.testing.assert_allclose(fit._Z, fit._Zd.to_numpy() * sqrt_weight)
+    weights = lifecycle_data["weight"].to_numpy(dtype=np.float64)
+    weighted_design = weights[:, None] * within.design
+    weighted_response = weights[:, None] * within.response
+    np.testing.assert_allclose(fit._tZX, within.instruments.T @ weighted_design)
+    np.testing.assert_allclose(fit._tZy, within.instruments.T @ weighted_response)
     np.testing.assert_allclose(
-        fit._u_hat.flatten(), fit.resid() * sqrt_weight.flatten()
+        fit._scores,
+        within.instruments * (weights * fit._u_hat)[:, None],
     )
+    np.testing.assert_allclose(fit.resid(), fit._u_hat)
 
 
 def test_formula_data_remains_canonical_after_linear_fit(
     lifecycle_data: pd.DataFrame,
 ) -> None:
-    """Formula roles remain tabular while compatibility aliases are transformed."""
+    """Formula roles remain tabular after numerical arrays are prepared."""
     fit = pf.feols(
         "y ~ x + [endog ~ z] | fe",
         data=lifecycle_data,
@@ -217,16 +164,13 @@ def test_formula_data_remains_canonical_after_linear_fit(
     assert isinstance(formula_data, FormulaData)
     assert not hasattr(formula_data, "__dict__")
     with pytest.raises(FrozenInstanceError):
-        formula_data.na_index = frozenset()
+        formula_data.na_index = frozenset()  # type: ignore[misc]
 
     assert isinstance(formula_data.dependent, pd.DataFrame)
     assert isinstance(formula_data.independent, pd.DataFrame)
     assert isinstance(formula_data.fixed_effects, pd.DataFrame)
     assert isinstance(formula_data.instruments, pd.DataFrame)
     assert isinstance(formula_data.weights, pd.DataFrame)
-    assert isinstance(fit._Y, np.ndarray)
-    assert isinstance(fit._X, np.ndarray)
-    assert isinstance(fit._Z, np.ndarray)
     pd.testing.assert_frame_equal(
         formula_data.dependent,
         lifecycle_data.loc[:, ["y"]],
@@ -236,6 +180,17 @@ def test_formula_data_remains_canonical_after_linear_fit(
         lifecycle_data.loc[:, ["weight"]],
     )
     assert fit._model_spec is formula_data.model_spec
+
+
+def test_unweighted_effective_n_remains_integer_for_prediction_errors(
+    lifecycle_data: pd.DataFrame,
+) -> None:
+    """An integer physical row count remains usable by prediction allocation."""
+    fit = pf.feols("y ~ x", data=lifecycle_data, vcov="iid")
+
+    assert isinstance(fit._N, int)
+    assert isinstance(fit._observation_weights.n_effective, int)
+    assert fit.predict(se_fit=True).shape == (len(lifecycle_data),)
 
 
 def test_glm_separation_replaces_formula_data_with_filtered_state() -> None:
@@ -269,10 +224,10 @@ def test_glm_separation_replaces_formula_data_with_filtered_state() -> None:
     assert fit.n_separation_na == 2
 
 
-def test_multiple_estimation_shares_dataframe_demean_cache(
+def test_multiple_estimation_shares_array_native_demean_cache(
     lifecycle_data: pd.DataFrame,
 ) -> None:
-    """Record the shared mutable DataFrame cache used by FixestMulti."""
+    """Multiple fits share one ordered array cache without DataFrame round trips."""
     fit = pf.feols(
         "y ~ sw(x, x2) | fe",
         data=lifecycle_data,
@@ -291,11 +246,30 @@ def test_multiple_estimation_shares_dataframe_demean_cache(
     assert demeaned_caches[0] is demeaned_caches[1]
     assert preconditioner_caches[0] is preconditioner_caches[1]
     assert demeaned_caches[0]
-    assert all(isinstance(value, pd.DataFrame) for value in demeaned_caches[0].values())
-    assert all(isinstance(model._Yd, pd.DataFrame) for model in models)
-    assert all(isinstance(model._Xd, pd.DataFrame) for model in models)
-    assert all(isinstance(model._Y, np.ndarray) for model in models)
-    assert all(isinstance(model._X, np.ndarray) for model in models)
+    assert all(isinstance(value, DemeanedData) for value in demeaned_caches[0].values())
+    assert all(isinstance(model._within_data, WithinLinearData) for model in models)
+    assert all(model._Y is model._within_data.response for model in models)
+    assert all(model._X is model._within_data.design for model in models)
+
+
+@pytest.mark.parametrize("fit_kwargs", [{"store_data": False}, {"lean": True}])
+def test_multiple_estimation_respects_storage_options(
+    lifecycle_data: pd.DataFrame,
+    fit_kwargs: dict[str, bool],
+) -> None:
+    """The result container must not retain data cleared from all child fits."""
+    fit = pf.feols(
+        "y ~ sw(x, x2) | fe",
+        data=lifecycle_data,
+        vcov="iid",
+        **fit_kwargs,
+    )
+
+    assert isinstance(fit, FixestMulti)
+    assert not hasattr(fit, "_data")
+    assert not hasattr(fit, "_config")
+    assert not hasattr(fit, "_context")
+    assert all(not hasattr(model, "_data") for model in fit.to_list())
 
 
 @pytest.mark.parametrize(
@@ -308,15 +282,16 @@ def test_multiple_estimation_shares_dataframe_demean_cache(
             frozenset(
                 {
                     "_data",
+                    "_formula_data",
+                    "_within_data",
+                    "_observation_weights",
+                    "_demean_cache",
                     "_X",
                     "_Y",
                     "_Z",
-                    "_Xd",
-                    "_Yd",
                     "_weights",
                     "_scores",
                     "_u_hat",
-                    "_formula_data",
                 }
             ),
         ),
@@ -331,35 +306,168 @@ def test_storage_options_delete_expected_state(
     state_fields = frozenset(
         {
             "_data",
+            "_formula_data",
+            "_within_data",
+            "_observation_weights",
+            "_demean_cache",
             "_X",
             "_Y",
             "_Z",
-            "_Xd",
-            "_Yd",
             "_weights",
             "_scores",
             "_u_hat",
-            "_formula_data",
         }
     )
     fit = pf.feols("y ~ x | fe", data=lifecycle_data, vcov="iid", **fit_kwargs)
 
     observed_fields = frozenset(field for field in state_fields if hasattr(fit, field))
     assert observed_fields == state_fields - missing_fields
+    if fit_kwargs.get("lean"):
+        for field in ("_model_spec", "_context", "_fe", "_weights_df", "_offset_df"):
+            assert not hasattr(fit, field)
     assert np.isfinite(fit.coef()).all()
 
 
-def test_feglm_overwrites_observation_weights_with_working_weights() -> None:
-    """Record the current observation/IRLS weight field collision."""
+def test_store_data_false_allows_array_only_vcov_updates(
+    lifecycle_data: pd.DataFrame,
+) -> None:
+    """Array-only covariance updates do not require retained formula data."""
+    stripped = pf.feols("y ~ x", data=lifecycle_data, vcov="iid", store_data=False)
+    expected = pf.feols("y ~ x", data=lifecycle_data, vcov="HC1")
+
+    stripped.vcov("HC1")
+
+    np.testing.assert_allclose(stripped._vcov, expected._vcov)
+    assert not hasattr(stripped, "_data")
+
+
+def test_store_data_false_vcov_uses_explicit_estimation_sample(
+    lifecycle_data: pd.DataFrame,
+) -> None:
+    """Data-dependent covariance updates use the documented data argument."""
+    stripped = pf.feols("y ~ x | fe", data=lifecycle_data, vcov="iid", store_data=False)
+    expected = pf.feols("y ~ x | fe", data=lifecycle_data, vcov={"CRV1": "fe"})
+
+    with pytest.raises(RuntimeError, match=r"store_data=False.*Pass.*data="):
+        stripped.vcov({"CRV1": "fe"})
+
+    stripped.vcov({"CRV1": "fe"}, data=lifecycle_data)
+
+    np.testing.assert_allclose(stripped._vcov, expected._vcov)
+    assert not hasattr(stripped, "_data")
+
+
+def test_vcov_rejects_unfiltered_explicit_data(
+    lifecycle_data: pd.DataFrame,
+) -> None:
+    """An explicit covariance sample must align with the fitted row arrays."""
+    data = lifecycle_data.copy()
+    data.loc[data.index[0], "y"] = np.nan
+    estimation_sample = data.dropna(subset=["y", "x", "fe"])
+    stripped = pf.feols(
+        "y ~ x | fe",
+        data=data,
+        vcov="iid",
+        store_data=False,
+    )
+    expected = pf.feols(
+        "y ~ x | fe",
+        data=estimation_sample,
+        vcov={"CRV1": "fe"},
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"already-filtered estimation sample.*original estimation order; "
+            r"expected 23 rows, received 24"
+        ),
+    ):
+        stripped.vcov({"CRV1": "fe"}, data=data)
+
+    stripped.vcov({"CRV1": "fe"}, data=estimation_sample)
+    np.testing.assert_allclose(stripped._vcov, expected._vcov)
+
+
+def test_lean_vcov_fails_with_storage_guidance(
+    lifecycle_data: pd.DataFrame,
+) -> None:
+    """Lean results explain that covariance inputs were intentionally discarded."""
+    fit = pf.feols("y ~ x", data=lifecycle_data, vcov="iid", lean=True)
+
+    with pytest.raises(RuntimeError, match=r"vcov\(\).*lean=True.*discarded"):
+        fit.vcov("HC1")
+
+
+def test_iv_first_stage_respects_store_data_false(
+    lifecycle_data: pd.DataFrame,
+) -> None:
+    """A retained IV first stage must not hide a copy of stripped input data."""
+    fit = pf.feols(
+        "y ~ x + [endog ~ z] | fe",
+        data=lifecycle_data,
+        vcov="hetero",
+        store_data=False,
+    )
+
+    first_stage = fit._model_1st_stage
+    assert not hasattr(first_stage, "_data")
+    assert not hasattr(first_stage, "_formula_data")
+    assert hasattr(first_stage, "_within_data")
+    assert hasattr(first_stage, "_X")
+    fit.IV_Diag()
+    assert np.isfinite(fit._eff_F)
+    with pytest.raises(RuntimeError, match=r"first_stage\(\).*store_data=False"):
+        fit.first_stage()
+
+
+def test_iv_effective_f_explains_stripped_iid_data_requirement(
+    lifecycle_data: pd.DataFrame,
+) -> None:
+    """IID first-stage refits fail informatively when their data were stripped."""
+    fit = pf.feols(
+        "y ~ x + [endog ~ z] | fe",
+        data=lifecycle_data,
+        vcov="iid",
+        store_data=False,
+    )
+
+    with pytest.raises(RuntimeError, match=r"effective F.*store_data=False"):
+        fit.IV_Diag()
+
+
+def test_lean_iv_discards_retained_first_stage_arrays(
+    lifecycle_data: pd.DataFrame,
+) -> None:
+    """Lean IV results retain diagnostics but no nested fitted-data graph."""
+    fit = pf.feols(
+        "y ~ x + [endog ~ z] | fe",
+        data=lifecycle_data,
+        vcov="hetero",
+        lean=True,
+    )
+
+    assert not hasattr(fit, "_model_1st_stage")
+    assert not hasattr(fit, "_X_hat")
+    assert not hasattr(fit, "_v_hat")
+    assert not hasattr(fit, "_endogvar")
+    assert np.isfinite(fit._f_stat_1st_stage)
+    with pytest.raises(RuntimeError, match=r"IV_Diag\(\).*lean=True"):
+        fit.IV_Diag()
+
+
+def test_feglm_keeps_observation_and_working_weights_distinct() -> None:
+    """The stable observation-weight alias is never replaced by IRLS weights."""
     rng = np.random.default_rng(8675309)
     n_obs = 160
     covariate = rng.normal(size=n_obs)
     probability = 1 / (1 + np.exp(-(-0.2 + 0.8 * covariate)))
+    observation_weights = np.linspace(0.5, 2.0, n_obs)
     data = pd.DataFrame(
         {
             "y": rng.binomial(1, probability),
             "x": covariate,
-            "observation_weight": np.linspace(0.5, 2.0, n_obs),
+            "observation_weight": observation_weights,
         }
     )
 
@@ -372,10 +480,71 @@ def test_feglm_overwrites_observation_weights_with_working_weights() -> None:
         iwls_tol=1e-10,
     )
 
-    observation_weights = fit._weights_df.to_numpy()
-    assert isinstance(fit._Y_untransformed, pd.DataFrame)
-    assert isinstance(fit._X, np.ndarray)
-    assert isinstance(fit._Y, np.ndarray)
-    np.testing.assert_allclose(fit._weights.flatten(), fit._irls_weights.flatten())
-    assert not np.allclose(fit._weights.flatten(), observation_weights.flatten())
-    np.testing.assert_allclose(fit._scores, fit._u_hat[:, None] * fit._X)
+    working = fit._working_state
+    assert isinstance(working, GlmWorkingState)
+    np.testing.assert_allclose(fit._weights.flatten(), observation_weights)
+    np.testing.assert_allclose(fit._observation_weights.values, observation_weights)
+    np.testing.assert_allclose(fit._irls_weights, working.working_weights)
+    assert not np.allclose(working.working_weights, observation_weights)
+    assert fit._X is working.design_within
+    assert fit._Y is working.working_response_within
+    np.testing.assert_allclose(fit.resid("response"), working.response_residuals)
+    np.testing.assert_allclose(fit.resid("working"), working.working_residuals)
+    np.testing.assert_allclose(
+        fit._scores,
+        fit._X * (working.working_weights * working.working_residuals)[:, None],
+    )
+
+
+def test_glm_lean_discards_formula_and_working_state() -> None:
+    """Lean GLM results discard both canonical input and working fit arrays."""
+    data = pd.DataFrame({"y": [0, 1, 0, 1, 1, 0], "x": np.arange(6.0)})
+    fit = pf.feglm("y ~ x", data=data, family="logit", lean=True, vcov="iid")
+
+    discarded = (
+        "_formula_data",
+        "_observation_weights",
+        "_demean_cache",
+        "_working_state",
+        "_irls_weights",
+        "_u_hat_response",
+        "_u_hat_working",
+        "_scores_response",
+        "_scores_working",
+        "_Xbeta",
+        "_offset",
+    )
+    assert all(not hasattr(fit, attr) for attr in discarded)
+    assert np.isfinite(fit.coef()).all()
+    for residual_type in ("response", "working"):
+        with pytest.raises(
+            RuntimeError, match=r"resid\(\).*lean=True.*residual arrays were discarded"
+        ):
+            fit.resid(residual_type)
+
+
+def test_poisson_lean_discards_offset_and_null_fit_arrays() -> None:
+    """Lean Poisson results do not retain offset or null-fit row arrays."""
+    data = pd.DataFrame(
+        {
+            "y": [0, 1, 2, 1, 3, 2],
+            "x": np.arange(6.0),
+            "offset": np.linspace(0.1, 0.6, 6),
+        }
+    )
+    fit = pf.fepois("y ~ x", data=data, offset="offset", lean=True, vcov="iid")
+
+    assert not hasattr(fit, "_offset")
+    assert not hasattr(fit, "_y_hat_null")
+    assert np.isfinite(fit.coef()).all()
+
+
+def test_quantreg_lean_discards_solver_arrays() -> None:
+    """Lean quantile results do not retain row-sized solver outputs."""
+    data = pd.DataFrame({"y": [0.2, 1.1, 1.8, 3.2, 3.9, 5.1], "x": np.arange(6.0)})
+    with pytest.warns(FutureWarning, match="experimental"):
+        fit = pf.quantreg("y ~ x", data=data, lean=True, vcov="iid", maxiter=100)
+
+    solver_arrays = ("_x_final", "_s_final", "_z_final", "_w_final", "_y_final")
+    assert all(not hasattr(fit, attr) for attr in solver_arrays)
+    assert np.isfinite(fit.coef()).all()

--- a/tests/test_estimator_state_lifecycle.py
+++ b/tests/test_estimator_state_lifecycle.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from copy import deepcopy
 from dataclasses import FrozenInstanceError
 
 import numpy as np
@@ -348,13 +349,160 @@ def test_store_data_false_vcov_uses_explicit_estimation_sample(
     stripped = pf.feols("y ~ x | fe", data=lifecycle_data, vcov="iid", store_data=False)
     expected = pf.feols("y ~ x | fe", data=lifecycle_data, vcov={"CRV1": "fe"})
 
+    metadata_before = deepcopy(
+        (
+            stripped._vcov_type,
+            stripped._vcov_type_detail,
+            stripped._is_clustered,
+            stripped._clustervar,
+            stripped._G,
+            stripped._df_k,
+            stripped._df_t,
+        )
+    )
+    arrays_before = {
+        attr: getattr(stripped, attr).copy()
+        for attr in (
+            "_bread",
+            "_ssc",
+            "_vcov",
+            "_se",
+            "_tstat",
+            "_pvalue",
+            "_conf_int",
+        )
+    }
+
     with pytest.raises(RuntimeError, match=r"store_data=False.*Pass.*data="):
         stripped.vcov({"CRV1": "fe"})
+
+    assert (
+        stripped._vcov_type,
+        stripped._vcov_type_detail,
+        stripped._is_clustered,
+        stripped._clustervar,
+        stripped._G,
+        stripped._df_k,
+        stripped._df_t,
+    ) == metadata_before
+    for attr, value in arrays_before.items():
+        np.testing.assert_array_equal(getattr(stripped, attr), value)
 
     stripped.vcov({"CRV1": "fe"}, data=lifecycle_data)
 
     np.testing.assert_allclose(stripped._vcov, expected._vcov)
     assert not hasattr(stripped, "_data")
+
+
+def test_fixest_multi_forwards_explicit_vcov_data(
+    lifecycle_data: pd.DataFrame,
+) -> None:
+    """Multiple-estimation covariance updates forward an explicit sample."""
+    stripped = pf.feols(
+        "y ~ sw(x, x2) | fe",
+        data=lifecycle_data,
+        vcov="iid",
+        store_data=False,
+    )
+    expected = pf.feols(
+        "y ~ sw(x, x2) | fe",
+        data=lifecycle_data,
+        vcov={"CRV1": "fe"},
+    )
+
+    stripped.vcov({"CRV1": "fe"}, data=lifecycle_data)
+
+    for stripped_model, expected_model in zip(
+        stripped.to_list(), expected.to_list(), strict=True
+    ):
+        np.testing.assert_allclose(stripped_model._vcov, expected_model._vcov)
+        assert not hasattr(stripped_model, "_data")
+
+
+def test_fixest_multi_vcov_preflights_different_estimation_samples(
+    lifecycle_data: pd.DataFrame,
+) -> None:
+    """A common-sample mismatch leaves every child model unchanged."""
+    data = lifecycle_data.copy()
+    data.loc[data.index[:3], "x2"] = np.nan
+    fit = pf.feols(
+        "y ~ sw(x, x2) | fe",
+        data=data,
+        vcov="iid",
+        store_data=False,
+    )
+    children = fit.to_list()
+    inference_before = [
+        (child._vcov_type_detail, child._vcov.copy()) for child in children
+    ]
+
+    with pytest.raises(
+        ValueError,
+        match=r"common, already-filtered estimation sample.*\[21, 24\], received 24",
+    ):
+        fit.vcov({"CRV1": "fe"}, data=data)
+
+    for child, (vcov_type_detail, vcov) in zip(children, inference_before, strict=True):
+        assert child._vcov_type_detail == vcov_type_detail
+        np.testing.assert_array_equal(child._vcov, vcov)
+
+
+def test_fixest_multi_vcov_rejects_equal_size_split_samples(
+    lifecycle_data: pd.DataFrame,
+) -> None:
+    """Equal row counts do not make distinct split samples interchangeable."""
+    data = lifecycle_data.assign(sample=np.tile(["left", "right"], 12))
+    fit = pf.feols(
+        "y ~ x | fe",
+        data=data,
+        split="sample",
+        vcov="iid",
+        store_data=False,
+    )
+    children = fit.to_list()
+    inference_before = [
+        (child._vcov_type_detail, child._vcov.copy()) for child in children
+    ]
+    left_sample = data.loc[data["sample"] == "left"]
+
+    with pytest.raises(
+        ValueError,
+        match=r"child models use different estimation samples.*Fetch each child",
+    ):
+        fit.vcov({"CRV1": "fe"}, data=left_sample)
+
+    for child, (vcov_type_detail, vcov) in zip(children, inference_before, strict=True):
+        assert child._vcov_type_detail == vcov_type_detail
+        np.testing.assert_array_equal(child._vcov, vcov)
+
+
+def test_fixest_multi_vcov_rejects_equal_size_distinct_na_masks(
+    lifecycle_data: pd.DataFrame,
+) -> None:
+    """Equal-sized formula expansions must retain the same source rows."""
+    data = lifecycle_data.copy()
+    data.loc[data.index[0], "x"] = np.nan
+    data.loc[data.index[1], "x2"] = np.nan
+    fit = pf.feols(
+        "y ~ sw(x, x2) | fe",
+        data=data,
+        vcov="iid",
+        store_data=False,
+    )
+    children = fit.to_list()
+    inference_before = [
+        (child._vcov_type_detail, child._vcov.copy()) for child in children
+    ]
+
+    with pytest.raises(
+        ValueError,
+        match=r"child models use different estimation samples.*Fetch each child",
+    ):
+        fit.vcov({"CRV1": "fe"}, data=data.drop(index=0))
+
+    for child, (vcov_type_detail, vcov) in zip(children, inference_before, strict=True):
+        assert child._vcov_type_detail == vcov_type_detail
+        np.testing.assert_array_equal(child._vcov, vcov)
 
 
 def test_vcov_rejects_unfiltered_explicit_data(
@@ -421,19 +569,27 @@ def test_iv_first_stage_respects_store_data_false(
         fit.first_stage()
 
 
-def test_iv_effective_f_explains_stripped_iid_data_requirement(
+def test_iv_effective_f_uses_retained_arrays_without_stored_data(
     lifecycle_data: pd.DataFrame,
 ) -> None:
-    """IID first-stage refits fail informatively when their data were stripped."""
-    fit = pf.feols(
+    """IID first-stage diagnostics need retained arrays, not formula data."""
+    stripped = pf.feols(
         "y ~ x + [endog ~ z] | fe",
         data=lifecycle_data,
         vcov="iid",
         store_data=False,
     )
+    retained = pf.feols(
+        "y ~ x + [endog ~ z] | fe",
+        data=lifecycle_data,
+        vcov="iid",
+    )
 
-    with pytest.raises(RuntimeError, match=r"effective F.*store_data=False"):
-        fit.IV_Diag()
+    stripped.IV_Diag()
+    retained.IV_Diag()
+
+    np.testing.assert_allclose(stripped._eff_F, retained._eff_F)
+    assert not hasattr(stripped._model_1st_stage, "_data")
 
 
 def test_lean_iv_discards_retained_first_stage_arrays(
@@ -548,3 +704,23 @@ def test_quantreg_lean_discards_solver_arrays() -> None:
     solver_arrays = ("_x_final", "_s_final", "_z_final", "_w_final", "_y_final")
     assert all(not hasattr(fit, attr) for attr in solver_arrays)
     assert np.isfinite(fit.coef()).all()
+
+
+def test_quantreg_multi_retains_default_post_estimation_state() -> None:
+    """Default multi-quantile results support prediction and vcov updates."""
+    rng = np.random.default_rng(20260901)
+    x = rng.normal(size=200)
+    data = pd.DataFrame({"y": 1 + 2 * x + rng.normal(size=200), "x": x})
+    with pytest.warns(FutureWarning, match="experimental"):
+        multi = pf.quantreg("y ~ x", data=data, quantile=[0.25, 0.75], vcov="iid")
+        single = pf.quantreg("y ~ x", data=data, quantile=0.25, vcov="hetero")
+
+    multi.vcov("hetero")
+
+    for model in multi.to_list():
+        assert np.isfinite(model.predict()).all()
+        assert np.isfinite(model.se()).all()
+
+    first_quantile = multi.fetch_model(0, print_fml=False)
+    np.testing.assert_allclose(first_quantile.predict(), single.predict())
+    np.testing.assert_allclose(first_quantile.se(), single.se())

--- a/tests/test_feols_feglm_internally.py
+++ b/tests/test_feols_feglm_internally.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pandas as pd
 import pytest
 
 import pyfixest as pf
@@ -34,16 +35,204 @@ fml_list = [
 fml_ols_vs_gaussian = ["Y ~ X1", "Y ~ X1 + C(f1)", "Y ~ X1 * X2"]
 
 
+@pytest.mark.parametrize("family", ["gaussian", "logit", "probit", "poisson"])
+def test_glm_keeps_formula_observation_and_working_domains_distinct(family):
+    """Retain formula inputs and observation weights beside final IWLS state."""
+    rng = np.random.default_rng(918273)
+    n_groups = 12
+    group_size = 15
+    n_obs = n_groups * group_size
+    fixed_effect = np.repeat(np.arange(n_groups), group_size)
+    covariate = rng.normal(size=n_obs)
+    linear_predictor = -0.2 + 0.7 * covariate + 0.05 * fixed_effect
+
+    if family == "gaussian":
+        response = linear_predictor + rng.normal(scale=0.5, size=n_obs)
+    elif family == "poisson":
+        # Strict positivity prevents a group from being removed for separation.
+        response = rng.poisson(np.exp(linear_predictor)) + 1
+    else:
+        probability = 1 / (1 + np.exp(-linear_predictor))
+        response = rng.binomial(1, probability)
+
+    observation_weights = np.linspace(0.5, 2.0, n_obs)
+    data = pd.DataFrame(
+        {
+            "y": response,
+            "x": covariate,
+            "fe": fixed_effect,
+            "weight": observation_weights,
+        }
+    )
+    fit = pf.feglm(
+        "y ~ x | fe",
+        data=data,
+        family=family,
+        weights="weight",
+        vcov="hetero",
+        separation_check=[],
+        iwls_tol=1e-10,
+    )
+
+    assert isinstance(fit._formula_data.dependent, pd.DataFrame)
+    assert isinstance(fit._formula_data.independent, pd.DataFrame)
+    assert isinstance(fit._fe, pd.DataFrame)
+    np.testing.assert_allclose(
+        fit._observation_weights.values,
+        observation_weights,
+    )
+    np.testing.assert_allclose(fit._weights.flatten(), observation_weights)
+
+    working = fit._working_state
+    assert fit._X is working.design_within
+    assert fit._Y is working.working_response_within
+    assert fit._Z is working.design_within
+    assert fit._irls_weights is working.working_weights
+    assert not hasattr(working, "sqrt_working_weights")
+    assert not hasattr(working, "design_solver")
+    assert not hasattr(working, "response_solver")
+
+    np.testing.assert_allclose(fit.resid("response"), working.response_residuals)
+    np.testing.assert_allclose(fit.resid("working"), working.working_residuals)
+    np.testing.assert_allclose(
+        fit._scores,
+        working.design_within
+        * (working.working_weights * working.working_residuals)[:, None],
+    )
+    expected_hessian = working.design_within.T @ (
+        working.working_weights[:, None] * working.design_within
+    )
+    np.testing.assert_allclose(fit._hessian, expected_hessian)
+    np.testing.assert_allclose(fit._leverage_weights(), working.working_weights)
+    np.testing.assert_allclose(fit._fixef_weights(), working.working_weights)
+
+    for group in np.unique(fixed_effect):
+        group_rows = fixed_effect == group
+        group_weights = working.working_weights[group_rows]
+        np.testing.assert_allclose(
+            group_weights @ working.design_within[group_rows],
+            0,
+            atol=1e-8,
+        )
+        np.testing.assert_allclose(
+            group_weights @ working.working_response_within[group_rows],
+            0,
+            atol=1e-8,
+        )
+
+    if family == "gaussian":
+        np.testing.assert_allclose(working.working_weights, observation_weights)
+    else:
+        assert not np.allclose(working.working_weights, observation_weights)
+
+
+@pytest.mark.parametrize("vcov", ["HC2", "HC3"])
+def test_feglm_frequency_weight_leverage_matches_expanded_sample(vcov):
+    """Use observation counts, not IRLS weights, in fweight HC leverage."""
+    rng = np.random.default_rng(102938)
+    covariate = np.linspace(-1.5, 1.5, 80)
+    probability = 1 / (1 + np.exp(-(-0.15 + 0.8 * covariate)))
+    aggregated = pd.DataFrame(
+        {
+            "y": rng.binomial(1, probability),
+            "x": covariate,
+            "count": rng.integers(1, 5, size=len(covariate)),
+        }
+    )
+    expanded = aggregated.loc[aggregated.index.repeat(aggregated["count"])].copy()
+
+    fit_frequency = pf.feglm(
+        "y ~ x",
+        data=aggregated,
+        family="logit",
+        weights="count",
+        weights_type="fweights",
+        vcov=vcov,
+        iwls_tol=1e-11,
+    )
+    fit_expanded = pf.feglm(
+        "y ~ x",
+        data=expanded,
+        family="logit",
+        vcov=vcov,
+        iwls_tol=1e-11,
+    )
+
+    np.testing.assert_allclose(
+        fit_frequency.coef(),
+        fit_expanded.coef(),
+        atol=1e-10,
+        err_msg="Frequency-weighted logit coefficients differ from row expansion.",
+    )
+    # Collapsing duplicate rows changes floating-point accumulation order and
+    # therefore the final IWLS stopping point at roughly the low 1e-6 scale.
+    np.testing.assert_allclose(
+        fit_frequency._vcov,
+        fit_expanded._vcov,
+        atol=1e-9,
+        rtol=5e-6,
+        err_msg=f"Frequency-weighted logit {vcov} differs from row expansion.",
+    )
+
+
+def test_feglm_frequency_weight_sample_size_survives_separation():
+    """Recompute effective and physical sample sizes in their distinct domains."""
+    aggregated = pd.DataFrame(
+        {
+            "y": [0, 0, 0, 0, 1, 0, 1, 0, 1, 1, 1, 0],
+            "x": [-1.2, -0.4, 0.7, -1.1, -0.2, 0.9, -0.8, 0.1, 1.2, -0.9, 0.4, 1.4],
+            "fe": np.repeat(list("abcd"), 3),
+            "count": [1, 3, 2, 2, 1, 4, 1, 2, 3, 3, 2, 1],
+        }
+    )
+    expanded = aggregated.loc[aggregated.index.repeat(aggregated["count"])].copy()
+
+    with pytest.warns(UserWarning, match="observations removed because of separation"):
+        fit_frequency = pf.feglm(
+            "y ~ x | fe",
+            data=aggregated,
+            family="logit",
+            weights="count",
+            weights_type="fweights",
+            vcov="HC1",
+            separation_check=["fe"],
+            iwls_tol=1e-11,
+        )
+    with pytest.warns(UserWarning, match="observations removed because of separation"):
+        fit_expanded = pf.feglm(
+            "y ~ x | fe",
+            data=expanded,
+            family="logit",
+            vcov="HC1",
+            separation_check=["fe"],
+            iwls_tol=1e-11,
+        )
+
+    assert fit_frequency._N == fit_expanded._N == 19
+    assert fit_frequency._N_rows == 9
+    assert fit_expanded._N_rows == 19
+    assert fit_frequency._observation_weights.n_effective == 19
+    np.testing.assert_allclose(fit_frequency.coef(), fit_expanded.coef(), atol=1e-10)
+    np.testing.assert_allclose(fit_frequency._vcov, fit_expanded._vcov, atol=1e-10)
+
+
 @pytest.mark.parametrize("fml", fml_ols_vs_gaussian)
 @pytest.mark.parametrize("inference", ["iid", "hetero", {"CRV1": "f1"}])
 @pytest.mark.parametrize("dropna", [True])
-def test_ols_vs_gaussian_glm(fml, inference, dropna):
+@pytest.mark.parametrize("weights", [None, "weights"])
+def test_ols_vs_gaussian_glm(fml, inference, dropna, weights):
     data = pf.get_data()
     if dropna:
         data = data.dropna()
 
-    fit_ols = pf.feols(fml=fml, data=data, vcov=inference)
-    fit_gaussian = pf.feglm(fml=fml, data=data, family="gaussian", vcov=inference)
+    fit_ols = pf.feols(fml=fml, data=data, vcov=inference, weights=weights)
+    fit_gaussian = pf.feglm(
+        fml=fml,
+        data=data,
+        family="gaussian",
+        vcov=inference,
+        weights=weights,
+    )
 
     check_absolute_diff(
         fit_ols.coef().xs("X1"), fit_gaussian.coef().xs("X1"), tol=1e-10

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import pyfixest.estimation.internals.fit_ as fit_module
+from pyfixest.estimation.internals.fit_ import fit_iv, fit_ols
+
+
+@pytest.fixture
+def ols_arrays() -> tuple[np.ndarray, np.ndarray]:
+    X = np.array(
+        [
+            [1.0, -1.0],
+            [1.0, 0.0],
+            [1.0, 0.5],
+            [1.0, 2.0],
+            [1.0, 3.0],
+        ]
+    )
+    Y = np.array([[0.5], [1.0], [1.25], [2.5], [4.0]])
+    return X, Y
+
+
+@pytest.fixture
+def iv_arrays() -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    X = np.array(
+        [
+            [1.0, -1.0],
+            [1.0, 0.5],
+            [1.0, 2.0],
+            [1.0, 3.0],
+            [1.0, 1.5],
+        ]
+    )
+    Z = np.array(
+        [
+            [1.0, -0.5, 1.0],
+            [1.0, 0.0, -1.0],
+            [1.0, 1.5, 0.5],
+            [1.0, 2.5, 2.0],
+            [1.0, 1.0, -0.5],
+        ]
+    )
+    Y = np.array([[0.5], [1.0], [2.5], [4.0], [2.0]])
+    return X, Z, Y
+
+
+@pytest.mark.parametrize(
+    "weights",
+    [None, np.array([0.5, 1.0, 1.5, 2.0, 3.0])],
+    ids=("unweighted", "weighted"),
+)
+def test_fit_ols_matches_direct_equations_without_mutating_inputs(
+    ols_arrays: tuple[np.ndarray, np.ndarray],
+    weights: np.ndarray | None,
+) -> None:
+    X, Y = ols_arrays
+    X_before = X.copy()
+    Y_before = Y.copy()
+    weights_before = None if weights is None else weights.copy()
+    X.setflags(write=False)
+    Y.setflags(write=False)
+    if weights is not None:
+        weights.setflags(write=False)
+
+    fit = fit_ols(X=X, Y=Y, weights=weights)
+
+    weight_values = np.ones(X.shape[0]) if weights is None else weights.reshape(-1)
+    expected_tXX = X.T @ (weight_values[:, None] * X)
+    expected_tXy = X.T @ (weight_values[:, None] * Y)
+    expected_beta = np.linalg.solve(expected_tXX, expected_tXy).flatten()
+    expected_residuals = Y.flatten() - X @ expected_beta
+
+    np.testing.assert_allclose(fit.beta, expected_beta, err_msg="OLS coefficients")
+    np.testing.assert_allclose(
+        fit.residuals,
+        expected_residuals,
+        err_msg="OLS response-scale residuals",
+    )
+    np.testing.assert_allclose(
+        fit.scores,
+        X * (weight_values * expected_residuals)[:, None],
+        err_msg="OLS weighted scores",
+    )
+    np.testing.assert_allclose(
+        fit.hessian,
+        expected_tXX,
+        err_msg="OLS weighted Hessian",
+    )
+    np.testing.assert_allclose(
+        fit.tZX,
+        expected_tXX,
+        err_msg="OLS weighted X'X",
+    )
+    np.testing.assert_allclose(
+        fit.tZy,
+        expected_tXy,
+        err_msg="OLS weighted X'Y",
+    )
+    np.testing.assert_array_equal(X, X_before, err_msg="fit_ols mutated X")
+    np.testing.assert_array_equal(Y, Y_before, err_msg="fit_ols mutated Y")
+    if weights is not None:
+        np.testing.assert_array_equal(
+            weights,
+            weights_before,
+            err_msg="fit_ols mutated weights",
+        )
+
+
+@pytest.mark.parametrize(
+    "weights",
+    [None, np.array([[0.5], [1.0], [1.5], [2.0], [3.0]])],
+    ids=("unweighted", "weighted"),
+)
+def test_fit_iv_matches_direct_equations_without_mutating_inputs(
+    iv_arrays: tuple[np.ndarray, np.ndarray, np.ndarray],
+    weights: np.ndarray | None,
+) -> None:
+    X, Z, Y = iv_arrays
+    X_before = X.copy()
+    Z_before = Z.copy()
+    Y_before = Y.copy()
+    weights_before = None if weights is None else weights.copy()
+    X.setflags(write=False)
+    Z.setflags(write=False)
+    Y.setflags(write=False)
+    if weights is not None:
+        weights.setflags(write=False)
+
+    fit = fit_iv(X=X, Z=Z, Y=Y, weights=weights)
+
+    weight_values = np.ones(X.shape[0]) if weights is None else weights.reshape(-1)
+    expected_tZX = Z.T @ (weight_values[:, None] * X)
+    expected_tXZ = X.T @ (weight_values[:, None] * Z)
+    expected_tZy = Z.T @ (weight_values[:, None] * Y)
+    expected_tZZ = Z.T @ (weight_values[:, None] * Z)
+    expected_tZZinv = np.linalg.inv(expected_tZZ)
+    projection = expected_tXZ @ expected_tZZinv
+    expected_beta = np.linalg.solve(
+        projection @ expected_tZX,
+        projection @ expected_tZy,
+    ).flatten()
+    expected_residuals = Y.flatten() - X @ expected_beta
+
+    np.testing.assert_allclose(fit.beta, expected_beta, err_msg="IV coefficients")
+    np.testing.assert_allclose(
+        fit.residuals,
+        expected_residuals,
+        err_msg="IV response-scale residuals",
+    )
+    np.testing.assert_allclose(
+        fit.scores,
+        Z * (weight_values * expected_residuals)[:, None],
+        err_msg="IV weighted scores",
+    )
+    np.testing.assert_allclose(
+        fit.hessian,
+        expected_tZZ,
+        err_msg="IV weighted Z'Z",
+    )
+    np.testing.assert_allclose(
+        fit.tZX,
+        expected_tZX,
+        err_msg="IV weighted Z'X",
+    )
+    np.testing.assert_allclose(
+        fit.tXZ,
+        expected_tXZ,
+        err_msg="IV weighted X'Z",
+    )
+    np.testing.assert_allclose(
+        fit.tZy,
+        expected_tZy,
+        err_msg="IV weighted Z'Y",
+    )
+    np.testing.assert_allclose(
+        fit.tZZinv,
+        expected_tZZinv,
+        err_msg="inverse IV weighted Z'Z",
+    )
+    np.testing.assert_array_equal(X, X_before, err_msg="fit_iv mutated X")
+    np.testing.assert_array_equal(Z, Z_before, err_msg="fit_iv mutated Z")
+    np.testing.assert_array_equal(Y, Y_before, err_msg="fit_iv mutated Y")
+    if weights is not None:
+        np.testing.assert_array_equal(
+            weights,
+            weights_before,
+            err_msg="fit_iv mutated weights",
+        )
+
+
+@pytest.mark.parametrize("fit_name", ["ols", "iv"])
+def test_unweighted_fit_does_not_compute_sqrt_weights(
+    monkeypatch: pytest.MonkeyPatch,
+    ols_arrays: tuple[np.ndarray, np.ndarray],
+    iv_arrays: tuple[np.ndarray, np.ndarray, np.ndarray],
+    fit_name: str,
+) -> None:
+    def unexpected_sqrt(_: np.ndarray) -> np.ndarray:
+        raise AssertionError("the unweighted path must not transform unit weights")
+
+    monkeypatch.setattr(fit_module.np, "sqrt", unexpected_sqrt)
+    if fit_name == "ols":
+        X, Y = ols_arrays
+        fit_ols(X=X, Y=Y, weights=None)
+    else:
+        X, Z, Y = iv_arrays
+        fit_iv(X=X, Z=Z, Y=Y, weights=None)

--- a/tests/test_formulaic_compat.py
+++ b/tests/test_formulaic_compat.py
@@ -18,6 +18,8 @@ from pyfixest.estimation.formula.formulaic_compat import (
     rows_with_unseen_contrast_levels,
     terms_without_intercept,
 )
+from pyfixest.estimation.formula.model_matrix import create_model_matrix
+from pyfixest.estimation.formula.parse import Formula
 
 FORMULAIC_271 = "https://github.com/matthewwardrop/formulaic/issues/271"
 
@@ -34,6 +36,26 @@ def data() -> pd.DataFrame:
             "f1": rng.integers(0, 5, size=100),
             "f2": rng.integers(0, 3, size=100),
         }
+    )
+
+
+def test_create_model_matrix_preserves_positional_offset_slot() -> None:
+    """Adding weight semantics must not shift the existing offset argument."""
+    data = pd.DataFrame(
+        {
+            "y": [1.0, 2.0, 3.0],
+            "x": [0.0, 1.0, 2.0],
+            "w": [1.0, 2.0, 1.0],
+            "exposure": [1.0, 2.0, 4.0],
+        }
+    )
+    formula = Formula.parse("y ~ x")[0]
+
+    model_matrix = create_model_matrix(formula, data, "w", "log(exposure)")
+
+    assert model_matrix.offset is not None
+    np.testing.assert_allclose(
+        model_matrix.offset.to_numpy().ravel(), np.log(data["exposure"])
     )
 
 

--- a/tests/test_model_state.py
+++ b/tests/test_model_state.py
@@ -1,0 +1,127 @@
+from dataclasses import FrozenInstanceError
+
+import numpy as np
+import pytest
+
+from pyfixest.estimation.internals.model_state import (
+    GlmWorkingState,
+    ObservationWeights,
+    WithinLinearData,
+)
+
+
+def test_observation_weights_unweighted_fast_path() -> None:
+    weights = ObservationWeights.unweighted(n_rows=4)
+
+    assert weights.values is None
+    assert weights.kind is None
+    assert weights.n_rows == 4
+    assert weights.n_effective == 4
+    assert isinstance(weights.n_effective, int)
+    assert not weights.is_weighted
+    assert not hasattr(weights, "__dict__")
+
+
+@pytest.mark.parametrize(
+    ("kind", "expected_n"),
+    [("aweights", 3.0), ("fweights", 6.0)],
+)
+def test_observation_weights_keep_canonical_user_values(kind, expected_n) -> None:
+    user_weights = np.array([[1.0], [2.0], [3.0]])
+
+    weights = ObservationWeights.from_values(user_weights, kind=kind)
+
+    np.testing.assert_array_equal(weights.values, user_weights.flatten())
+    assert weights.kind == kind
+    assert weights.n_rows == 3
+    assert weights.n_effective == expected_n
+    assert isinstance(weights.n_effective, int if kind == "aweights" else float)
+    assert weights.is_weighted
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        (
+            {
+                "values": None,
+                "kind": "aweights",
+                "n_rows": 2,
+                "n_effective": 2.0,
+            },
+            "Unweighted observations cannot have a weight kind",
+        ),
+        (
+            {
+                "values": np.ones(2),
+                "kind": None,
+                "n_rows": 2,
+                "n_effective": 2.0,
+            },
+            "Weighted observations must declare a weight kind",
+        ),
+        (
+            {
+                "values": np.ones(2),
+                "kind": "pweights",
+                "n_rows": 2,
+                "n_effective": 2.0,
+            },
+            "Weight kind must be 'aweights' or 'fweights'",
+        ),
+    ],
+)
+def test_observation_weights_reject_inconsistent_state(kwargs, message) -> None:
+    with pytest.raises(ValueError, match=message):
+        ObservationWeights(**kwargs)
+
+
+def test_within_linear_data_is_structurally_immutable() -> None:
+    response = np.arange(3.0)[:, None]
+    design = np.column_stack((np.ones(3), np.arange(3.0)))
+    instruments = np.arange(6.0).reshape(3, 2)
+    endogenous = np.arange(3.0)[:, None]
+    state = WithinLinearData(
+        response=response,
+        design=design,
+        instruments=instruments,
+        endogenous=endogenous,
+    )
+
+    assert state.response is response
+    assert state.design is design
+    assert state.instruments is instruments
+    assert state.endogenous is endogenous
+    assert not hasattr(state, "__dict__")
+    with pytest.raises(FrozenInstanceError):
+        state.response = design  # type: ignore[misc]
+
+
+def test_glm_working_state_names_every_persisted_domain() -> None:
+    working_response = np.arange(3.0)
+    design = np.arange(6.0).reshape(3, 2)
+    working_weights = np.array([1.0, 2.0, 3.0])
+    eta = np.array([-1.0, 0.0, 1.0])
+    mu = np.array([0.2, 0.5, 0.8])
+    response_residuals = np.array([-0.2, 0.5, 0.2])
+    working_residuals = np.array([-1.0, 1.0, 0.5])
+
+    state = GlmWorkingState(
+        working_response_within=working_response,
+        design_within=design,
+        working_weights=working_weights,
+        eta=eta,
+        mu=mu,
+        response_residuals=response_residuals,
+        working_residuals=working_residuals,
+    )
+
+    assert state.working_response_within is working_response
+    assert state.design_within is design
+    assert state.working_weights is working_weights
+    assert state.eta is eta
+    assert state.mu is mu
+    assert state.response_residuals is response_residuals
+    assert state.working_residuals is working_residuals
+    assert not hasattr(state, "sqrt_weights")
+    assert not hasattr(state, "__dict__")

--- a/tests/test_others.py
+++ b/tests/test_others.py
@@ -89,11 +89,12 @@ def test_coef_update():
     np.testing.assert_allclose(updated_coefs, full_coefs)
 
 
-def test_coef_update_inplace():
+def test_coef_update_inplace_is_explicitly_unsupported():
     rng = np.random.default_rng(1234)
     data = get_data().dropna(subset=["Y", "X1", "X2"])
     data_subsample = data.sample(frac=0.3, random_state=1234)
     m = feols("Y ~ X1 + X2", data=data_subsample)
+    original_coef = m.coef().copy()
     new_points_id = rng.choice(
         data.index.difference(data_subsample.index), 5, replace=False
     )
@@ -105,16 +106,10 @@ def test_coef_update_inplace():
         ],
         data.loc[new_points_id]["Y"].values,
     )
-    m.update(X_new, y_new, inplace=True)
-    full_coefs = (
-        feols(
-            "Y ~ X1 + X2",
-            data=data.loc[data_subsample.index.append(pd.Index(new_points_id))],
-        )
-        .coef()
-        .values
-    )
-    np.testing.assert_allclose(m.coef().values, full_coefs)
+    with pytest.raises(NotImplementedError, match=r"inplace=True.*not supported"):
+        m.update(X_new, y_new, inplace=True)
+
+    pd.testing.assert_series_equal(m.coef(), original_coef)
 
 
 def test_rename_categoricals():

--- a/tests/test_poisson.py
+++ b/tests/test_poisson.py
@@ -106,7 +106,7 @@ def test_against_fixest(fml):
     fit_r = fixest.fepois(ro.Formula(fml), data=data, vcov=vcov, glm_tol=iwls_tol)
 
     np.testing.assert_allclose(
-        fit_r.rx2("irls_weights").reshape(-1, 1), fit._weights, atol=1e-08, rtol=1e-07
+        fit_r.rx2("irls_weights"), fit._irls_weights, atol=1e-08, rtol=1e-07
     )
     np.testing.assert_allclose(
         fit_r.rx2("linear.predictors").reshape(-1, 1),

--- a/tests/test_predict_resid_fixef.py
+++ b/tests/test_predict_resid_fixef.py
@@ -199,6 +199,81 @@ def test_vs_fixest(data, fml):
 
 
 @pytest.mark.against_r_core
+@pytest.mark.parametrize(
+    ("weights_name", "weights_type"),
+    [("weights", "aweights"), ("fweights", "fweights")],
+)
+def test_weighted_fixef_is_on_response_scale(data, weights_name, weights_type):
+    """Weighted fixed effects and predictions stay in response units."""
+    group_size = data.groupby("f1")["f1"].transform("size")
+    weighted_data = data.loc[group_size > 1].copy().reset_index(drop=True)
+    weighted_data["fweights"] = np.arange(len(weighted_data)) % 4 + 1
+
+    fit = pf.feols(
+        "Y ~ X1 | f1",
+        data=weighted_data,
+        weights=weights_name,
+        weights_type=weights_type,
+    )
+    fixed_effects = fit.fixef(atol=1e-12, btol=1e-12)
+
+    fit_r = fixest.feols(
+        ro.Formula("Y ~ X1 | f1"),
+        data=weighted_data,
+        weights=ro.Formula(f"~{weights_name}"),
+    )
+    ro.globalenv[".pyfixest_weighted_fixef_fit"] = fit_r
+    fixed_effects_r = ro.r["fixef"](fit_r).rx2("f1")
+    fixed_effect_levels_r = np.asarray(
+        ro.r("names(fixef(.pyfixest_weighted_fixef_fit)$f1)"), dtype=float
+    )
+
+    response_scale_fixed_effect = fit.predict() - weighted_data[
+        "X1"
+    ].to_numpy() * fit.coef().xs("X1")
+    np.testing.assert_allclose(
+        fit._sumFE,
+        response_scale_fixed_effect,
+        rtol=1e-8,
+        atol=1e-8,
+    )
+    np.testing.assert_allclose(
+        fit._sumFE,
+        np.asarray(fit_r.rx2("sumFE")),
+        rtol=1e-8,
+        atol=1e-8,
+    )
+
+    fixed_effects_by_level = fixed_effects.set_index(
+        fixed_effects["level"].astype(float)
+    )["coefficient"].sort_index()
+    fixed_effects_r_by_level = pd.Series(
+        np.asarray(fixed_effects_r),
+        index=fixed_effect_levels_r,
+    ).sort_index()
+    np.testing.assert_allclose(
+        fixed_effects_by_level,
+        fixed_effects_r_by_level,
+        rtol=1e-8,
+        atol=1e-8,
+    )
+
+    np.testing.assert_allclose(
+        fit.predict(),
+        np.asarray(fit_r.rx2("fitted.values")),
+        rtol=1e-8,
+        atol=1e-8,
+    )
+    newdata = weighted_data.iloc[:100]
+    np.testing.assert_allclose(
+        fit.predict(newdata=newdata),
+        np.asarray(stats.predict(fit_r, newdata=newdata)),
+        rtol=1e-8,
+        atol=1e-8,
+    )
+
+
+@pytest.mark.against_r_core
 def test_predict_nas():
     # tests to fix #246: https://github.com/py-econometrics/pyfixest/issues/246
 

--- a/tests/test_ritest.py
+++ b/tests/test_ritest.py
@@ -172,6 +172,69 @@ def test_fepois_ritest():
     assert np.allclose(fit.pvalue().xs("f3"), fit._ritest_pvalue, rtol=0.01, atol=0.01)
 
 
+def test_fepois_slow_ritest_replays_estimation_contract(monkeypatch):
+    """Poisson RI refits must retain offsets, formula context, and fit options."""
+    import pyfixest.estimation as estimation
+
+    data = pf.get_data(model="Fepois").dropna().iloc[:96].copy()
+    data["treatment"] = (data["X2"] > data["X2"].median()).astype(int)
+    data["exposure"] = np.random.default_rng(20260901).uniform(0.5, 3.0, len(data))
+
+    def shift(values):
+        return values + 0.125
+
+    demeaner = pf.MapDemeaner(fixef_tol=1e-8, fixef_maxiter=20_000)
+    ssc_config = pf.ssc(k_adj=False, G_adj=False)
+    real_fepois = estimation.fepois
+    fit = real_fepois(
+        "Y ~ treatment + shift(X1) | f1",
+        data=data,
+        offset="log(exposure)",
+        ssc=ssc_config,
+        fixef_rm="none",
+        iwls_tol=1e-10,
+        iwls_maxiter=100,
+        collin_tol=1e-8,
+        separation_check=[],
+        solver="np.linalg.lstsq",
+        demeaner=demeaner,
+        drop_intercept=True,
+        context={"shift": shift},
+    )
+
+    refit_calls = []
+
+    def recording_fepois(fml, *, data, vcov, **kwargs):
+        refit_calls.append((fml, vcov, kwargs))
+        return real_fepois(fml=fml, data=data, vcov=vcov, **kwargs)
+
+    monkeypatch.setattr(estimation, "fepois", recording_fepois)
+    fit.ritest(
+        resampvar="treatment",
+        reps=3,
+        choose_algorithm="slow",
+        rng=np.random.default_rng(1234),
+    )
+
+    assert len(refit_calls) == 3
+    for fml, vcov, kwargs in refit_calls:
+        assert fml == "Y ~ treatment_resampled + shift(X1) | f1"
+        assert vcov == "iid"
+        assert kwargs["weights"] is None
+        assert kwargs["weights_type"] == "aweights"
+        assert kwargs["ssc"] == ssc_config
+        assert kwargs["fixef_rm"] == "none"
+        assert kwargs["iwls_tol"] == 1e-10
+        assert kwargs["iwls_maxiter"] == 100
+        assert kwargs["collin_tol"] == 1e-8
+        assert kwargs["separation_check"] == []
+        assert kwargs["solver"] == "np.linalg.lstsq"
+        assert kwargs["demeaner"] is demeaner
+        assert kwargs["drop_intercept"] is True
+        assert kwargs["offset"] == "log(exposure)"
+        assert kwargs["context"]["shift"] is shift
+
+
 @pytest.fixture
 def data_r_vs_t():
     return pf.get_data(N=5000, seed=2999)

--- a/tests/test_ses.py
+++ b/tests/test_ses.py
@@ -1,6 +1,9 @@
 import numpy as np
+import pandas as pd
 import pytest
 
+import pyfixest.estimation as estimation
+from pyfixest.demeaners import LsmrDemeaner, MapDemeaner
 from pyfixest.estimation import feols, fepois
 from pyfixest.utils.utils import get_data, ssc
 
@@ -218,6 +221,128 @@ def run_crv3_poisson():
         vcov={"CRV3": "f1"},
         ssc=ssc(k_adj=False, G_adj=False),
     )
+
+
+def test_fepois_crv3_replays_estimation_contract(monkeypatch):
+    """Poisson jackknife refits must preserve every coefficient-affecting option."""
+    rng = np.random.default_rng(20260901)
+    n_clusters = 6
+    rows_per_cluster = 12
+    n = n_clusters * rows_per_cluster
+    cluster = np.repeat(np.arange(n_clusters), rows_per_cluster)
+    fixed_effect = np.tile(np.arange(6), n // 6)
+    x = rng.normal(size=n)
+    exposure = rng.uniform(0.5, 3.0, size=n)
+    weight = rng.uniform(0.75, 1.5, size=n)
+    fixed_effect_value = np.linspace(-0.25, 0.25, 6)[fixed_effect]
+
+    def shift(values):
+        return values + 0.125
+
+    eta = 0.35 * shift(x) + fixed_effect_value + np.log(exposure)
+    data = pd.DataFrame(
+        {
+            "y": rng.poisson(np.exp(eta)),
+            "x": x,
+            "exposure": exposure,
+            "weight": weight,
+            "fixed_effect": fixed_effect,
+            "cluster": cluster,
+        }
+    )
+
+    demeaner = MapDemeaner(fixef_tol=1e-8, fixef_maxiter=20_000)
+    ssc_config = ssc(k_adj=False, G_adj=False)
+    real_fepois = estimation.fepois
+    refit_calls = []
+    beta_jack = []
+
+    def recording_fepois(*, data, **kwargs):
+        refit_calls.append((data, kwargs))
+        refit = real_fepois(data=data, **kwargs)
+        beta_jack.append(refit.coef().to_numpy())
+        return refit
+
+    monkeypatch.setattr(estimation, "fepois", recording_fepois)
+    fit = real_fepois(
+        "y ~ shift(x) | fixed_effect",
+        data=data,
+        vcov={"CRV3": "cluster"},
+        weights="weight",
+        weights_type="aweights",
+        offset="log(exposure)",
+        ssc=ssc_config,
+        fixef_rm="none",
+        iwls_tol=1e-10,
+        iwls_maxiter=100,
+        collin_tol=1e-8,
+        separation_check=[],
+        solver="np.linalg.lstsq",
+        demeaner=demeaner,
+        drop_intercept=True,
+        context={"shift": shift},
+    )
+
+    assert len(refit_calls) == n_clusters
+    for refit_data, kwargs in refit_calls:
+        assert refit_data["cluster"].nunique() == n_clusters - 1
+        assert kwargs["fml"] == "y ~ shift(x) | fixed_effect"
+        assert kwargs["vcov"] == "iid"
+        assert kwargs["weights"] == "weight"
+        assert kwargs["weights_type"] == "aweights"
+        assert kwargs["ssc"] == ssc_config
+        assert kwargs["fixef_rm"] == "none"
+        assert kwargs["iwls_tol"] == 1e-10
+        assert kwargs["iwls_maxiter"] == 100
+        assert kwargs["collin_tol"] == 1e-8
+        assert kwargs["separation_check"] == []
+        assert kwargs["solver"] == "np.linalg.lstsq"
+        assert kwargs["demeaner"] is demeaner
+        assert kwargs["drop_intercept"] is True
+        assert kwargs["offset"] == "log(exposure)"
+        assert kwargs["context"]["shift"] is shift
+
+    expected_vcov = np.zeros_like(fit._vcov)
+    for beta in beta_jack:
+        centered = beta - fit.coef().to_numpy()
+        expected_vcov += np.outer(centered, centered)
+    np.testing.assert_allclose(fit._vcov, expected_vcov, rtol=1e-12, atol=1e-12)
+
+
+def test_crv3_rebuilds_preconditioner_for_each_changed_design():
+    """Leave-cluster-out refits must not reuse a full-sample factorization."""
+    rng = np.random.default_rng(20260902)
+    n_groups = 6
+    rows_per_group = 6
+    n = n_groups * rows_per_group
+    data = pd.DataFrame(
+        {
+            "y": rng.normal(size=n),
+            "x": rng.normal(size=n),
+            "group": np.repeat(np.arange(n_groups), rows_per_group),
+            "time": np.tile(np.arange(rows_per_group), n_groups),
+        }
+    )
+    base = feols(
+        "y ~ x | group + time",
+        data=data,
+        vcov="iid",
+        demeaner=LsmrDemeaner(backend="within"),
+    )
+    assert base.preconditioner is not None
+    reused = LsmrDemeaner(
+        backend="within",
+        preconditioner=base.preconditioner,
+    )
+
+    fit = feols(
+        "y ~ x | group + time",
+        data=data,
+        vcov={"CRV3": "group"},
+        demeaner=reused,
+    )
+
+    assert np.isfinite(fit._vcov).all()
 
 
 @pytest.mark.parametrize("vcov", ["NW", "DK"])

--- a/tests/test_vs_fixest.py
+++ b/tests/test_vs_fixest.py
@@ -109,6 +109,53 @@ def data_fepois(N=1000, seed=7651, beta_type="2", error_type="2"):
     )
 
 
+def _make_frequency_weighted_linear_data():
+    """Return deterministic aggregate linear and IV data (seed 20260901)."""
+    rng = np.random.default_rng(20260901)
+    n_per_group = 12
+    fixed_effect = np.repeat(list("abcd"), n_per_group)
+    fixed_effect_value = np.repeat([-0.8, -0.2, 0.3, 0.9], n_per_group)
+    x = rng.normal(size=4 * n_per_group)
+    z = rng.normal(size=4 * n_per_group)
+    d = (
+        0.9 * z
+        + 0.3 * x
+        + 0.25 * fixed_effect_value
+        + rng.normal(scale=0.35, size=len(x))
+    )
+    y = (
+        1.0
+        + 0.8 * d
+        - 0.5 * x
+        + fixed_effect_value
+        + rng.normal(scale=0.45, size=len(x))
+    )
+
+    data = pd.DataFrame(
+        {
+            "y": y,
+            "x": x,
+            "d": d,
+            "z": z,
+            "fe": fixed_effect,
+            "fweights": rng.integers(1, 5, size=len(x)),
+        }
+    )
+    # One aggregate row represents two identical observations. Its FE level is
+    # not a singleton in the literal expansion and must survive default removal.
+    singleton_pair = pd.DataFrame(
+        {
+            "y": [0.75],
+            "x": [0.2],
+            "d": [0.4],
+            "z": [0.9],
+            "fe": ["frequency-pair"],
+            "fweights": [2],
+        }
+    )
+    return pd.concat([data, singleton_pair], ignore_index=True)
+
+
 rng = np.random.default_rng(8760985)
 
 
@@ -576,6 +623,121 @@ def test_single_fit_fepois(
         r_predict_link[0:5],
         1e-06,
         "py_predict_link != r_predict_link",
+    )
+
+
+@pytest.mark.against_r_core
+@pytest.mark.parametrize("fml", ["Y ~ X1", "Y ~ X1 | f1"])
+@pytest.mark.parametrize("vcov", ["iid", "hetero"])
+def test_fepois_frequency_weights_against_fixest(data_fepois, fml, vcov):
+    """Compare FEPoisson fweights with the literal expansion in R fixest."""
+    data = data_fepois.dropna().copy()
+    data["fweights"] = np.arange(len(data)) % 4 + 1
+    expanded_data = (
+        data.loc[data.index.repeat(data["fweights"])]
+        .drop(columns="fweights")
+        .reset_index(drop=True)
+    )
+    py_ssc = ssc(k_adj=True, G_adj=True)
+    r_ssc = fixest.ssc(True, "nonnested", False, True, "min", "min")
+
+    py_fit = pf.fepois(
+        fml=fml,
+        data=data,
+        weights="fweights",
+        weights_type="fweights",
+        vcov=vcov,
+        ssc=py_ssc,
+        iwls_tol=1e-10,
+        iwls_maxiter=100,
+    )
+    r_fit = fixest.fepois(
+        ro.Formula(fml),
+        data=expanded_data,
+        vcov=vcov,
+        ssc=r_ssc,
+        glm_tol=1e-10,
+        glm_iter=100,
+    )
+
+    np.testing.assert_allclose(
+        py_fit.coef().to_numpy(),
+        np.asarray(stats.coef(r_fit)),
+        rtol=0,
+        atol=1e-6,
+        err_msg="FEPoisson fweights differ from the R fixest literal expansion",
+    )
+    np.testing.assert_allclose(
+        py_fit._vcov,
+        np.asarray(stats.vcov(r_fit)),
+        rtol=0,
+        atol=1e-6,
+        err_msg="FEPoisson fweight covariance differs from the R fixest literal expansion",
+    )
+
+
+@pytest.mark.against_r_core
+@pytest.mark.parametrize(
+    "fml",
+    [
+        "y ~ x",
+        "y ~ x | fe",
+        "y ~ x | d ~ z",
+        "y ~ x | fe | d ~ z",
+    ],
+)
+def test_frequency_weighted_linear_models_against_fixest(fml):
+    """Compare fweight OLS and IV covariance to R fixest literal expansion."""
+    data = _make_frequency_weighted_linear_data()
+    expanded_data = (
+        data.loc[data.index.repeat(data["fweights"])]
+        .drop(columns="fweights")
+        .reset_index(drop=True)
+    )
+    py_ssc = ssc(k_adj=True, G_adj=True)
+    r_ssc = fixest.ssc(True, "nonnested", False, True, "min", "min")
+
+    py_fit = pf.feols(
+        fml=fml,
+        data=data,
+        weights="fweights",
+        weights_type="fweights",
+        vcov="hetero",
+        ssc=py_ssc,
+    )
+    r_fit = fixest.feols(ro.Formula(fml), data=expanded_data, vcov="hetero", ssc=r_ssc)
+
+    ro.globalenv[".fweight_r_fit"] = r_fit
+    r_coefficient_names = list(ro.r("names(coef(.fweight_r_fit))"))
+    r_vcov_names = list(ro.r("rownames(vcov(.fweight_r_fit))"))
+    py_coefficient_names = list(py_fit.coef().index)
+    is_iv = "d ~ z" in fml
+    r_name_by_py_name = {
+        "Intercept": "(Intercept)",
+        "d": "fit_d" if is_iv else "d",
+    }
+    r_order = [
+        r_coefficient_names.index(r_name_by_py_name.get(name, name))
+        for name in py_coefficient_names
+    ]
+    r_vcov_order = [
+        r_vcov_names.index(r_name_by_py_name.get(name, name))
+        for name in py_coefficient_names
+    ]
+
+    np.testing.assert_allclose(
+        py_fit.coef().to_numpy(),
+        np.asarray(stats.coef(r_fit))[r_order],
+        rtol=0,
+        atol=1e-8,
+        err_msg="Fweight coefficients differ from the R fixest literal expansion",
+    )
+    np.testing.assert_allclose(
+        py_fit._vcov,
+        np.asarray(stats.vcov(r_fit))[np.ix_(r_vcov_order, r_vcov_order)],
+        rtol=0,
+        atol=1e-7,
+        err_msg="Fweight covariance differs from the R fixest literal expansion",
     )
 
 

--- a/tests/test_wls_types.py
+++ b/tests/test_wls_types.py
@@ -1,7 +1,42 @@
 import numpy as np
+import pandas as pd
 import pytest
 
 import pyfixest as pf
+
+
+def _make_frequency_weight_data():
+    """Return aggregate rows and their literal frequency-weight expansion."""
+    x = np.array([-1.5, -0.5, 0.5, 1.5, -1.4, -0.4, 0.6, 1.4, -1.6, -0.6, 0.4, 1.6])
+    z = np.array([-1.0, 1.0, -1.0, 1.0, 1.0, -1.0, -1.0, 1.0, -1.0, -1.0, 1.0, 1.0])
+    first_stage_error = np.array(
+        [0.3, -0.2, 0.1, -0.1, -0.25, 0.2, -0.15, 0.05, 0.12, -0.18, 0.22, -0.08]
+    )
+    structural_error = np.array(
+        [0.2, -0.4, 0.3, -0.1, -0.25, 0.35, -0.2, 0.15, 0.28, -0.32, 0.18, -0.12]
+    )
+    fixef = np.repeat(["a", "b", "c"], 4)
+    fixef_effect = np.repeat([-0.8, 0.4, 1.1], 4)
+    count = np.array([1, 3, 2, 4, 2, 1, 3, 2, 4, 1, 2, 3])
+    endogenous = 1.1 * z + 0.25 * x + 0.15 * fixef_effect + first_stage_error
+    response = 1.0 + 1.4 * endogenous - 0.6 * x + fixef_effect + structural_error
+
+    aggregate = pd.DataFrame(
+        {
+            "y": response,
+            "x": x,
+            "d": endogenous,
+            "z": z,
+            "fe": fixef,
+            "count": count,
+        }
+    )
+    expanded = (
+        aggregate.loc[aggregate.index.repeat(count)]
+        .drop(columns="count")
+        .reset_index(drop=True)
+    )
+    return aggregate, expanded
 
 
 def _assert_fit_equal(fit1, fit2, vcov_types, rtol=1e-5):
@@ -68,7 +103,110 @@ def test_fweights_ols(fml, cols, vcov_types):
     _assert_fit_equal(fit_raw, fit_agg, vcov_types)
 
 
-@pytest.mark.skip(reason="Poisson fweights has a separate bug - see issue #367")
+@pytest.mark.parametrize(
+    "fml,vcov_types,performance_attributes",
+    [
+        ("y ~ x", ["iid", "HC1", "HC2", "HC3"], ["_rmse", "_r2", "_adj_r2"]),
+        (
+            "y ~ x | fe",
+            ["iid", "HC1"],
+            ["_rmse", "_r2", "_adj_r2", "_r2_within", "_adj_r2_within"],
+        ),
+    ],
+)
+def test_fweights_ols_matches_literal_expansion(
+    fml, vcov_types, performance_attributes
+):
+    """Frequency-weighted OLS state matches literally repeated observations."""
+    aggregate, expanded = _make_frequency_weight_data()
+    counts = aggregate["count"].to_numpy(dtype=np.int64)
+
+    fit_weighted = pf.feols(
+        fml,
+        data=aggregate,
+        weights="count",
+        weights_type="fweights",
+        vcov="iid",
+    )
+    fit_expanded = pf.feols(fml, data=expanded, vcov="iid")
+
+    _assert_fit_equal(fit_weighted, fit_expanded, vcov_types, rtol=1e-10)
+    assert len(expanded) == fit_weighted._N
+    assert fit_weighted._N_rows == len(aggregate)
+
+    np.testing.assert_allclose(
+        np.repeat(fit_weighted.resid(), counts),
+        fit_expanded.resid(),
+        rtol=1e-10,
+        atol=1e-10,
+    )
+    np.testing.assert_allclose(
+        fit_weighted.resid(),
+        fit_weighted._within_data.response.flatten()
+        - fit_weighted._X @ fit_weighted._beta_hat,
+        rtol=1e-10,
+        atol=1e-10,
+    )
+
+    for attribute in performance_attributes:
+        np.testing.assert_allclose(
+            getattr(fit_weighted, attribute),
+            getattr(fit_expanded, attribute),
+            rtol=1e-10,
+            atol=1e-10,
+        )
+
+
+@pytest.mark.parametrize("estimator", ["ols", "iv", "poisson"])
+def test_fweights_singleton_detection_matches_literal_expansion(estimator):
+    """An aggregate row with count above one is not an FE singleton."""
+    aggregate = pd.DataFrame(
+        {
+            "y": [2, 1, 4, 2, 5],
+            "x": [0.2, -1.0, 1.0, -0.5, 0.8],
+            "d": [0.1, -0.8, 1.2, -0.2, 1.0],
+            "z": [0.3, -1.1, 0.7, -0.7, 1.3],
+            "fe": ["solo", "a", "a", "b", "b"],
+            "count": [2, 1, 2, 1, 2],
+        }
+    )
+    expanded = (
+        aggregate.loc[aggregate.index.repeat(aggregate["count"])]
+        .drop(columns="count")
+        .reset_index(drop=True)
+    )
+    formula = {
+        "ols": "y ~ x | fe",
+        "iv": "y ~ x + [d ~ z] | fe",
+        "poisson": "y ~ x | fe",
+    }[estimator]
+    fit = pf.fepois if estimator == "poisson" else pf.feols
+    fit_kwargs = (
+        {"iwls_tol": 1e-10, "iwls_maxiter": 100} if estimator == "poisson" else {}
+    )
+
+    weighted = fit(
+        formula,
+        data=aggregate,
+        weights="count",
+        weights_type="fweights",
+        vcov="iid",
+        **fit_kwargs,
+    )
+    literal = fit(formula, data=expanded, vcov="iid", **fit_kwargs)
+
+    assert weighted._N_rows == len(aggregate)
+    assert len(expanded) == weighted._N
+    assert literal._N_rows == len(expanded)
+    np.testing.assert_allclose(weighted.coef(), literal.coef(), rtol=1e-10, atol=1e-10)
+    np.testing.assert_allclose(
+        weighted._vcov,
+        literal._vcov,
+        rtol=1e-10,
+        atol=1e-10,
+    )
+
+
 @pytest.mark.parametrize(
     "fml,fe_col",
     [
@@ -88,13 +226,15 @@ def test_fweights_poisson(fml, fe_col):
         data[cols].groupby(cols).size().reset_index().rename(columns={0: "count"})
     )
 
-    fit_raw = pf.fepois(fml, data=data, vcov="iid")
+    fit_raw = pf.fepois(fml, data=data, vcov="iid", iwls_tol=1e-12, iwls_maxiter=100)
     fit_agg = pf.fepois(
         fml,
         data=data_agg,
         weights="count",
         weights_type="fweights",
         vcov="iid",
+        iwls_tol=1e-12,
+        iwls_maxiter=100,
     )
 
     # Poisson only supports HC1 for hetero-robust SEs
@@ -102,40 +242,83 @@ def test_fweights_poisson(fml, fe_col):
     _assert_fit_equal(fit_raw, fit_agg, vcov_types)
 
 
-@pytest.mark.skip(reason="Not implemented yet.")
-def test_fweights_iv():
-    data = pf.get_data()
-    data2_w = (
-        data[["Y", "X1", "Z1"]]
-        .groupby(["Y", "X1", "Z1"])
-        .size()
-        .reset_index()
-        .rename(columns={0: "count"})
-    )
+@pytest.mark.parametrize("fml", ["y ~ x + [d ~ z]", "y ~ x + [d ~ z] | fe"])
+def test_fweights_iv_matches_literal_expansion(fml):
+    """Frequency-weighted IV and first-stage state match repeated observations."""
+    aggregate, expanded = _make_frequency_weight_data()
+    counts = aggregate["count"].to_numpy(dtype=np.int64)
 
-    fit1 = pf.feols("Y ~ 1 | X1 ~ Z1", data=data)
-    fit2 = pf.feols(
-        "Y ~ 1 | X1 ~ Z1", data=data2_w, weights="count", weights_type="fweights"
-    )
-    np.testing.assert_allclose(fit1.tidy().values, fit2.tidy().values)
-
-    data3_w = (
-        data[["Y", "X1", "Z1", "f1"]]
-        .groupby(["Y", "X1", "Z1", "f1"])
-        .size()
-        .reset_index()
-        .rename(columns={0: "count"})
-    )
-
-    fit3 = pf.feols("Y ~ 1 | f1 | X1 ~ Z1 ", data=data.dropna(), vcov={"CRV1": "f1"})
-    fit4 = pf.feols(
-        "Y ~ 1 | f1 | X1 ~ Z1",
-        data=data3_w.dropna(),
+    fit_weighted = pf.feols(
+        fml,
+        data=aggregate,
         weights="count",
         weights_type="fweights",
-        vcov={"CRV1": "f1"},
+        vcov="hetero",
     )
-    np.testing.assert_allclose(fit3.tidy().values, fit4.tidy().values)
+    fit_expanded = pf.feols(fml, data=expanded, vcov="hetero")
+
+    np.testing.assert_allclose(
+        fit_weighted.coef().values,
+        fit_expanded.coef().values,
+        rtol=1e-10,
+        atol=1e-10,
+    )
+    np.testing.assert_allclose(
+        fit_weighted._vcov, fit_expanded._vcov, rtol=1e-10, atol=1e-10
+    )
+    np.testing.assert_allclose(
+        np.repeat(fit_weighted.resid(), counts),
+        fit_expanded.resid(),
+        rtol=1e-10,
+        atol=1e-10,
+    )
+
+    np.testing.assert_allclose(
+        fit_weighted._pi_hat, fit_expanded._pi_hat, rtol=1e-10, atol=1e-10
+    )
+    np.testing.assert_allclose(
+        np.repeat(fit_weighted._X_hat, counts),
+        fit_expanded._X_hat,
+        rtol=1e-10,
+        atol=1e-10,
+    )
+    np.testing.assert_allclose(
+        np.repeat(fit_weighted._v_hat, counts),
+        fit_expanded._v_hat,
+        rtol=1e-10,
+        atol=1e-10,
+    )
+    np.testing.assert_allclose(
+        fit_weighted._X_hat,
+        fit_weighted._model_1st_stage._X @ fit_weighted._pi_hat,
+        rtol=1e-10,
+        atol=1e-10,
+    )
+    np.testing.assert_allclose(
+        fit_weighted._v_hat,
+        fit_weighted._model_1st_stage._within_data.response.flatten()
+        - fit_weighted._X_hat,
+        rtol=1e-10,
+        atol=1e-10,
+    )
+    np.testing.assert_allclose(
+        fit_weighted._f_stat_1st_stage,
+        fit_expanded._f_stat_1st_stage,
+        rtol=1e-10,
+        atol=1e-10,
+    )
+    np.testing.assert_allclose(
+        fit_weighted._p_value_1st_stage,
+        fit_expanded._p_value_1st_stage,
+        rtol=1e-10,
+        atol=1e-10,
+    )
+
+    fit_weighted.IV_Diag()
+    fit_expanded.IV_Diag()
+    np.testing.assert_allclose(
+        fit_weighted._eff_F, fit_expanded._eff_F, rtol=1e-10, atol=1e-10
+    )
 
 
 def test_aweights():


### PR DESCRIPTION
## Summary

Completes the estimator-state refactor by separating immutable observation weights, unpremultiplied within arrays, GLM working state, and array-native demeaning results. Square-root-weighted arrays now exist only as local solver temporaries; canonical linear residuals and fixed-effect contributions remain in response units.

Frequency weights follow literal expanded-sample semantics across OLS, IV, GLM/Poisson, singleton detection, and HC2/HC3. Numerical coverage compares against R `fixest` and literal row expansion; narrowly scoped snapshot deltas document intentional corrections.

The final safety commits also make failed stripped-data covariance updates preserve existing inference state, allow a common explicit sample to be forwarded safely by `FixestMulti.vcov()`, keep array-only IV effective-F diagnostics usable, retain default multi-quantile prediction/covariance state, and reject decomposition explicitly for unsupported GLM and quantile models.

## Stack

Layer 3 of 3. Depends on [#1492](https://github.com/py-econometrics/pyfixest/pull/1492).

## Verification

- `pixi run test-py`: 6,865 passed, 4,690 skipped, 1 xfailed on this exact head, including the complete release-contract snapshot matrix (298.53 s).
- `pixi run -e py312-r test-r-fixest`: 5,104 passed, 37 skipped against R `fixest` on this exact head (104.71 s).
- `pixi run -e py312-r pytest tests/test_estimator_state_lifecycle.py -x -q --no-cov`: 28 passed on this exact head.
- Changed-file `ruff-check` across all 37 Python files: passed on this exact head.
- Changed-file `mypy` across all 37 Python files: passed on this exact head.

## Compatibility / risks

Probability weights remain unsupported. Weighted CCV, non-Poisson GLM CRV3, non-OLS wild bootstrap, and non-OLS/non-Poisson randomization inference now fail explicitly. `Feols.update(inplace=True)` is rejected because a coefficient-only update cannot reconstruct coherent retained result state. Quantile-regression weight and fixed-effect limitations are unchanged.

A benchmark smoke run completed, but base/head ordering and machine drift produced contradictory timing directions, so runtime evidence is inconclusive. Formal process-level ABBA benchmarking is deferred. Full R-core, HAC, extended, documentation-render, and cross-platform checks are deferred to exact-head CI; they are not claimed as passed here.
