### PR TITLE
refactor(estimation): retain formula state and route lifecycle hooks

### DIFF
--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -40,6 +40,12 @@ fit3 = pf.feols("Y ~ X1 + X2 | f1", data = df)
   platform, because pixi has deprecated the `[system-requirements]` table. We
   also refresh `pixi.lock` in the newer v7 format. Both ask for pixi 0.71.0 or
   newer.
+- Fitted models now retain the formula `ModelMatrix` as read-only formula
+  state, GLM separation filters it through `ModelMatrix.without_rows()`, and
+  the generic fit runner delegates response validation, post-fit work, and
+  result expansion through a structural lifecycle protocol. This keeps formula
+  roles stable while the later within- and weight-scale cleanup proceeds
+  independently.
 
 ### Inference Types
 

--- a/docs/developer/architecture.md
+++ b/docs/developer/architecture.md
@@ -77,6 +77,119 @@ shared estimator API
 `FixestMulti` is a container for fitted results. Numerical behavior belongs in
 the individual models and shared primitives, not in the container.
 
+## Current estimator-state lifecycle
+
+The fitted-model classes currently use themselves as both a work area and a
+result object. Several private attributes therefore change representation and
+numerical scale while a model is fitted. This section records that status quo;
+it is not a contract for new code.
+
+For linear models, the transformations are:
+
+```text
+formula-materialized scale
+  -> weighted fixed-effect projection
+within scale (original units; not premultiplied)
+  -> multiplication by sqrt(observation weights)
+solver scale
+```
+
+The word *weighted* has two distinct meanings in that sequence. Fixed-effect
+residualization uses the observation weights when computing group projections,
+but its output is still in the dependent variable's and covariates' original
+units. Only `wls_transform()` premultiplies those within-scale values by the
+square root of the weights.
+
+### Linear and IV models
+
+`Feols.prepare_model_matrix()` initially stores formula-materialized pandas
+objects in `_Y`, `_X`, `_fe`, `_weights_df`, and, for IV models, `_Z` and
+`_endogvar`. It also retains a copy of the response in `_Y_untransformed`.
+The subsequent stages reuse the same model object:
+
+| Stage | OLS fields | Additional IV fields | Representation and scale |
+|---|---|---|---|
+| `demean()` | `_Yd`, `_Xd` | `_Zd`, `_endogvard` | pandas DataFrames on within scale; the FE projection uses observation weights |
+| `to_array()` | `_Y`, `_X` are reassigned | `_Z` and `_endogvar` are reassigned | NumPy arrays; `_Y` and `_X` now hold within-scale values |
+| `drop_multicol_vars()` | `_X` may lose columns | `_Z` may lose columns | NumPy arrays on within scale; coefficient-name lists mutate in parallel |
+| `wls_transform()` | `_Y`, `_X` are reassigned again | `_Z` and `_endogvar` are reassigned again | NumPy arrays on solver scale, premultiplied by `sqrt(_weights)` |
+| solve | `_Z` aliases `_X`; fit products overwrite empty placeholders | IV cross-products and fit outputs replace placeholders | Solver-scale arrays remain attached to the fitted result |
+
+Consequently, the meaning of `_X`, `_Y`, and `_Z` cannot be inferred from
+their names or type annotations alone. OLS and IV `_u_hat` are also stored on
+solver scale; the public `resid()` accessor divides by `sqrt(_weights)` to
+return residuals in response units. Consumers such as leverage, covariance,
+fixed-effect recovery, and decomposition either expect solver-scale fields or
+undo the transform locally.
+
+The API currently accepts analytic weights (`aweights`) and frequency weights
+(`fweights`), not probability weights. Both weight types use the same weighted
+point-estimation transform. They differ in effective sample size and parts of
+inference: analytic weights use the number of retained rows, while frequency
+weights use the sum of the weights. Estimator-specific support limitations
+must remain explicit rather than being inferred from the array representation.
+
+### GLM, Poisson, and quantile models
+
+`Feglm` starts with formula-materialized DataFrames and converts `_Y`, `_X`,
+and `_fe` to arrays before IRLS. Each iteration creates a working response and
+working weights, performs a weighted FE projection, and solves a square-root-
+weighted least-squares problem. After the final iteration:
+
+- `_X` and `_Y` are replaced by the final solver-scale working design and
+  response;
+- `_weights`, which initially contains observation weights, is replaced by the
+  final IRLS weights and duplicated in `_irls_weights`;
+- `_u_hat` is the solver-scale working residual, while
+  `_u_hat_response` and `_u_hat_working` record two public residual domains;
+- `_scores`, `_scores_response`, and `_scores_working` similarly coexist on
+  different scales.
+
+`Fepois` must copy the observation weights before delegating to this GLM path
+because the inherited `_weights` field changes meaning. `Quantreg` does not
+support fixed effects or weights, but it still reassigns formula-materialized
+`_Y` and `_X` DataFrames to NumPy arrays before solving.
+
+### Shared caches, result completion, and cleanup
+
+For a multiple-estimation cache block, the runner gives each model a
+`DemeanCache` backed by the same mutable dictionaries. Its linear-model cache
+converts pandas inputs to arrays for demeaning, wraps the results in a
+DataFrame, stores that frame, and converts selected columns back to arrays in
+each model. The cache key is the retained-row index set because formulas in one
+cache block share fixed effects and observation weights. GLM iterations do not
+cache demeaned values because their working weights change; they share only a
+preconditioner cache.
+
+Model constructors also create many empty-array and `None` placeholders. The
+runner then mutates the model through preparation, fitting, covariance
+calculation, inference, performance statistics or IV first stages, and finally
+`_clear_attributes()`. `store_data=False` deletes `_data`; `lean=True` deletes
+the retained matrices and several fit products. The public `vcov()` method is
+intentionally in-place and remains a post-fit mutation boundary. User input is
+copied by default, with the documented `copy_data=False` path as the exception.
+
+## Estimation-state vocabulary
+
+New shared-core work should name the transformation domain instead of relying
+on `_X`, `_Y`, `_Z`, or `_weights`. The planned immutable-state refactor uses
+the following vocabulary:
+
+| Term | Meaning |
+|---|---|
+| formula data | Post-filtering, formula-materialized tabular values and metadata; not necessarily identical to raw user columns |
+| observation weights | The weights supplied by the user, together with their `aweights` or `fweights` interpretation |
+| within data | Arrays after the possibly weighted FE projection, still in original units and not premultiplied by square-root weights |
+| solver data | Ephemeral arrays such as `design_sqrt_weighted` used by a numerical solve |
+| working state | GLM iteration values, including a working response and working weights, kept distinct from observation weights |
+| response residual | A residual in the response's units; weighted scores and solver residuals should be named separately |
+
+These states should be completed values returned by transformations. Persisted
+arrays should not change type or numerical domain, and solver scratch should
+not replace canonical within data. A fitted result may still expose explicitly
+in-place post-estimation operations, but those operations must not repurpose
+estimation fields.
+
 ## Repository map and extension seams
 
 Step-by-step recipes for estimators, post-estimation features, vcov types,

--- a/docs/developer/architecture.md
+++ b/docs/developer/architecture.md
@@ -169,10 +169,38 @@ the retained matrices and several fit products. The public `vcov()` method is
 intentionally in-place and remains a post-fit mutation boundary. User input is
 copied by default, with the documented `copy_data=False` path as the exception.
 
+## Formula-state and lifecycle boundaries
+
+`ModelMatrix` builds the formula inputs and is also the formula state a fitted
+model retains. Missing, infinite, singleton, and other formula-level row filters
+run during construction; afterwards the instance is treated as read-only, and
+its dependent, independent, fixed-effect, IV, weight, and offset roles stay on
+formula scale. Models populate legacy attributes from it in one
+direction; later transformations produce separate within- or solver-scale
+arrays and do not change the role or representation of the retained formula
+state. Estimator-level filters that need the materialized design, such as GLM
+separation, call `ModelMatrix.without_rows()`, which returns a filtered copy
+whose `na_index` includes the dropped rows, so the canonical row sample and the
+demeaning-cache key stay aligned with the data that enter IRLS.
+`store_data=False` and `lean=True` discard the formula state together with the
+other retained input state.
+
+The generic runner operates on the structural `FittedModel` protocol. Response
+validation, estimator-specific post-fit work, and result expansion live behind
+model hooks rather than estimator-name dispatch in the runner. Pipeline-object
+constructors only assemble configuration and child objects; for example,
+`QuantregMulti` prepares its children in `prepare_model_matrix`, not during
+construction.
+
+This is the representation foundation, not the final within/weight cleanup.
+The compatibility fields documented above still move through their established
+DataFrame, within-array, and solver-array states until the numerical primitives
+and inference consumers move to explicit within-scale inputs.
+
 ## Estimation-state vocabulary
 
 New shared-core work should name the transformation domain instead of relying
-on `_X`, `_Y`, `_Z`, or `_weights`. The planned immutable-state refactor uses
+on `_X`, `_Y`, `_Z`, or `_weights`. The immutable-state refactor uses
 the following vocabulary:
 
 | Term | Meaning |

--- a/pyfixest/estimation/formula/model_matrix.py
+++ b/pyfixest/estimation/formula/model_matrix.py
@@ -1,7 +1,10 @@
+from __future__ import annotations
+
+import copy
 import warnings
 from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Any, Final
+from typing import Any, Final, TypeAlias, cast
 
 import formulaic
 import numpy as np
@@ -15,6 +18,8 @@ from pyfixest.estimation.formula.formulaic_compat import flatten_model_matrix
 from pyfixest.estimation.formula.parse import Formula
 from pyfixest.estimation.formula.utils import _get_weights
 from pyfixest.utils.utils import capture_context
+
+_ModelSpecMapping: TypeAlias = Mapping[str, formulaic.ModelSpec]
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -42,6 +47,11 @@ class ModelMatrix:
     [feols()](/reference/estimation.api.feols.feols.qmd). See the
     [formula syntax tutorial](/tutorials/formula-syntax.qmd) for the syntax.
 
+    Once constructed, the instance is the formula state a fitted model retains
+    and is treated as read-only. Estimator-level row filters such as GLM
+    separation call `without_rows`, which returns a filtered copy instead of
+    mutating the instance.
+
     Attributes
     ----------
     dependent : pd.DataFrame
@@ -56,8 +66,8 @@ class ModelMatrix:
         Instrumental variables for IV estimation.
     weights : pd.DataFrame or None
         Observation weights for weighted estimation.
-    model_spec : formulaic.ModelSpec
-        The underlying formulaic model specification.
+    model_spec : Mapping[str, formulaic.ModelSpec]
+        The underlying formulaic model specifications keyed by role.
     na_index : frozenset[int]
         Indices of rows that were dropped.
     """
@@ -70,7 +80,7 @@ class ModelMatrix:
         drop_intercept: bool = False,
     ) -> None:
         self._drop_intercept = drop_intercept
-        self._model_spec = model_matrix.model_spec
+        self._model_spec = cast(_ModelSpecMapping, model_matrix.model_spec)
         self._na_index = drop_rows
         self._collect_columns(model_matrix)
         self._collect_data(model_matrix)
@@ -171,6 +181,20 @@ class ModelMatrix:
         self._na_index = self._na_index.union(self._data.index[is_dropped].tolist())
         self._data = self._data.loc[~is_dropped]
         warnings.warn(f"{n_dropped} {reason} dropped from the model.")
+
+    def without_rows(self, rows: list[int]) -> ModelMatrix:
+        """Return a copy without ``rows``; they are recorded in ``na_index``.
+
+        Estimator-level filters such as GLM separation run after construction and
+        call this instead of mutating the retained instance, which is left
+        unchanged.
+        """
+        if not rows:
+            return self
+        filtered = copy.copy(self)
+        filtered._data = self._data.drop(index=rows)
+        filtered._na_index = self._na_index.union(rows)
+        return filtered
 
     @property
     def dependent(self) -> pd.DataFrame:
@@ -286,21 +310,20 @@ class ModelMatrix:
             return self._data.loc[:, self._offset]
 
     @property
-    def model_spec(self) -> formulaic.ModelSpec:
+    def model_spec(self) -> _ModelSpecMapping:
         """
         Get the underlying formulaic model specification.
 
         Returns
         -------
-        formulaic.ModelSpec
-            The formulaic ModelSpec object containing metadata about the
-            model structure and transformations.
+        Mapping[str, formulaic.ModelSpec]
+            Formulaic specifications keyed by model-matrix role.
         """
         return self._model_spec
 
     @property
     def na_index(self) -> frozenset[int]:
-        """Integer positions of rows dropped in model matrix creation."""
+        """Integer positions of dropped rows, including ``without_rows`` drops."""
         return self._na_index
 
 

--- a/pyfixest/estimation/models/feglm_.py
+++ b/pyfixest/estimation/models/feglm_.py
@@ -126,7 +126,7 @@ class Feglm(Feols):
 
     def prepare_model_matrix(self):
         "Prepare model inputs for estimation."
-        super().prepare_model_matrix()
+        model_matrix = super().prepare_model_matrix()
 
         # check for separation
         na_separation: list[int] = []
@@ -146,23 +146,21 @@ class Feglm(Feols):
             )
 
         if na_separation:
-            self._Y.drop(na_separation, axis=0, inplace=True)
-            self._X.drop(na_separation, axis=0, inplace=True)
-            self._fe.drop(na_separation, axis=0, inplace=True)
             self._data.drop(na_separation, axis=0, inplace=True)
-            if self._weights_df is not None:
-                self._weights_df.drop(na_separation, axis=0, inplace=True)
-            if self._offset_df is not None:
-                self._offset_df.drop(na_separation, axis=0, inplace=True)
+            model_matrix = model_matrix.without_rows(na_separation)
+            self._publish_model_matrix(model_matrix)
+
+            # Preserve the established GLM sample-size convention after
+            # separation. Frequency-weight policy is handled separately.
             self._N = self._Y.shape[0]
             self._N_rows = self._N
-            # Re-set weights after dropping rows (handles both weighted and unweighted)
-            self._weights = self._set_weights()
 
             self.n_separation_na = len(na_separation)
             # possible to have dropped fixed effects level due to separation
             self._k_fe = self._fe.nunique(axis=0) if self._has_fixef else None
             self._n_fe = np.sum(self._k_fe > 1) if self._has_fixef else 0
+
+        return model_matrix
 
     def to_array(self):
         "Turn estimation DataFrames to np arrays."
@@ -373,6 +371,10 @@ class Feglm(Feols):
     def _check_dependent_variable(self) -> None:
         "Validate the dependent variable according to the family's constraints."
         self._family.check_y(self._Y)
+
+    def _validate_response(self) -> None:
+        """Apply family-specific response validation after matrix preparation."""
+        self._check_dependent_variable()
 
 
 def _glm_input_checks(drop_singletons: bool, tol: float, maxiter: int):

--- a/pyfixest/estimation/models/feiv_.py
+++ b/pyfixest/estimation/models/feiv_.py
@@ -335,6 +335,10 @@ class Feiv(Feols):
 
         self.IV_weakness_test(["f_stat"])
 
+    def _finalize_fit(self) -> None:
+        """Fit and retain the first-stage model after second-stage inference."""
+        self.first_stage()
+
     def IV_Diag(self, statistics: list[str] | None = None):
         """Implement IV diagnostic tests.
 

--- a/pyfixest/estimation/models/feols_.py
+++ b/pyfixest/estimation/models/feols_.py
@@ -404,7 +404,7 @@ class Feols(ResultAccessorMixin):
         self.iplot_aggregate = _not_implemented_did
 
     def prepare_model_matrix(self):
-        "Prepare model matrices for estimation."
+        """Build and retain the canonical formula-derived estimator inputs."""
         model_matrix = model_matrix_fixest.create_model_matrix(
             formula=self.FixestFormula,
             data=self._data,
@@ -414,7 +414,19 @@ class Feols(ResultAccessorMixin):
             offset=self._offset_name,
             context=self._context,
         )
+        self._publish_model_matrix(model_matrix)
 
+        # an empty drop still rebuilds the whole frame, so guard it
+        if self._na_index:
+            self._data.drop(index=list(self._na_index), inplace=True)
+
+        return model_matrix
+
+    # Deliberately untyped: an annotation makes mypy check this body, whose published
+    # attribute types are still transitional or loose; see the typing follow-up.
+    def _publish_model_matrix(self, model_matrix):
+        """Publish one structurally immutable state through compatibility aliases."""
+        self._model_matrix = model_matrix
         self._Y = model_matrix.dependent
         self._Y_untransformed = self._Y.copy()
         self._X = model_matrix.independent
@@ -450,12 +462,11 @@ class Feols(ResultAccessorMixin):
         self._k_fe = self._fe.nunique(axis=0) if self._has_fixef else None
         self._n_fe = len(self._k_fe) if self._has_fixef else 0
 
-        # an empty drop still rebuilds the whole frame, so guard it
-        if self._na_index:
-            self._data.drop(index=list(self._na_index), inplace=True)
-
         self._weights = self._set_weights()
         self._N, self._N_rows = self._set_nobs()
+
+    def _validate_response(self) -> None:
+        """Validate estimator-specific response constraints, if any."""
 
     def _set_nobs(self) -> tuple[int, int]:
         """
@@ -588,6 +599,16 @@ class Feols(ResultAccessorMixin):
             self._tZZinv = np.array([])
 
         self._get_predictors()
+
+    def _finalize_fit(self) -> None:
+        """Compute OLS-only post-fit statistics."""
+        if self._method == "feols" and not self._is_iv:
+            self.get_performance()
+            self.wald_test()
+
+    def _iter_fitted_models(self) -> tuple[Feols, ...]:
+        """Yield this fitted result to the result container."""
+        return (self,)
 
     def vcov(
         self,
@@ -880,7 +901,7 @@ class Feols(ResultAccessorMixin):
         attributes = []
 
         if not self._store_data:
-            attributes += ["_data"]
+            attributes += ["_data", "_model_matrix"]
 
         if self._lean:
             attributes += [
@@ -902,6 +923,7 @@ class Feols(ResultAccessorMixin):
                 "_Y_hat_link",
                 "_Y_hat_response",
                 "_Y_untransformed",
+                "_model_matrix",
             ]
 
         for attr in attributes:

--- a/pyfixest/estimation/plan_.py
+++ b/pyfixest/estimation/plan_.py
@@ -12,12 +12,12 @@ from pyfixest.estimation.config import EstimationConfig
 from pyfixest.estimation.formula.parse import Formula as FixestFormula
 from pyfixest.estimation.internals.vcov_utils import _get_vcov_type
 from pyfixest.estimation.models.fegaussian_ import Fegaussian
-from pyfixest.estimation.models.feglm_ import Feglm
 from pyfixest.estimation.models.feiv_ import Feiv
 from pyfixest.estimation.models.felogit_ import Felogit
 from pyfixest.estimation.models.feols_ import Feols
 from pyfixest.estimation.models.fepois_ import Fepois
 from pyfixest.estimation.models.feprobit_ import Feprobit
+from pyfixest.estimation.protocols import FittedModel, ModelFactory
 from pyfixest.estimation.quantreg.quantreg_ import Quantreg
 from pyfixest.estimation.quantreg.QuantregMulti import QuantregMulti
 
@@ -33,7 +33,7 @@ class ModelEntry:
     to decide which config fields to thread through.
     """
 
-    model_cls: type
+    model_cls: ModelFactory
     needs: frozenset[str] = field(default_factory=frozenset)
 
 
@@ -62,7 +62,7 @@ MODEL_REGISTRY: dict[str, ModelEntry] = {
 }
 
 
-def _resolve_model_class(method: str, is_iv: bool) -> type:
+def _resolve_model_class(method: str, is_iv: bool) -> ModelFactory:
     """Pick the model class to instantiate for this method.
 
     The only special case is `feols` with an IV formula, which
@@ -135,7 +135,7 @@ class ModelSpec:
     """
 
     method: str
-    model_cls: type
+    model_cls: ModelFactory
     formula: FixestFormula
     fixef_key: str | None
     sample_split_value: Any
@@ -289,11 +289,6 @@ def _build_model_kwargs(
     return kwargs
 
 
-FittedModel = (
-    Feols | Feiv | Fepois | Fegaussian | Felogit | Feprobit | Quantreg | QuantregMulti
-)
-
-
 def fit_one(
     spec: ModelSpec,
     *,
@@ -318,27 +313,16 @@ def fit_one(
     FIT: FittedModel = spec.model_cls(**model_kwargs)
 
     FIT.prepare_model_matrix()
-    if isinstance(FIT, Feglm):
-        FIT._check_dependent_variable()
+    FIT._validate_response()
     FIT.get_fit()
     # if X is empty: no inference (empty X only as shorthand for demeaning)
     if not FIT._X_is_empty:
         vcov_type = _get_vcov_type(vcov)
-        FIT.vcov(
-            vcov=vcov_type,
-            vcov_kwargs=vcov_kwargs,
-            data=FIT._data
-            if not isinstance(FIT, QuantregMulti)
-            else FIT.all_quantregs[FIT.quantiles[0]]._data,
-        )  # a little hacky, but works
+        # vcov() reads the model's retained estimation data when data is None
+        FIT.vcov(vcov=vcov_type, vcov_kwargs=vcov_kwargs)
 
         FIT.get_inference()
-        if spec.method == "feols" and not FIT._is_iv:
-            FIT.get_performance()
-            if isinstance(FIT, Feols):
-                FIT.wald_test()
-        if isinstance(FIT, Feiv):
-            FIT.first_stage()
+        FIT._finalize_fit()
     # delete large attributes
     FIT._clear_attributes()
 

--- a/pyfixest/estimation/protocols.py
+++ b/pyfixest/estimation/protocols.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+from typing import TYPE_CHECKING, Any, Protocol, TypeAlias
+
+if TYPE_CHECKING:
+    from pyfixest.estimation.models.feols_ import Feols
+
+
+class FittedModel(Protocol):
+    """Structural contract consumed by the generic estimation pipeline."""
+
+    _X_is_empty: bool
+    _is_iv: bool
+
+    def prepare_model_matrix(self) -> object:
+        """Prepare and retain estimator inputs derived from the formula."""
+        ...
+
+    def _validate_response(self) -> None:
+        """Validate estimator-specific dependent-variable constraints."""
+        ...
+
+    def get_fit(self) -> object:
+        """Estimate the model parameters."""
+        ...
+
+    def vcov(
+        self,
+        vcov: str | dict[str, str],
+        vcov_kwargs: dict[str, str | int] | None = None,
+        data: Any = None,
+    ) -> object:
+        """Compute the requested covariance matrix."""
+        ...
+
+    def get_inference(self) -> object:
+        """Compute coefficient-level inference from the covariance matrix."""
+        ...
+
+    def _finalize_fit(self) -> None:
+        """Run estimator-specific post-fit orchestration."""
+        ...
+
+    def _iter_fitted_models(self) -> Iterable[Feols]:
+        """Yield concrete fitted results produced by this pipeline object."""
+        ...
+
+    def _clear_attributes(self) -> None:
+        """Clear large state according to storage options."""
+        ...
+
+
+ModelFactory: TypeAlias = Callable[..., FittedModel]

--- a/pyfixest/estimation/quantreg/QuantregMulti.py
+++ b/pyfixest/estimation/quantreg/QuantregMulti.py
@@ -69,15 +69,17 @@ class QuantregMulti:
         self.multi_method = multi_method
         self._is_iv = False
 
-        # TODO: call model_matrix(), to_array(), drop_multicol_vars() only once for model 0
-        # and then copy the attributes to the other models (less robust? but faster)
-        [q.prepare_model_matrix() for q in self.all_quantregs.values()]
-        [q.to_array() for q in self.all_quantregs.values()]
-        [q.drop_multicol_vars() for q in self.all_quantregs.values()]
+    def prepare_model_matrix(self) -> None:
+        """Prepare the model inputs for every requested quantile."""
+        # TODO: prepare once and share immutable state across quantiles.
+        for quantreg in self.all_quantregs.values():
+            quantreg.prepare_model_matrix()
+            quantreg.to_array()
+            quantreg.drop_multicol_vars()
 
         self._X_is_empty = False
 
-    def get_fit(self):
+    def get_fit(self) -> dict[float, Quantreg]:
         "Fit multiple quantile regressions via either algo 2 or 3 of CFM."
         # sort q increasing
         q = np.sort(self.quantiles)
@@ -191,54 +193,38 @@ class QuantregMulti:
         vcov: str | dict[str, str],
         vcov_kwargs: dict[str, str | int] | None = None,
         data: DataFrameType | None = None,
-    ):
+    ) -> dict[float, Quantreg]:
         "Compute variance-covariance matrices for all models in the quantile regression process."
-        [
-            QuantReg.vcov(vcov=vcov, vcov_kwargs=vcov_kwargs, data=data)
-            for QuantReg in self.all_quantregs.values()
-        ]
+        for quantreg in self.all_quantregs.values():
+            quantreg.vcov(vcov=vcov, vcov_kwargs=vcov_kwargs, data=data)
 
         return self.all_quantregs
 
-    def get_inference(self):
+    def get_inference(self) -> dict[float, Quantreg]:
         "Compute inference for all models of the quantile regression process."
-        [QuantReg.get_inference() for QuantReg in self.all_quantregs.values()]
+        for quantreg in self.all_quantregs.values():
+            quantreg.get_inference()
 
         return self.all_quantregs
 
-    def prepare_model_matrix(self):
-        "Prepare model matrix. Placeholder, only needed due to structure of execution of FixestMulti class."
-        pass
+    def _validate_response(self) -> None:
+        """Quantile regression has no additional response constraint."""
 
-    def to_array(self):
-        "Covert to array. Placeholder, only needed due to structure of execution of FixestMulti class."
-        pass
+    def _finalize_fit(self) -> None:
+        """Quantile models require no additional post-fit orchestration."""
 
-    def drop_multicol_vars(self):
-        "Drop multicollinear variables. Placeholder, only needed due to structure of execution of FixestMulti class."
-        pass
+    def _iter_fitted_models(self) -> tuple[Quantreg, ...]:
+        """Yield each fitted quantile to the result container."""
+        return tuple(self.all_quantregs.values())
 
-    def wls_transform(self):
-        "Apply the WLS transform. Placeholder, only needed due to structure of execution of FixestMulti class."
-        pass
-
-    def demean(self):
-        "Demean the data. Placeholder, only needed due to structure of execution of FixestMulti class."
-        pass
-
-    def get_performance(self):
-        "Compute performance metrics for all models of the quantile regression process."
-        [QuantReg.get_performance() for QuantReg in self.all_quantregs.values()]
-        return self.all_quantregs
-
-    def _clear_attributes(self):
+    def _clear_attributes(self) -> None:
         "Clear all large non-necessary attributes to free memory."
-        [QuantReg._clear_attributes() for QuantReg in self.all_quantregs.values()]
-        del_attributes = ["_X", "_Y"]
-        for QuantReg in self.all_quantregs.values():
-            for attr in del_attributes:
-                if hasattr(QuantReg, attr):
-                    delattr(QuantReg, attr)
-        gc.collect()
+        for quantreg in self.all_quantregs.values():
+            quantreg._clear_attributes()
 
-        return self.all_quantregs
+        del_attributes = ["_X", "_Y"]
+        for quantreg in self.all_quantregs.values():
+            for attr in del_attributes:
+                if hasattr(quantreg, attr):
+                    delattr(quantreg, attr)
+        gc.collect()

--- a/pyfixest/estimation/runner.py
+++ b/pyfixest/estimation/runner.py
@@ -17,7 +17,6 @@ from pyfixest.estimation.plan_ import (
     expand_specs,
     fit_one,
 )
-from pyfixest.estimation.quantreg.QuantregMulti import QuantregMulti
 from pyfixest.utils.dev_utils import _narwhals_to_pandas
 from pyfixest.utils.utils import capture_context
 
@@ -99,11 +98,8 @@ def run_estimation(
             vcov_kwargs=config.vcov_kwargs,
         )
 
-        if isinstance(FIT, QuantregMulti):
-            for q_model in FIT.all_quantregs.values():
-                fixest.all_fitted_models[q_model._model_name] = q_model
-        else:
-            fixest.all_fitted_models[FIT._model_name] = FIT
+        for fitted_result in FIT._iter_fitted_models():
+            fixest.all_fitted_models[fitted_result._model_name] = fitted_result
 
     if parsed.is_multiple_estimation:
         return fixest

--- a/tests/test_estimator_state_lifecycle.py
+++ b/tests/test_estimator_state_lifecycle.py
@@ -1,0 +1,139 @@
+"""Protect the estimator-state lifecycle boundaries of formula data.
+
+These tests deliberately inspect private state: public numerical behavior is
+covered by the release snapshots and live-R suites, while the representation
+and row-sample seams locked here are not observable from those suites.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import pyfixest as pf
+from pyfixest.estimation.formula.model_matrix import ModelMatrix, create_model_matrix
+from pyfixest.estimation.formula.parse import Formula
+
+
+@pytest.fixture
+def lifecycle_data() -> pd.DataFrame:
+    """Return a small full-rank weighted FE/IV data set."""
+    rng = np.random.default_rng(20260831)
+    n_obs = 24
+    fixed_effect = np.repeat(["a", "b", "c", "d"], n_obs // 4)
+    group_effect = pd.Series(fixed_effect).map(
+        {"a": -1.0, "b": 0.5, "c": 1.25, "d": -0.25}
+    )
+    instrument = rng.normal(size=n_obs)
+    covariate = rng.normal(size=n_obs)
+    second_covariate = rng.normal(size=n_obs)
+    endogenous = 0.8 * instrument + 0.4 * covariate + rng.normal(size=n_obs)
+    response = (
+        1.2 * covariate
+        - 0.6 * second_covariate
+        + 1.5 * endogenous
+        + group_effect.to_numpy()
+        + rng.normal(scale=0.3, size=n_obs)
+    )
+
+    return pd.DataFrame(
+        {
+            "y": response,
+            "x": covariate,
+            "x2": second_covariate,
+            "endog": endogenous,
+            "z": instrument,
+            "fe": fixed_effect,
+            "weight": np.tile([1, 2, 4, 3, 1, 2], 4),
+        }
+    )
+
+
+def test_formula_data_remains_canonical_after_linear_fit(
+    lifecycle_data: pd.DataFrame,
+) -> None:
+    """Formula roles remain tabular while compatibility aliases are transformed."""
+    fit = pf.feols(
+        "y ~ x + [endog ~ z] | fe",
+        data=lifecycle_data,
+        weights="weight",
+        vcov="iid",
+    )
+
+    model_matrix = fit._model_matrix
+    assert isinstance(model_matrix, ModelMatrix)
+
+    assert isinstance(model_matrix.dependent, pd.DataFrame)
+    assert isinstance(model_matrix.independent, pd.DataFrame)
+    assert isinstance(model_matrix.fixed_effects, pd.DataFrame)
+    assert isinstance(model_matrix.instruments, pd.DataFrame)
+    assert isinstance(model_matrix.weights, pd.DataFrame)
+    assert isinstance(fit._Y, np.ndarray)
+    assert isinstance(fit._X, np.ndarray)
+    assert isinstance(fit._Z, np.ndarray)
+    pd.testing.assert_frame_equal(
+        model_matrix.dependent,
+        lifecycle_data.loc[:, ["y"]],
+    )
+    pd.testing.assert_frame_equal(
+        model_matrix.weights,
+        lifecycle_data.loc[:, ["weight"]],
+    )
+    assert fit._model_spec is model_matrix.model_spec
+
+
+def test_glm_separation_replaces_formula_data_with_filtered_state() -> None:
+    """Canonical GLM formula data describes the post-separation sample."""
+    data = pd.DataFrame(
+        {
+            "y": [0, 0, 0, 1, 2, 3],
+            "fe": ["a", "a", "b", "b", "b", "c"],
+            "x": [-1.0, 0.5, 0.25, 1.0, -0.5, 1.5],
+        }
+    )
+
+    with pytest.warns(
+        UserWarning, match="2 observations removed because of separation"
+    ):
+        fit = pf.fepois(
+            "y ~ x | fe",
+            data=data,
+            vcov="hetero",
+            separation_check=["fe"],
+        )
+
+    model_matrix = fit._model_matrix
+    assert model_matrix.dependent.index.equals(fit._data.index)
+    assert model_matrix.independent.index.equals(fit._data.index)
+    assert model_matrix.fixed_effects is not None
+    assert model_matrix.fixed_effects.index.equals(fit._data.index)
+    # Row 5 is a formula-stage singleton; rows 0 and 1 are separated.
+    assert model_matrix.na_index == frozenset({0, 1, 5})
+    assert len(model_matrix.dependent) == fit._N_rows
+    assert fit.n_separation_na == 2
+
+
+def test_model_matrix_without_rows_returns_filtered_copy(
+    lifecycle_data: pd.DataFrame,
+) -> None:
+    """Estimator-level row filters yield a new ModelMatrix and keep the source."""
+    model_matrix = create_model_matrix(
+        formula=Formula.parse("y ~ x | fe")[0],
+        data=lifecycle_data.copy(),
+        weights="weight",
+    )
+    kept_index = model_matrix.dependent.index.drop([0, 5])
+
+    filtered = model_matrix.without_rows([0, 5])
+
+    assert model_matrix.without_rows([]) is model_matrix
+    assert filtered is not model_matrix
+    assert filtered.na_index == model_matrix.na_index | {0, 5}
+    assert filtered.model_spec is model_matrix.model_spec
+    for role in ("dependent", "independent", "fixed_effects", "weights"):
+        assert getattr(filtered, role).index.equals(kept_index)
+    assert filtered.endogenous is None
+    assert filtered.instruments is None
+    assert filtered.offset is None
+    assert len(model_matrix.dependent) == len(lifecycle_data)

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -15,11 +15,14 @@ from pyfixest.estimation.models.feols_ import Feols
 from pyfixest.estimation.models.fepois_ import Fepois
 from pyfixest.estimation.plan_ import (
     MODEL_REGISTRY,
+    ModelSpec,
     _resolve_model_class,
     build_all_splits,
     expand_specs,
+    fit_one,
 )
 from pyfixest.estimation.quantreg.quantreg_ import Quantreg
+from pyfixest.estimation.quantreg.QuantregMulti import QuantregMulti
 
 
 def _config(method: str, fml: str, data, **overrides) -> EstimationConfig:
@@ -299,3 +302,99 @@ def test_public_feols_matches_legacy_behavior():
     fit = pf.feols("Y ~ X1 + X2 | f1 + f2", data)
     # If the planner regressed anything, coefficients would shift.
     assert abs(fit.coef().iloc[0] - (-0.9240461507764969)) < 1e-10
+
+
+def test_fit_one_uses_the_structural_lifecycle_contract():
+    """The generic pipeline delegates estimator-specific work through hooks."""
+    events: list[str] = []
+
+    class StubModel:
+        _X_is_empty = False
+        _is_iv = False
+
+        def __init__(self, *, events, **kwargs):
+            self.events = events
+
+        def prepare_model_matrix(self):
+            self.events.append("prepare")
+
+        def _validate_response(self):
+            self.events.append("validate")
+
+        def get_fit(self):
+            self.events.append("fit")
+
+        def vcov(self, vcov, vcov_kwargs=None, data=None):
+            assert vcov == "iid"
+            assert data is None
+            self.events.append("vcov")
+
+        def get_inference(self):
+            self.events.append("inference")
+
+        def _finalize_fit(self):
+            self.events.append("finalize")
+
+        def _clear_attributes(self):
+            self.events.append("clear")
+
+        def _iter_fitted_models(self):
+            return ()
+
+    formula = Formula.parse_to_dict("Y ~ X1")[None][0]
+    spec = ModelSpec(
+        method="quantreg",
+        model_cls=StubModel,
+        formula=formula,
+        fixef_key=None,
+        sample_split_value=_ALL_SAMPLE,
+        model_kwargs={"events": events},
+    )
+
+    fit_one(
+        spec,
+        lookup_demeaned_data={},
+        lookup_preconditioner={},
+        vcov=None,
+        vcov_kwargs=None,
+    )
+
+    assert events == [
+        "prepare",
+        "validate",
+        "fit",
+        "vcov",
+        "inference",
+        "finalize",
+        "clear",
+    ]
+
+
+def test_quantreg_multi_prepares_children_in_lifecycle_hook():
+    """Multi-quantile construction is deferred to the preparation phase."""
+    events: list[str] = []
+
+    class StubQuantreg:
+        def prepare_model_matrix(self):
+            events.append("prepare")
+
+        def to_array(self):
+            events.append("to_array")
+
+        def drop_multicol_vars(self):
+            events.append("drop_multicol_vars")
+
+    fit = QuantregMulti.__new__(QuantregMulti)
+    fit.all_quantregs = {0.25: StubQuantreg(), 0.75: StubQuantreg()}
+
+    fit.prepare_model_matrix()
+
+    assert events == [
+        "prepare",
+        "to_array",
+        "drop_multicol_vars",
+        "prepare",
+        "to_array",
+        "drop_multicol_vars",
+    ]
+    assert fit._X_is_empty is False


### PR DESCRIPTION
## Summary

Base layer of the estimation-state stack; #1516 and #1518–#1525 are stacked on it (#1500 and #1501 were closed as superseded).

Fitted models now retain the formula `ModelMatrix` as read-only formula state instead of copying its roles into a separate record, and the generic fit runner delegates response validation, post-fit work, and result expansion through a structural `FittedModel` protocol instead of estimator-name dispatch. Numerical results are unchanged.

- GLM separation filters the sample through the new `ModelMatrix.without_rows()`, which returns a copy and records the dropped rows in `na_index`. On master the post-separation `_na_index` was stale, so the demeaning and preconditioner cache key described the pre-separation sample, and `_Y_untransformed` kept its pre-separation length.
- The runner no longer passes `data=` to `vcov()`: `vcov()` already reads the model's retained estimation data, and `QuantregMulti` children carry their own.
- `QuantregMulti.get_performance()` is removed; the old `spec.method == "feols"` gate never reached it.
- The architecture guide records the pre-refactor estimator-state lifecycle and the stack's vocabulary.

## Verification

Release contract 1355/1355 against pyfixest 0.60.0, fast live-R 22/22, targeted Python suites, broad Python-only suite (pre-existing `torch_mps` demeaner-backend failures excluded), ruff, and mypy all pass. Deferred to CI: full R suites, HAC, docs render.

## Compatibility / risks

Retaining the `ModelMatrix` keeps the design frame alive for the model's lifetime: about 20 MB on a 200k x 13 design, roughly doubling per-model retained memory. `lean=True` and `store_data=False` free it, and the layers stacked above are its first consumers.
