### PR TITLE
test(glm): cover the feglm residual default against fixest

### DIFF
--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -88,6 +88,9 @@ fit.confint(inference_type="savi", mixture_precision=mixture_precision)
 - `feglm(family="gaussian")` now matches `pf.feols()` (and base R `lm`/`glm`)
   exactly. We slightly deviate from `fixest::feglm(family="gaussian")`, which uses slightly different small sample corrections between OLS and GLM with Gaussian link.
 - Logit and probit IRLS initialise at new values for better numerical stability.
+- `feglm().resid()` now returns the response residual `y - mu` by default,
+  matching `fixest` and base R's `glm()`. It previously returned the IRLS
+  working residual, which is still available as `resid(type="working")`.
 
 ### Formula Parsing on `formulaic`
 

--- a/tests/test_feols_feglm_internally.py
+++ b/tests/test_feols_feglm_internally.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from scipy.stats import norm
 
 import pyfixest as pf
 from pyfixest.errors import NonConvergenceError
@@ -240,3 +241,49 @@ def test_glm_raises_after_iwls_maxiter_without_convergence():
             maxiter=1,
             tol=1e-14,
         )
+
+
+@pytest.mark.parametrize("family", ["gaussian", "logit", "probit"])
+def test_glm_resid_types(family):
+    """`resid()` is the response residual; `working` divides it by dmu/deta.
+
+    The response residual is compared with `fixest` in
+    `tests/test_predict_resid_fixef.py`; this pins the relationship between the
+    two types, which `residuals.fixest` cannot express.
+    """
+    data = pf.get_data(model="Fepois").dropna()
+    data["Y_bin"] = (data["Y"] > 0).astype(int)
+    binomial = family in ("logit", "probit")
+    fml = "Y_bin ~ X1 + X2 | f1" if binomial else "Y ~ X1 + X2 | f1"
+
+    mod = pf.feglm(fml=fml, data=data, family=family, iwls_tol=1e-10, iwls_maxiter=100)
+
+    response = mod.resid()
+    working = mod.resid(type="working")
+    mu = mod.predict(type="response")
+    eta = mod.predict(type="link")
+    if family == "logit":
+        dmu_deta = mu * (1 - mu)
+    elif family == "probit":
+        dmu_deta = norm.pdf(eta)
+    else:
+        dmu_deta = np.ones_like(mu)
+
+    # The working residual is stored from the final IRLS iterate, so its mu
+    # trails the returned coefficients by one step and the identity holds to the
+    # size of that last update. That is far tighter than the factor of two to
+    # five that separates the two residual types, which is what this pins.
+    np.testing.assert_allclose(
+        working * dmu_deta,
+        response,
+        rtol=1e-04,
+        atol=1e-08,
+        err_msg=f"{family} working residual is not the response residual / dmu_deta",
+    )
+    if not binomial:
+        check_absolute_diff(
+            working, response, 1e-12, "gaussian residual types should coincide"
+        )
+
+    with pytest.raises(ValueError, match="type must be one of 'response' or 'working'"):
+        mod.resid(type="deviance")

--- a/tests/test_predict_resid_fixef.py
+++ b/tests/test_predict_resid_fixef.py
@@ -199,6 +199,54 @@ def test_vs_fixest(data, fml):
 
 
 @pytest.mark.against_r_core
+@pytest.mark.parametrize("family", ["logit", "probit"])
+@pytest.mark.parametrize(
+    "fml",
+    [
+        "Y_bin ~ X1",
+        "Y_bin ~ X1 | f1",
+        "Y_bin ~ X1 + X2 | f1 + f2",
+    ],
+)
+def test_feglm_resid_vs_fixest(data, family, fml):
+    """Compare binomial GLM residuals with fixest.
+
+    `feglm().resid()` returns the response residual `y - mu`, which is what
+    `residuals.fixest` returns for a GLM. Note that `residuals.fixest` ignores
+    its `type` argument for `feglm` objects, so the working residual has no
+    counterpart here; `test_glm_resid_types` covers it internally.
+    """
+    data = data.copy()
+    data["Y_bin"] = (data["Y"] > 0).astype(int)
+
+    mod = pf.feglm(
+        fml=fml,
+        data=data,
+        family=family,
+        vcov="hetero",
+        iwls_tol=1e-10,
+        iwls_maxiter=100,
+    )
+
+    r_mod = fixest.feglm(
+        ro.Formula(fml),
+        data=data,
+        family=stats.binomial(link=family),
+        se="hetero",
+        glm_tol=1e-10,
+        glm_iter=100,
+    )
+
+    np.testing.assert_allclose(
+        mod.resid(),
+        np.asarray(stats.residuals(r_mod)).ravel(),
+        rtol=1e-08,
+        atol=1e-08,
+        err_msg=f"{family} response residuals differ from fixest",
+    )
+
+
+@pytest.mark.against_r_core
 def test_predict_nas():
     # tests to fix #246: https://github.com/py-econometrics/pyfixest/issues/246
 


### PR DESCRIPTION
`feglm().resid()` returns the response residual `y - mu`, matching `fixest` and base R's `glm()`. Nothing tested that: the residual comparisons in `tests/test_predict_resid_fixef.py` covered only OLS and Poisson, and the change from the earlier IRLS working residual was never recorded in the changelog.