### PR TITLE
refactor(estimation): explicit array and weight domains

### DIFF
--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -54,6 +54,9 @@ fit3 = pf.feols("Y ~ X1 + X2 | f1", data = df)
 
 ### Inference Types
 
+- Weighted models now reject `ccv()` explicitly. `Feols.update()` remains a
+  coefficient-only calculation and rejects `inplace=True`, weights, IV, and
+  non-OLS models instead of mixing scales.
 - `tidy()`, `confint()`, and `summary()` gain an `inference_type` argument.
   `confint()` takes `"regular"` (pointwise, the default), `"simult"`
   (simultaneous / joint intervals), or `"savi"`; `tidy()` and `summary()` take

--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -49,7 +49,8 @@ fit3 = pf.feols("Y ~ X1 + X2 | f1", data = df)
 - Estimator internals now keep formula tables, unpremultiplied within arrays,
   and user-scale observation weights in separate typed domains.
   Square-root-weighted arrays are local solver temporaries, and linear
-  residuals remain in response units.
+  residuals remain in response units. GLM IRLS working state (working response,
+  design, and weights) is kept separate from observation weights.
 
 ### Inference Types
 

--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -46,6 +46,10 @@ fit3 = pf.feols("Y ~ X1 + X2 | f1", data = df)
   result expansion through a structural lifecycle protocol. This keeps formula
   roles stable while the later within- and weight-scale cleanup proceeds
   independently.
+- Estimator internals now keep formula tables, unpremultiplied within arrays,
+  and user-scale observation weights in separate typed domains.
+  Square-root-weighted arrays are local solver temporaries, and linear
+  residuals remain in response units.
 
 ### Inference Types
 

--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -217,6 +217,9 @@ We also removed:
   that need discarded state now raise an informative `RuntimeError` instead of
   `AttributeError`. `vcov(..., data=...)` now validates that the explicit sample
   matches the fitted rows.
+- `store_data=False` and `lean=True` now apply to retained IV first stages; lean
+  fits also discard demeaning caches, GLM working state, and quantile solver
+  outputs.
 - Fitted models and non-plotting DiD and reporting paths no longer import
   plotting dependencies eagerly. `ritest()` loads its numerical helpers on use,
   while Matplotlib, Seaborn, and Lets-Plot load only when plotting.

--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -51,6 +51,8 @@ fit3 = pf.feols("Y ~ X1 + X2 | f1", data = df)
   Square-root-weighted arrays are local solver temporaries, and linear
   residuals remain in response units. GLM IRLS working state (working response,
   design, and weights) is kept separate from observation weights.
+- Legacy estimator attributes such as `_X`, `_Y`, `_Z`, and `_weights` are now
+  read-only views over the typed state objects.
 
 ### Inference Types
 

--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -53,6 +53,8 @@ fit3 = pf.feols("Y ~ X1 + X2 | f1", data = df)
   design, and weights) is kept separate from observation weights.
 - Legacy estimator attributes such as `_X`, `_Y`, `_Z`, and `_weights` are now
   read-only views over the typed state objects.
+- Internal demeaning and covariance code now names column-order, normal-equation,
+  and frequency-replication invariants explicitly alongside their formulas.
 
 ### Inference Types
 

--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -94,8 +94,9 @@ fit.confint(inference_type="savi", mixture_precision=mixture_precision)
 
 ### GLM API and Behavior
 
-- Poisson and GLM frequency weights now work; the 0.60.0 path raised a shape
-  error. Probability weights remain unsupported.
+- Poisson and GLM frequency weights now work, including post-separation sample
+  sizes; the 0.60.0 path raised a shape error. Probability weights remain
+  unsupported.
 - Poisson offsets now accept Formulaic transformations such as
   `offset="log(exposure)"` when the expression evaluates to one numeric column.
 - `feglm()` now accepts `weights`, `weights_type`, and `offset`, and supports

--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -94,6 +94,8 @@ fit.confint(inference_type="savi", mixture_precision=mixture_precision)
 
 ### GLM API and Behavior
 
+- Poisson and GLM frequency weights now work; the 0.60.0 path raised a shape
+  error. Probability weights remain unsupported.
 - Poisson offsets now accept Formulaic transformations such as
   `offset="log(exposure)"` when the expression evaluates to one numeric column.
 - `feglm()` now accepts `weights`, `weights_type`, and `offset`, and supports

--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -212,6 +212,11 @@ We also removed:
 
 ### Bug Fixes
 
+- `lean=True` results keep the formula specification and evaluation context, so
+  `predict(newdata=...)` keeps working for models without fixed effects; methods
+  that need discarded state now raise an informative `RuntimeError` instead of
+  `AttributeError`. `vcov(..., data=...)` now validates that the explicit sample
+  matches the fitted rows.
 - Fitted models and non-plotting DiD and reporting paths no longer import
   plotting dependencies eagerly. `ritest()` loads its numerical helpers on use,
   while Matplotlib, Seaborn, and Lets-Plot load only when plotting.

--- a/docs/developer/architecture.md
+++ b/docs/developer/architecture.md
@@ -60,13 +60,11 @@ shared estimator API
   -> prepare_model_matrix
   -> estimator-specific get_fit
        -> feols / feiv
-            -> demean
-            -> to_array
-            -> drop_multicol_vars
-            -> wls_transform
-            -> solve OLS / 2SLS
+            -> construct within-scale arrays
+            -> drop collinear columns
+            -> solve OLS / 2SLS with local weight transforms
        -> fepois / feglm
-            -> IRLS with weighted demeaning and solving inside each iteration
+            -> IRLS with explicit observation and working weights
        -> quantreg
             -> Frisch-Newton solve (absorbed fixed effects are unsupported)
   -> vcov
@@ -77,12 +75,13 @@ shared estimator API
 `FixestMulti` is a container for fitted results. Numerical behavior belongs in
 the individual models and shared primitives, not in the container.
 
-## Current estimator-state lifecycle
+## Historical estimator-state lifecycle (pre-refactor)
 
-The fitted-model classes currently use themselves as both a work area and a
-result object. Several private attributes therefore change representation and
-numerical scale while a model is fitted. This section records that status quo;
-it is not a contract for new code.
+Before the immutable-state refactor, fitted-model classes used themselves as
+both a work area and a result object. Several private attributes therefore
+changed representation and numerical scale while a model was fitted. This
+section preserves that baseline as migration history; it is not the current
+contract for new code.
 
 For linear models, the transformations are:
 
@@ -192,10 +191,9 @@ constructors only assemble configuration and child objects; for example,
 `QuantregMulti` prepares its children in `prepare_model_matrix`, not during
 construction.
 
-This is the representation foundation, not the final within/weight cleanup.
-The compatibility fields documented above still move through their established
-DataFrame, within-array, and solver-array states until the numerical primitives
-and inference consumers move to explicit within-scale inputs.
+This established the representation foundation. The within/weight cleanup
+described below completes that layer by moving numerical primitives and
+inference consumers to explicit within-scale inputs.
 
 ## Estimation-state vocabulary
 
@@ -217,6 +215,71 @@ arrays should not change type or numerical domain, and solver scratch should
 not replace canonical within data. A fitted result may still expose explicitly
 in-place post-estimation operations, but those operations must not repurpose
 estimation fields.
+
+## Implemented array and weight domains
+
+The shared linear and GLM paths now implement the vocabulary above with frozen,
+slotted state values:
+
+| State | Persisted contract |
+|---|---|
+| `ModelMatrix` | Formula-materialized pandas tables remain on formula scale and keep dependent, independent, fixed-effect, IV, weight, and offset roles separate. |
+| `ObservationWeights` | Canonical user-scale weights and their `aweights` or `fweights` semantics. `values=None` is the allocation-free unweighted path. |
+| `WithinLinearData` | Unpremultiplied within-scale arrays, with response, design, instruments, and endogenous variables in named roles. |
+| `GlmWorkingState` | Final within-scale working response and design, IRLS working weights, predictors, means, and response- and working-residual domains. |
+| `DemeanedData` | Array-native cache entries whose ordered column names are metadata rather than DataFrame conversions around each reuse. |
+
+Analytic weights keep the retained row count as the effective sample size;
+frequency weights use the sum of their user-scale values. Probability weights
+(`pweights`) remain unsupported. Fixed-effect projection may use observation or
+IRLS weights, but the returned arrays remain within scale. OLS, IV, and IRLS
+fit primitives create square-root-weighted design and response arrays only as
+local solver temporaries. They persist response-unit residuals and weighted
+scores or cross-products, not solver-scale copies of canonical data.
+Singleton fixed-effect detection counts physical rows even under frequency
+weights, so an aggregate row alone in its level is dropped although its literal
+expansion would not be; this deliberate deviation is documented in
+`tests/test_wls_types.py`.
+
+GLMs keep two weight concepts deliberately separate. `ObservationWeights`
+never changes after formula preparation, while each IRLS iteration computes
+working weights and the final values live in `GlmWorkingState`. Response
+residuals and working residuals likewise have separate fields.
+
+The compatibility aliases are still available, but they are read-only
+properties over the typed state rather than cross-type workspaces: the state
+objects are the single writable representation, and assigning or deleting an
+alias raises. For linear and IV fits, `_Y`, `_X`, and `_Z` view within-scale
+arrays; for GLMs they view the final within-scale working response and design.
+`_weights` always means observation weights, never square-root solver weights
+or GLM working weights, and an unweighted fit materializes its ones column on
+access instead of keeping one alive for the lifetime of the result. New code
+should consume the typed state values rather than infer semantics from these
+aliases.
+
+`ccv()` explicitly rejects weighted models. `update()` can compute and return
+coefficient-only Sherman-Morrison updates for unweighted, non-IV OLS without
+fixed effects, but rejects `inplace=True`: design rows alone cannot reconstruct
+the complete formula, prediction, inference, and performance state of a fitted
+result.
+
+Storage policy follows the full result graph. Retained IV first stages honor
+`store_data=False`, and lean results discard within state, GLM working state,
+demeaning caches, quantile solver outputs, and large first-stage arrays. Lean
+results do keep the formula specification and evaluation context, so
+`predict(newdata=...)` still works for models without fixed effects. Array-only
+covariance updates remain available after `store_data=False`; cluster and HAC
+updates require the estimation sample through the documented `vcov(data=...)`
+argument. Explicit covariance data must already be filtered to the fitted row
+sample and retain its estimation order; a row-count check rejects misaligned
+inputs before covariance dispatch. Lean results reject post-fit covariance
+updates because their numerical arrays have been discarded. Every other method
+that needs discarded state raises an informative error naming the storage
+option and its remedy.
+
+Keeping canonical arrays unpremultiplied favors readability without moving
+weight work out of the numerical hot path: each solver still performs the same
+vectorized square-root transform locally.
 
 ## Repository map and extension seams
 

--- a/docs/developer/architecture.md
+++ b/docs/developer/architecture.md
@@ -219,7 +219,8 @@ estimation fields.
 ## Implemented array and weight domains
 
 The shared linear and GLM paths now implement the vocabulary above with frozen,
-slotted state values:
+slotted state values. Frozen state prevents field rebinding, but contained NumPy
+arrays remain mutable unless they are explicitly marked read-only:
 
 | State | Persisted contract |
 |---|---|
@@ -271,11 +272,11 @@ results do keep the formula specification and evaluation context, so
 covariance updates remain available after `store_data=False`; cluster and HAC
 updates require the estimation sample through the documented `vcov(data=...)`
 argument. Explicit covariance data must already be filtered to the fitted row
-sample and retain its estimation order; a row-count check rejects misaligned
-inputs before covariance dispatch. Lean results reject post-fit covariance
-updates because their numerical arrays have been discarded. Every other method
-that needs discarded state raises an informative error naming the storage
-option and its remedy.
+sample and retain its estimation order. A row-count check rejects length
+mismatches but cannot establish row identity or ordering. Lean results reject
+post-fit covariance updates because their numerical arrays have been discarded.
+Every other method that needs discarded state raises an informative error naming
+the storage option and its remedy.
 
 Keeping canonical arrays unpremultiplied favors readability without moving
 weight work out of the numerical hot path: each solver still performs the same

--- a/pyfixest/estimation/formula/model_matrix.py
+++ b/pyfixest/estimation/formula/model_matrix.py
@@ -183,11 +183,11 @@ class ModelMatrix:
         warnings.warn(f"{n_dropped} {reason} dropped from the model.")
 
     def without_rows(self, rows: list[int]) -> ModelMatrix:
-        """Return a copy without ``rows``; they are recorded in ``na_index``.
+        """Return a shallow copy without ``rows``.
 
-        Estimator-level filters such as GLM separation run after construction and
-        call this instead of mutating the retained instance, which is left
-        unchanged.
+        The copied object receives a new filtered data frame and ``na_index``;
+        its unchanged formula metadata remains shared with the original object.
+        An empty ``rows`` sequence returns this instance unchanged.
         """
         if not rows:
             return self

--- a/pyfixest/estimation/internals/demean_.py
+++ b/pyfixest/estimation/internals/demean_.py
@@ -1,8 +1,25 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+
 import numpy as np
-import pandas as pd
+from numpy.typing import NDArray
 
 from pyfixest.core.demean import Preconditioner
 from pyfixest.demeaners import AnyDemeaner
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class DemeanedData:
+    """Array-native cache entry for named, demeaned columns.
+
+    ``columns`` records the insertion order of the columns in ``values``.
+    Cached arrays are treated as read-only after publication.
+    """
+
+    values: NDArray[np.float64]
+    columns: tuple[str, ...]
 
 
 class DemeanCache:
@@ -10,7 +27,7 @@ class DemeanCache:
 
     `Compute once, never forget`:
 
-    - `lookup_demeaned_data`: already-demeaned columns from previous fits.
+    - `lookup_demeaned_data`: already-demeaned named arrays from previous fits.
     - `lookup_preconditioner`: the preconditioner from the first fit on a
        data set / na index combination.
 
@@ -23,13 +40,13 @@ class DemeanCache:
 
     def __init__(
         self,
-        lookup_demeaned_data: dict[frozenset[int], pd.DataFrame] | None = None,
+        lookup_demeaned_data: dict[frozenset[int], DemeanedData] | None = None,
         lookup_preconditioner: dict[frozenset[int], Preconditioner] | None = None,
     ) -> None:
-        self.lookup_demeaned_data: dict[frozenset[int], pd.DataFrame] = (
+        self.lookup_demeaned_data = (
             {} if lookup_demeaned_data is None else lookup_demeaned_data
         )
-        self.lookup_preconditioner: dict[frozenset[int], Preconditioner] = (
+        self.lookup_preconditioner = (
             {} if lookup_preconditioner is None else lookup_preconditioner
         )
 
@@ -81,62 +98,109 @@ class DemeanCache:
 
     def demean_yx(
         self,
-        Y: pd.DataFrame,
-        X: pd.DataFrame,
-        fe: pd.DataFrame | None,
-        weights: np.ndarray | None,
+        Y: NDArray[np.float64],
+        X: NDArray[np.float64],
+        *,
+        y_names: Sequence[str],
+        x_names: Sequence[str],
+        fe: np.ndarray | None,
+        weights: NDArray[np.float64] | None,
         na_index: frozenset[int],
         demeaner: AnyDemeaner,
-    ) -> tuple[pd.DataFrame, pd.DataFrame, Preconditioner | None]:
-        """Demean a regression model: check cache, demean what's missing, update cache.
+    ) -> tuple[
+        NDArray[np.float64],
+        NDArray[np.float64],
+        Preconditioner | None,
+    ]:
+        """Demean response and design arrays and cache missing named columns.
 
-        Prior to demeaning, checks whether some of the variables have already
-        been demeaned and reuses values from `self.lookup_demeaned_data` if
-        possible. If the model has no fixed effects, the data is returned
-        undemeaned.
+        The cache stays array-native. Column names are carried separately so
+        multiple-estimation fits can reuse matching columns without converting
+        solver arrays back into DataFrames. New columns are demeaned and appended
+        in their requested order; cache hits never reorder or discard earlier
+        columns.
+
+        Parameters
+        ----------
+        Y : NDArray[np.float64]
+            Response array, shape ``(n_rows, n_responses)``.
+        X : NDArray[np.float64]
+            Design array, shape ``(n_rows, n_regressors)``.
+        y_names : Sequence[str]
+            Ordered response names corresponding to the columns of ``Y``.
+        x_names : Sequence[str]
+            Ordered regressor names corresponding to the columns of ``X``.
+        fe : np.ndarray or None
+            Encoded fixed-effect identifiers, or ``None`` for no fixed effects.
+        weights : NDArray[np.float64] or None
+            Observation weights passed to the within transformation.
+        na_index : frozenset[int]
+            Row-removal identity used to share cached data between model fits.
+        demeaner : AnyDemeaner
+            Configured within-transformation strategy.
 
         Returns
         -------
-        tuple[pd.DataFrame, pd.DataFrame, Preconditioner | None]
-            The demeaned `Y`, the demeaned `X`, and the within
-            preconditioner used during the solve (`None` for non-within
-            backends, `preconditioner='off'`, the single-FE MAP fallback,
-            or when no demeaning happened).
+        tuple[NDArray[np.float64], NDArray[np.float64], Preconditioner or None]
+            Demeaned response and design arrays, in their requested column order,
+            plus the preconditioner used when new columns were transformed.
         """
-        used: Preconditioner | None = None
-        YX = pd.concat([Y, X], axis=1)
-        yx_names = YX.columns
-        YX_array = YX.to_numpy()
-        if YX_array.dtype != np.dtype("float64"):
-            YX_array = YX_array.astype(np.float64)
-
+        Y_array = np.asarray(Y, dtype=np.float64)
+        X_array = np.asarray(X, dtype=np.float64)
         if fe is None:
-            YX_demeaned = pd.DataFrame(YX_array, columns=yx_names)
-            return YX_demeaned[Y.columns], YX_demeaned[X.columns], None
+            return Y_array, X_array, None
 
-        fe_array = fe.to_numpy()
-        cached_demeaned = self.lookup_demeaned_data.get(na_index)
-        if cached_demeaned is None:
-            arr, used = self._run_or_raise(
-                YX_array, fe_array, weights, na_index, demeaner
+        y_names_tuple = tuple(y_names)
+        x_names_tuple = tuple(x_names)
+        requested_names = y_names_tuple + x_names_tuple
+        YX_array = np.concatenate((Y_array, X_array), axis=1)
+
+        cached = self.lookup_demeaned_data.get(na_index)
+        used: Preconditioner | None = None
+        if cached is None:
+            requested_values, used = self._run_or_raise(
+                YX_array, fe, weights, na_index, demeaner
             )
-            YX_demeaned = pd.DataFrame(arr, columns=yx_names)
+            # Cached buffers are shared across fits, so publish them read-only.
+            requested_values.setflags(write=False)
+            cached = DemeanedData(
+                values=requested_values,
+                columns=requested_names,
+            )
+            self.lookup_demeaned_data[na_index] = cached
         else:
-            # demean only the not-yet-demeaned columns
-            new_names = list(set(yx_names) - set(cached_demeaned.columns))
-            if new_names:
-                yx_names_list = list(yx_names)
-                new_index = [yx_names_list.index(name) for name in new_names]
-                arr, used = self._run_or_raise(
-                    YX_array[:, new_index], fe_array, weights, na_index, demeaner
+            cached_names = frozenset(cached.columns)
+            new_positions = tuple(
+                index
+                for index, name in enumerate(requested_names)
+                if name not in cached_names
+            )
+            if new_positions:
+                new_values, used = self._run_or_raise(
+                    YX_array[:, new_positions], fe, weights, na_index, demeaner
                 )
-                YX_demeaned = pd.DataFrame(
-                    np.concatenate([cached_demeaned, arr], axis=1),
-                    columns=list(cached_demeaned.columns) + new_names,
+                cached_values = np.concatenate((cached.values, new_values), axis=1)
+                cached_values.setflags(write=False)
+                cached = DemeanedData(
+                    values=cached_values,
+                    columns=cached.columns
+                    + tuple(requested_names[index] for index in new_positions),
                 )
-            else:
-                # all variables already demeaned
-                YX_demeaned = cached_demeaned[yx_names]
+                self.lookup_demeaned_data[na_index] = cached
+            requested_values = self._select_columns(cached, requested_names)
 
-        self.lookup_demeaned_data[na_index] = YX_demeaned
-        return YX_demeaned[Y.columns], YX_demeaned[X.columns], used
+        n_y = len(y_names_tuple)
+        return requested_values[:, :n_y], requested_values[:, n_y:], used
+
+    @staticmethod
+    def _select_columns(
+        cached: DemeanedData,
+        requested_names: tuple[str, ...],
+    ) -> NDArray[np.float64]:
+        positions_by_name = {
+            name: position for position, name in enumerate(cached.columns)
+        }
+        positions = tuple(positions_by_name[name] for name in requested_names)
+        if positions == tuple(range(len(positions))):
+            return cached.values[:, : len(positions)]
+        return cached.values[:, positions]

--- a/pyfixest/estimation/internals/demean_.py
+++ b/pyfixest/estimation/internals/demean_.py
@@ -12,10 +12,12 @@ from pyfixest.demeaners import AnyDemeaner
 
 @dataclass(frozen=True, slots=True, kw_only=True)
 class DemeanedData:
-    """Array-native cache entry for named, demeaned columns.
+    """Cache entry for named, demeaned columns.
 
     ``columns`` records the insertion order of the columns in ``values``.
-    Cached arrays are treated as read-only after publication.
+    ``values`` is marked read-only before publication because cache entries are
+    shared across fitted models. The frozen dataclass prevents field rebinding;
+    the array flag prevents element assignment through ordinary NumPy APIs.
     """
 
     values: NDArray[np.float64]
@@ -114,11 +116,9 @@ class DemeanCache:
     ]:
         """Demean response and design arrays and cache missing named columns.
 
-        The cache stays array-native. Column names are carried separately so
-        multiple-estimation fits can reuse matching columns without converting
-        solver arrays back into DataFrames. New columns are demeaned and appended
-        in their requested order; cache hits never reorder or discard earlier
-        columns.
+        New columns are appended to the cache in their requested order. Returned
+        arrays always follow ``y_names`` and ``x_names``, independently of the
+        cache's insertion order.
 
         Parameters
         ----------
@@ -153,15 +153,14 @@ class DemeanCache:
         y_names_tuple = tuple(y_names)
         x_names_tuple = tuple(x_names)
         requested_names = y_names_tuple + x_names_tuple
-        YX_array = np.concatenate((Y_array, X_array), axis=1)
 
         cached = self.lookup_demeaned_data.get(na_index)
         used: Preconditioner | None = None
         if cached is None:
+            requested_data = np.concatenate((Y_array, X_array), axis=1)
             requested_values, used = self._run_or_raise(
-                YX_array, fe, weights, na_index, demeaner
+                requested_data, fe, weights, na_index, demeaner
             )
-            # Cached buffers are shared across fits, so publish them read-only.
             requested_values.setflags(write=False)
             cached = DemeanedData(
                 values=requested_values,
@@ -169,28 +168,34 @@ class DemeanCache:
             )
             self.lookup_demeaned_data[na_index] = cached
         else:
-            cached_names = frozenset(cached.columns)
+            cached_column_names = cached.columns
+            cached_name_set = frozenset(cached_column_names)
             new_positions = tuple(
                 index
                 for index, name in enumerate(requested_names)
-                if name not in cached_names
+                if name not in cached_name_set
             )
             if new_positions:
+                requested_data = np.concatenate((Y_array, X_array), axis=1)
                 new_values, used = self._run_or_raise(
-                    YX_array[:, new_positions], fe, weights, na_index, demeaner
+                    requested_data[:, new_positions], fe, weights, na_index, demeaner
+                )
+                new_column_names = tuple(
+                    requested_names[index] for index in new_positions
                 )
                 cached_values = np.concatenate((cached.values, new_values), axis=1)
                 cached_values.setflags(write=False)
                 cached = DemeanedData(
                     values=cached_values,
-                    columns=cached.columns
-                    + tuple(requested_names[index] for index in new_positions),
+                    columns=cached_column_names + new_column_names,
                 )
                 self.lookup_demeaned_data[na_index] = cached
             requested_values = self._select_columns(cached, requested_names)
 
-        n_y = len(y_names_tuple)
-        return requested_values[:, :n_y], requested_values[:, n_y:], used
+        n_response_columns = len(y_names_tuple)
+        response_demeaned = requested_values[:, :n_response_columns]
+        design_demeaned = requested_values[:, n_response_columns:]
+        return response_demeaned, design_demeaned, used
 
     @staticmethod
     def _select_columns(
@@ -201,6 +206,7 @@ class DemeanCache:
             name: position for position, name in enumerate(cached.columns)
         }
         positions = tuple(positions_by_name[name] for name in requested_names)
-        if positions == tuple(range(len(positions))):
+        selects_cached_prefix = positions == tuple(range(len(positions)))
+        if selects_cached_prefix:
             return cached.values[:, : len(positions)]
         return cached.values[:, positions]

--- a/pyfixest/estimation/internals/fit_.py
+++ b/pyfixest/estimation/internals/fit_.py
@@ -17,15 +17,15 @@ class OlsFit:
     beta : np.ndarray
         Coefficient estimates, shape (k,).
     residuals : np.ndarray
-        Residuals Y - X @ beta, shape (N,).
+        Response-scale residuals Y - X @ beta, shape (N,).
     scores : np.ndarray
-        Score matrix X * residuals, shape (N, k).
+        Weighted score matrix W X * residuals, shape (N, k).
     hessian : np.ndarray
-        Hessian X'X, shape (k, k).
+        Weighted Hessian X' W X, shape (k, k).
     tZX : np.ndarray
-        Z'X (= X'X for OLS), shape (k, k).
+        Z'X (= X' W X for OLS), shape (k, k).
     tZy : np.ndarray
-        Z'Y (= X'Y for OLS), shape (k, 1).
+        Z'Y (= X' W Y for OLS), shape (k, 1).
     """
 
     beta: np.ndarray
@@ -38,26 +38,26 @@ class OlsFit:
 
 @dataclass(frozen=True, slots=True)
 class IvFit:
-    """Result of a 2SLS fit.
+    """Result of a (weighted) 2SLS fit.
 
     Attributes
     ----------
     beta : np.ndarray
         Coefficient estimates, shape (k,).
     residuals : np.ndarray
-        Second-stage residuals Y - X @ beta, shape (N,).
+        Response-scale second-stage residuals Y - X @ beta, shape (N,).
     scores : np.ndarray
-        Score matrix Z * residuals, shape (N, k_z).
+        Weighted score matrix W Z * residuals, shape (N, k_z).
     hessian : np.ndarray
-        Z'Z, shape (k_z, k_z).
+        Weighted instrument cross-product Z' W Z, shape (k_z, k_z).
     tZX : np.ndarray
-        Z'X, shape (k_z, k).
+        Weighted cross-product Z' W X, shape (k_z, k).
     tXZ : np.ndarray
-        X'Z, shape (k, k_z).
+        Weighted cross-product X' W Z, shape (k, k_z).
     tZy : np.ndarray
-        Z'Y, shape (k_z, 1).
+        Weighted cross-product Z' W Y, shape (k_z, 1).
     tZZinv : np.ndarray
-        (Z'Z)^{-1}, shape (k_z, k_z).
+        (Z' W Z)^{-1}, shape (k_z, k_z).
     """
 
     beta: np.ndarray
@@ -73,24 +73,43 @@ class IvFit:
 def fit_ols(
     X: np.ndarray,
     Y: np.ndarray,
+    *,
+    weights: np.ndarray | None = None,
     solver: SolverOptions = "np.linalg.solve",
 ) -> OlsFit:
-    """Fit a least-squares model on prepared arrays.
+    """Fit OLS/WLS while keeping inputs and residuals in response scale.
 
     Parameters
     ----------
     X : np.ndarray
-        Design matrix, shape (N, k). Demeaned and WLS-transformed.
+        Design matrix, shape (N, k). Demeaned but not WLS-transformed.
     Y : np.ndarray
-        Dependent variable, shape (N, 1). Demeaned and WLS-transformed.
+        Dependent variable, shape (N, 1). Demeaned but not WLS-transformed.
+    weights : np.ndarray or None
+        Non-negative observation weights, shape (N,) or (N, 1). ``None``
+        selects the unweighted path without creating unit weights or transformed
+        copies. Otherwise, the square-root transform is local to this function.
     solver : SolverOptions
         Solver passed through to ``solve_ols``.
     """
-    tZX = X.T @ X
-    tZy = X.T @ Y
+    if weights is None:
+        X_solver = X
+        Y_solver = Y
+        weight_values = None
+    else:
+        weight_values = weights.reshape(-1)
+        sqrt_weights = np.sqrt(weight_values)[:, None]
+        X_solver = X * sqrt_weights
+        Y_solver = Y * sqrt_weights
+
+    tZX = X_solver.T @ X_solver
+    tZy = X_solver.T @ Y_solver
     beta = solve_ols(tZX, tZy, solver)
     residuals = Y.flatten() - (X @ beta).flatten()
-    scores = X * residuals[:, None]
+    if weight_values is None:
+        scores = X * residuals[:, None]
+    else:
+        scores = X * (weight_values * residuals)[:, None]
     hessian = tZX.copy()
     return OlsFit(
         beta=beta,
@@ -106,26 +125,44 @@ def fit_iv(
     X: np.ndarray,
     Z: np.ndarray,
     Y: np.ndarray,
+    *,
+    weights: np.ndarray | None = None,
     solver: SolverOptions = "np.linalg.solve",
 ) -> IvFit:
-    """Fit a 2SLS model on prepared arrays.
+    """Fit 2SLS while keeping inputs and residuals in response scale.
 
     Parameters
     ----------
     X : np.ndarray
         Design matrix (incl. endogenous regressors), shape (N, k).
-        Demeaned and WLS-transformed.
+        Demeaned but not WLS-transformed.
     Z : np.ndarray
-        Instrument matrix, shape (N, k_z). Demeaned and WLS-transformed.
+        Instrument matrix, shape (N, k_z). Demeaned but not WLS-transformed.
     Y : np.ndarray
-        Dependent variable, shape (N, 1). Demeaned and WLS-transformed.
+        Dependent variable, shape (N, 1). Demeaned but not WLS-transformed.
+    weights : np.ndarray or None
+        Non-negative observation weights, shape (N,) or (N, 1). ``None``
+        selects the unweighted path without creating unit weights or transformed
+        copies. Otherwise, the square-root transform is local to this function.
     solver : SolverOptions
         Solver passed through to ``solve_ols``.
     """
-    tZX = Z.T @ X
-    tXZ = X.T @ Z
-    tZy = Z.T @ Y
-    tZZ = Z.T @ Z
+    if weights is None:
+        X_solver = X
+        Z_solver = Z
+        Y_solver = Y
+        weight_values = None
+    else:
+        weight_values = weights.reshape(-1)
+        sqrt_weights = np.sqrt(weight_values)[:, None]
+        X_solver = X * sqrt_weights
+        Z_solver = Z * sqrt_weights
+        Y_solver = Y * sqrt_weights
+
+    tZX = Z_solver.T @ X_solver
+    tXZ = X_solver.T @ Z_solver
+    tZy = Z_solver.T @ Y_solver
+    tZZ = Z_solver.T @ Z_solver
     tZZinv = np.linalg.inv(tZZ)
 
     H = tXZ @ tZZinv
@@ -134,7 +171,10 @@ def fit_iv(
     beta = solve_ols(A, B, solver)
 
     residuals = Y.flatten() - (X @ beta).flatten()
-    scores = Z * residuals[:, None]
+    if weight_values is None:
+        scores = Z * residuals[:, None]
+    else:
+        scores = Z * (weight_values * residuals)[:, None]
     hessian = tZZ
 
     return IvFit(

--- a/pyfixest/estimation/internals/fit_.py
+++ b/pyfixest/estimation/internals/fit_.py
@@ -109,6 +109,9 @@ def fit_ols(
     if weight_values is None:
         scores = X * residuals[:, None]
     else:
+        # The WLS estimating equation contributes s_i = a_i x_i u_i.
+        # The full weight appears here, not sqrt(a_i): both solver factors
+        # participate when differentiating the weighted squared-error loss.
         scores = X * (weight_values * residuals)[:, None]
     hessian = tZX.copy()
     return OlsFit(
@@ -137,7 +140,8 @@ def fit_iv(
         Design matrix (incl. endogenous regressors), shape (N, k).
         Demeaned but not WLS-transformed.
     Z : np.ndarray
-        Instrument matrix, shape (N, k_z). Demeaned but not WLS-transformed.
+        Full instrument matrix, including exogenous regressors that instrument
+        themselves, shape (N, k_z). Demeaned but not WLS-transformed.
     Y : np.ndarray
         Dependent variable, shape (N, 1). Demeaned but not WLS-transformed.
     weights : np.ndarray or None
@@ -174,6 +178,7 @@ def fit_iv(
     if weight_values is None:
         scores = Z * residuals[:, None]
     else:
+        # The weighted IV moment contribution is a_i z_i u_i.
         scores = Z * (weight_values * residuals)[:, None]
     hessian = tZZ
 

--- a/pyfixest/estimation/internals/fit_glm_.py
+++ b/pyfixest/estimation/internals/fit_glm_.py
@@ -9,6 +9,7 @@ from pyfixest.errors import NonConvergenceError
 from pyfixest.estimation.internals.collinearity import drop_multicollinear_variables
 from pyfixest.estimation.internals.families import GlmFamily
 from pyfixest.estimation.internals.literals import SolverOptions
+from pyfixest.estimation.internals.model_state import GlmWorkingState
 from pyfixest.estimation.internals.solvers import solve_ols
 
 DemeanFn = Callable[
@@ -25,18 +26,9 @@ class GlmFit:
     ----------
     beta : np.ndarray
         Coefficient estimates, shape (k,).
-    eta : np.ndarray
-        Final linear predictor (link scale), shape (N,).
-    mu : np.ndarray
-        Final fitted mean (response scale), shape (N,).
-    W : np.ndarray
-        Final IRLS weights, shape (N,).
-    sqrt_W : np.ndarray
-        Square root of W, shape (N,).
-    z_tilde : np.ndarray
-        Final demeaned working response, shape (N,).
-    X_tilde : np.ndarray
-        Final demeaned design matrix, shape (N, k).
+    working_state : GlmWorkingState
+        Final within-scale IRLS inputs, weights, fitted values, and residuals.
+        Square-root-weighted solver arrays are deliberately not retained.
     X : np.ndarray
         The (un-demeaned) design matrix with collinear columns dropped, shape (N, k).
     deviance : float
@@ -55,12 +47,7 @@ class GlmFit:
     """
 
     beta: np.ndarray
-    eta: np.ndarray
-    mu: np.ndarray
-    W: np.ndarray
-    sqrt_W: np.ndarray
-    z_tilde: np.ndarray
-    X_tilde: np.ndarray
+    working_state: GlmWorkingState
     X: np.ndarray
     deviance: float
     converged: bool
@@ -178,7 +165,7 @@ def fit_glm_irls(
     Y_flat = Y.flatten()
     N = Y_flat.shape[0]
     offset_flat = offset.flatten() if offset is not None else np.zeros(N)
-    weights_flat = weights.flatten() if weights is not None else np.ones(N)
+    observation_weights_flat = weights.flatten() if weights is not None else np.ones(N)
 
     mu = family.mu_start(Y, weights)
     eta = family.link(mu)
@@ -200,8 +187,7 @@ def fit_glm_irls(
     beta_final: np.ndarray
     z_tilde_final: np.ndarray
     X_tilde_final: np.ndarray
-    W_final: np.ndarray
-    sqrt_W_final: np.ndarray
+    working_weights_final: np.ndarray
     r = 0
 
     for r in range(maxiter):
@@ -224,8 +210,8 @@ def fit_glm_irls(
                 inner_tol = inner_tol / 10
 
         gprime = family.gprime(mu)
-        W = weights_flat / (gprime**2 * family.variance(mu))
-        sqrt_W = np.sqrt(W)
+        working_weights = observation_weights_flat / (gprime**2 * family.variance(mu))
+        sqrt_working_weights = np.sqrt(working_weights)
 
         z = (eta - offset_flat) + (Y_flat - mu) * gprime
 
@@ -238,7 +224,12 @@ def fit_glm_irls(
             z_input = z
             X_input = X_eff
 
-        z_tilde, X_tilde = demean(z_input, X_input, W.flatten(), inner_tol)
+        z_tilde, X_tilde = demean(
+            z_input,
+            X_input,
+            working_weights.flatten(),
+            inner_tol,
+        )
 
         if r == 0:
             X_tilde, coefnames, collin_vars, collin_index = (
@@ -247,10 +238,14 @@ def fit_glm_irls(
             if collin_index:
                 X_eff = X_eff[:, ~np.array(collin_index)]
 
-        WX = sqrt_W.flatten()[:, None] * X_tilde
-        WZ = sqrt_W.flatten() * z_tilde
+        design_solver = sqrt_working_weights.flatten()[:, None] * X_tilde
+        response_solver = sqrt_working_weights.flatten() * z_tilde
 
-        beta = solve_ols(WX.T @ WX, WX.T @ WZ, solver)
+        beta = solve_ols(
+            design_solver.T @ design_solver,
+            design_solver.T @ response_solver,
+            solver,
+        )
 
         e_new = z_tilde - X_tilde @ beta
         eta_new = (z - e_new) + offset_flat
@@ -285,8 +280,7 @@ def fit_glm_irls(
         beta_final = beta
         z_tilde_final = z_tilde
         X_tilde_final = X_tilde
-        W_final = W
-        sqrt_W_final = sqrt_W
+        working_weights_final = working_weights
 
     if not converged:
         if not step_halved_prev:
@@ -299,14 +293,20 @@ def fit_glm_irls(
         if not converged:
             _raise_non_convergence(maxiter)
 
+    working_residuals = z_tilde_final - X_tilde_final @ beta_final
+    working_state = GlmWorkingState(
+        working_response_within=z_tilde_final,
+        design_within=X_tilde_final,
+        working_weights=working_weights_final.flatten(),
+        eta=eta.flatten(),
+        mu=mu.flatten(),
+        response_residuals=Y_flat - mu.flatten(),
+        working_residuals=working_residuals.flatten(),
+    )
+
     return GlmFit(
         beta=beta_final,
-        eta=eta,
-        mu=mu,
-        W=W_final,
-        sqrt_W=sqrt_W_final,
-        z_tilde=z_tilde_final,
-        X_tilde=X_tilde_final,
+        working_state=working_state,
         X=X_eff,
         deviance=deviance,
         converged=converged,

--- a/pyfixest/estimation/internals/literals.py
+++ b/pyfixest/estimation/internals/literals.py
@@ -2,6 +2,8 @@ from typing import Any, Literal, get_args
 
 PredictionType = Literal["response", "link"]
 VcovTypeOptions = Literal["iid", "hetero", "HC1", "HC2", "HC3", "nid"]
+HeteroVcovTypeOptions = Literal["hetero", "HC1", "HC2", "HC3"]
+HacVcovTypeOptions = Literal["NW", "DK"]
 WeightsTypeOptions = Literal["aweights", "fweights"]
 FixedRmOptions = Literal["singleton", "none"]
 FamilyOptions = Literal["logit", "probit", "gaussian", "poisson"]

--- a/pyfixest/estimation/internals/model_state.py
+++ b/pyfixest/estimation/internals/model_state.py
@@ -110,3 +110,20 @@ class WithinLinearData:
     design: NDArray[np.float64]
     instruments: NDArray[np.float64] | None = None
     endogenous: NDArray[np.float64] | None = None
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class GlmWorkingState:
+    """Final GLM IRLS state in within scale.
+
+    ``working_weights`` are the final IRLS weights themselves.  Square-root
+    weighted arrays are solver-local temporaries and deliberately absent.
+    """
+
+    working_response_within: NDArray[np.float64]
+    design_within: NDArray[np.float64]
+    working_weights: NDArray[np.float64]
+    eta: NDArray[np.float64]
+    mu: NDArray[np.float64]
+    response_residuals: NDArray[np.float64]
+    working_residuals: NDArray[np.float64]

--- a/pyfixest/estimation/internals/model_state.py
+++ b/pyfixest/estimation/internals/model_state.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+from numpy.typing import NDArray
+
+from pyfixest.estimation.internals.literals import WeightsTypeOptions
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class ObservationWeights:
+    """Canonical observation weights retained by a fitted model.
+
+    ``values`` are always the user-scale weights, never their square roots or
+    an estimator-specific working weight.  ``None`` is the explicit unweighted
+    fast path: callers must not allocate a vector of ones merely to represent
+    an unweighted fit.
+
+    Parameters
+    ----------
+    values : NDArray[np.float64] or None
+        Flat, user-scale observation weights. ``None`` for an unweighted fit.
+    kind : {"aweights", "fweights"} or None
+        Weight semantics. ``None`` for an unweighted fit.
+    n_rows : int
+        Number of physical rows used for estimation.
+    n_effective : int or float
+        Effective observation count: ``n_rows`` for unweighted fits and
+        analytic weights, and ``sum(values)`` for frequency weights.
+    """
+
+    values: NDArray[np.float64] | None
+    kind: WeightsTypeOptions | None
+    n_rows: int
+    n_effective: int | float
+
+    def __post_init__(self) -> None:
+        if self.n_rows < 0:
+            raise ValueError("n_rows must be non-negative.")
+
+        if self.values is None:
+            if self.kind is not None:
+                raise ValueError("Unweighted observations cannot have a weight kind.")
+            if self.n_effective != self.n_rows:
+                raise ValueError(
+                    "Unweighted observations must have n_effective equal to n_rows."
+                )
+            return
+
+        if self.kind is None:
+            raise ValueError("Weighted observations must declare a weight kind.")
+        if self.kind not in ("aweights", "fweights"):
+            raise ValueError("Weight kind must be 'aweights' or 'fweights'.")
+        if self.values.ndim != 1:
+            raise ValueError("Observation weight values must be a flat array.")
+        if len(self.values) != self.n_rows:
+            raise ValueError("Observation weights must contain one value per row.")
+
+        expected_n = (
+            self.n_rows if self.kind == "aweights" else float(np.sum(self.values))
+        )
+        if self.n_effective != expected_n:
+            raise ValueError("n_effective must match the observation-weight semantics.")
+
+    @classmethod
+    def unweighted(cls, *, n_rows: int) -> ObservationWeights:
+        """Construct the allocation-free representation of an unweighted fit."""
+        return cls(
+            values=None,
+            kind=None,
+            n_rows=n_rows,
+            n_effective=n_rows,
+        )
+
+    @classmethod
+    def from_values(
+        cls,
+        values: NDArray[np.float64],
+        *,
+        kind: WeightsTypeOptions,
+    ) -> ObservationWeights:
+        """Construct canonical weighted state from user-scale values."""
+        canonical_values = np.asarray(values, dtype=np.float64).reshape(-1)
+        n_rows = len(canonical_values)
+        n_effective = n_rows if kind == "aweights" else float(np.sum(canonical_values))
+        return cls(
+            values=canonical_values,
+            kind=kind,
+            n_rows=n_rows,
+            n_effective=n_effective,
+        )
+
+    @property
+    def is_weighted(self) -> bool:
+        """Whether this state contains user-supplied observation weights."""
+        return self.values is not None
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class WithinLinearData:
+    """Linear-model arrays after within transformation, in original units.
+
+    These arrays have not been multiplied by square-root observation weights.
+    Optional IV roles are kept separate so their econometric meaning remains
+    visible throughout the estimator lifecycle.
+    """
+
+    response: NDArray[np.float64]
+    design: NDArray[np.float64]
+    instruments: NDArray[np.float64] | None = None
+    endogenous: NDArray[np.float64] | None = None

--- a/pyfixest/estimation/internals/model_state.py
+++ b/pyfixest/estimation/internals/model_state.py
@@ -76,16 +76,18 @@ class ObservationWeights:
     @classmethod
     def from_values(
         cls,
-        values: NDArray[np.float64],
+        weights: NDArray[np.float64],
         *,
         kind: WeightsTypeOptions,
     ) -> ObservationWeights:
-        """Construct canonical weighted state from user-scale values."""
-        canonical_values = np.asarray(values, dtype=np.float64).reshape(-1)
-        n_rows = len(canonical_values)
-        n_effective = n_rows if kind == "aweights" else float(np.sum(canonical_values))
+        """Construct canonical weighted state from user-scale weights."""
+        observation_weights = np.asarray(weights, dtype=np.float64).reshape(-1)
+        n_rows = len(observation_weights)
+        n_effective = (
+            n_rows if kind == "aweights" else float(np.sum(observation_weights))
+        )
         return cls(
-            values=canonical_values,
+            values=observation_weights,
             kind=kind,
             n_rows=n_rows,
             n_effective=n_effective,
@@ -102,8 +104,9 @@ class WithinLinearData:
     """Linear-model arrays after within transformation, in original units.
 
     These arrays have not been multiplied by square-root observation weights.
-    Optional IV roles are kept separate so their econometric meaning remains
-    visible throughout the estimator lifecycle.
+    For IV models, ``design`` is the full structural regressor matrix and may
+    include endogenous regressors. ``instruments`` is the full instrument
+    matrix, including exogenous regressors that instrument themselves.
     """
 
     response: NDArray[np.float64]

--- a/pyfixest/estimation/internals/vcov_.py
+++ b/pyfixest/estimation/internals/vcov_.py
@@ -58,7 +58,7 @@ def vcov_hetero(
     scores: np.ndarray,
     X: np.ndarray,
     tZX: np.ndarray,
-    weights: np.ndarray,
+    weights: np.ndarray | None,
     leverage_weights: np.ndarray | None,
     weights_type: WeightsTypeOptions | None,
     vcov_type_detail: HeteroVcovTypeOptions,
@@ -68,14 +68,19 @@ def vcov_hetero(
     tZZinv: np.ndarray,
 ) -> np.ndarray:
     "Unscaled heteroskedasticity-robust vcov (HC1/HC2/HC3)."
+    # Frequency weights are the only scheme corrected for here: each row stands
+    # for `weights` identical observations. Unweighted fits pass `weights=None`
+    # and need no correction.
+    frequency_weights = weights if weights_type == "fweights" else None
+
     if vcov_type_detail in ["hetero", "HC1"]:
         transformed_scores = scores
     elif vcov_type_detail in ["HC2", "HC3"]:
         leverage = np.sum(X * (X @ np.linalg.inv(tZX)), axis=1)
         if leverage_weights is not None:
             leverage = leverage_weights.flatten() * leverage
-        if weights_type == "fweights":
-            leverage = leverage / weights.flatten()
+        if frequency_weights is not None:
+            leverage = leverage / frequency_weights.flatten()
         transformed_scores = (
             scores / np.sqrt(1 - leverage)[:, None]
             if vcov_type_detail == "HC2"
@@ -86,9 +91,8 @@ def vcov_hetero(
             f"vcov_type_detail must be one of {HeteroVcovTypeOptions}, got {vcov_type_detail}."
         )
 
-    # for fweights, need to divide by sqrt(weights)
-    if weights_type == "fweights":
-        transformed_scores = transformed_scores / np.sqrt(weights)
+    if frequency_weights is not None:
+        transformed_scores = transformed_scores / np.sqrt(frequency_weights)
 
     Omega = transformed_scores.T @ transformed_scores
 

--- a/pyfixest/estimation/internals/vcov_.py
+++ b/pyfixest/estimation/internals/vcov_.py
@@ -1,20 +1,18 @@
 from __future__ import annotations
 
-from typing import Literal
-
 import numpy as np
 
 from pyfixest.core.crv1 import crv1_meat_loop
-from pyfixest.estimation.internals.literals import WeightsTypeOptions
+from pyfixest.estimation.internals.literals import (
+    HacVcovTypeOptions,
+    HeteroVcovTypeOptions,
+)
 from pyfixest.estimation.internals.vcov_utils import (
     _dk_meat_panel,
     _get_panel_idx,
     _nw_meat_panel,
     _nw_meat_time,
 )
-
-HeteroVcovTypeOptions = Literal["hetero", "HC1", "HC2", "HC3"]
-HacVcovTypeOptions = Literal["NW", "DK"]
 
 
 def _sandwich(
@@ -58,9 +56,8 @@ def vcov_hetero(
     scores: np.ndarray,
     X: np.ndarray,
     tZX: np.ndarray,
-    weights: np.ndarray | None,
-    leverage_weights: np.ndarray | None,
-    weights_type: WeightsTypeOptions | None,
+    frequency_weights: np.ndarray | None,
+    normal_equation_weights: np.ndarray | None,
     vcov_type_detail: HeteroVcovTypeOptions,
     bread: np.ndarray,
     is_iv: bool,
@@ -68,17 +65,15 @@ def vcov_hetero(
     tZZinv: np.ndarray,
 ) -> np.ndarray:
     "Unscaled heteroskedasticity-robust vcov (HC1/HC2/HC3)."
-    # Frequency weights are the only scheme corrected for here: each row stands
-    # for `weights` identical observations. Unweighted fits pass `weights=None`
-    # and need no correction.
-    frequency_weights = weights if weights_type == "fweights" else None
-
+    # For HC2/HC3, h_i = w_i x_i' (X' W X)^-1 x_i. Frequency-weighted
+    # rows represent repeated observations, so their per-observation leverage
+    # is h_i / f_i and their aggregated score is divided by sqrt(f_i).
     if vcov_type_detail in ["hetero", "HC1"]:
         transformed_scores = scores
     elif vcov_type_detail in ["HC2", "HC3"]:
         leverage = np.sum(X * (X @ np.linalg.inv(tZX)), axis=1)
-        if leverage_weights is not None:
-            leverage = leverage_weights.flatten() * leverage
+        if normal_equation_weights is not None:
+            leverage = normal_equation_weights.flatten() * leverage
         if frequency_weights is not None:
             leverage = leverage / frequency_weights.flatten()
         transformed_scores = (

--- a/pyfixest/estimation/internals/vcov_.py
+++ b/pyfixest/estimation/internals/vcov_.py
@@ -30,9 +30,22 @@ def _sandwich(
     return bread @ projected_meat @ bread
 
 
-def vcov_iid_ols(residuals: np.ndarray, bread: np.ndarray, N: int) -> np.ndarray:
-    "IID Variance-Covariance Matrix for OLS."
-    sigma2 = np.sum(residuals.flatten() ** 2) / (N - 1)
+def vcov_iid_ols(
+    residuals: np.ndarray,
+    bread: np.ndarray,
+    N: int | float,
+    weights: np.ndarray | None = None,
+) -> np.ndarray:
+    """Compute IID OLS covariance from response-scale residuals.
+
+    ``weights=None`` selects the allocation-free unweighted path. Otherwise,
+    the residual sum of squares is evaluated in the weighted estimating
+    equation without materializing square-root-weighted residuals.
+    """
+    squared_residuals = residuals.flatten() ** 2
+    if weights is not None:
+        squared_residuals = weights.flatten() * squared_residuals
+    sigma2 = np.sum(squared_residuals) / (N - 1)
     return bread * sigma2
 
 
@@ -46,6 +59,7 @@ def vcov_hetero(
     X: np.ndarray,
     tZX: np.ndarray,
     weights: np.ndarray,
+    leverage_weights: np.ndarray | None,
     weights_type: WeightsTypeOptions | None,
     vcov_type_detail: HeteroVcovTypeOptions,
     bread: np.ndarray,
@@ -58,6 +72,8 @@ def vcov_hetero(
         transformed_scores = scores
     elif vcov_type_detail in ["HC2", "HC3"]:
         leverage = np.sum(X * (X @ np.linalg.inv(tZX)), axis=1)
+        if leverage_weights is not None:
+            leverage = leverage_weights.flatten() * leverage
         if weights_type == "fweights":
             leverage = leverage / weights.flatten()
         transformed_scores = (
@@ -187,20 +203,31 @@ def _jackknife_vcov(beta_jack: np.ndarray, beta_center: np.ndarray) -> np.ndarra
 def vcov_crv3_fast(
     X: np.ndarray,
     Y: np.ndarray,
+    weights: np.ndarray | None,
     beta_hat: np.ndarray,
     clustid: np.ndarray,
     cluster_col: np.ndarray,
 ) -> np.ndarray:
-    "Unscaled CRV3 vcov via the closed-form cluster jackknife (no fixed effects)."
+    """Compute unscaled CRV3 from within-scale arrays without retaining WLS data."""
     beta_jack = np.zeros((len(clustid), X.shape[1]))
 
-    tXX = X.T @ X
-    tXy = X.T @ Y
+    if weights is None:
+        X_solver = X
+        Y_solver = Y.reshape(-1, 1)
+    else:
+        sqrt_weights = np.sqrt(weights).reshape(-1, 1)
+        X_solver = X * sqrt_weights
+        Y_solver = Y.reshape(-1, 1) * sqrt_weights
+
+    tXX = X_solver.T @ X_solver
+    tXy = X_solver.T @ Y_solver
 
     for ixg, g in enumerate(clustid):
-        Xg = X[np.equal(g, cluster_col)]
-        Yg = Y[np.equal(g, cluster_col)]
+        group = np.equal(g, cluster_col)
+        Xg = X_solver[group]
+        Yg = Y_solver[group]
         tXgXg = Xg.T @ Xg
-        beta_jack[ixg, :] = (np.linalg.pinv(tXX - tXgXg) @ (tXy - Xg.T @ Yg)).flatten()
+        tXgyg = Xg.T @ Yg
+        beta_jack[ixg, :] = (np.linalg.pinv(tXX - tXgXg) @ (tXy - tXgyg)).flatten()
 
     return _jackknife_vcov(beta_jack=beta_jack, beta_center=beta_hat)

--- a/pyfixest/estimation/models/_result_accessor_mixin.py
+++ b/pyfixest/estimation/models/_result_accessor_mixin.py
@@ -154,6 +154,19 @@ class ResultAccessorMixin(TidyColumnAccessors):
     _adj_r2_within: float
     _vcov_type: str
 
+    def _require_fit_arrays(
+        self,
+        method: str,
+        *,
+        arrays: str,
+        remedy: str = "Refit with lean=False.",
+    ) -> None:
+        """Reject a call whose input arrays `lean=True` discarded.
+
+        Implemented by the host class.
+        """
+        raise NotImplementedError
+
     def _bind_report_methods(self):
         """Bind summary, coefplot, iplot, and etable from pyfixest.report as instance methods."""
         _module = import_module("pyfixest.report")
@@ -308,6 +321,9 @@ class ResultAccessorMixin(TidyColumnAccessors):
         fit._r2, fit._adj_r2, fit._r2_within
         ```
         """
+        self._require_fit_arrays(
+            "get_performance", arrays="the response and within arrays"
+        )
         Y_within = self._within_data.response.flatten()
         Y = self._response
         observation_weights = self._observation_weights.values
@@ -602,4 +618,5 @@ class ResultAccessorMixin(TidyColumnAccessors):
         fit.resid()[:5]
         ```
         """
+        self._require_fit_arrays("resid", arrays="the residual arrays")
         return self._u_hat.flatten()

--- a/pyfixest/estimation/models/_result_accessor_mixin.py
+++ b/pyfixest/estimation/models/_result_accessor_mixin.py
@@ -10,6 +10,10 @@ from pyfixest.errors import EmptyVcovError
 
 if TYPE_CHECKING:
     from pyfixest.estimation.internals.families import InferenceDist
+    from pyfixest.estimation.internals.model_state import (
+        ObservationWeights,
+        WithinLinearData,
+    )
 from pyfixest.estimation.internals.literals import (
     InferenceType,
     _validate_literal_argument,
@@ -129,8 +133,10 @@ class ResultAccessorMixin(TidyColumnAccessors):
     _conf_int: np.ndarray
     _u_hat: np.ndarray
     _weights: np.ndarray
+    _observation_weights: "ObservationWeights"
+    _within_data: "WithinLinearData"
     _Y: np.ndarray
-    _Y_untransformed: pd.Series
+    _Y_untransformed: pd.DataFrame
     _coefnames: list[str]
     _method: str
     _drop_intercept: bool
@@ -138,7 +144,8 @@ class ResultAccessorMixin(TidyColumnAccessors):
     _has_weights: bool
     _is_iv: bool
     _k_fe: pd.Series
-    _N: int
+    _N: int | float
+    _N_rows: int
     _k: int
     _df_t: int
     _inference_dist: "InferenceDist"
@@ -303,8 +310,9 @@ class ResultAccessorMixin(TidyColumnAccessors):
         fit._r2, fit._adj_r2, fit._r2_within
         ```
         """
-        Y_within = self._Y
+        Y_within = self._within_data.response
         Y = self._Y_untransformed.to_numpy()
+        observation_weights = self._observation_weights.values
 
         has_intercept = not self._drop_intercept
 
@@ -315,14 +323,25 @@ class ResultAccessorMixin(TidyColumnAccessors):
         else:
             adj_factor = (self._N - has_intercept) / (self._N - self._k)
 
-        ssu = np.sum(self._u_hat**2)
-        ssy = np.sum(self._weights * (Y - np.average(Y, weights=self._weights)) ** 2)
+        if observation_weights is None:
+            ssu = np.sum(self._u_hat**2)
+            y_center = np.mean(Y)
+            ssy = np.sum((Y - y_center) ** 2)
+        else:
+            weights = observation_weights.reshape((-1, 1))
+            ssu = np.sum(weights.flatten() * self._u_hat**2)
+            y_center = np.average(Y, weights=weights)
+            ssy = np.sum(weights * (Y - y_center) ** 2)
         self._rmse = np.sqrt(ssu / self._N)
         self._r2 = 1 - (ssu / ssy)
         self._adj_r2 = 1 - (ssu / ssy) * adj_factor
 
         if self._has_fixef:
-            ssy_within = np.sum(Y_within**2)
+            ssy_within = (
+                np.sum(Y_within**2)
+                if observation_weights is None
+                else np.sum(weights * Y_within**2)
+            )
             self._r2_within = 1 - (ssu / ssy_within)
             self._adj_r2_within = 1 - (ssu / ssy_within) * adj_factor_within
 
@@ -567,8 +586,9 @@ class ResultAccessorMixin(TidyColumnAccessors):
         """
         Fitted model residuals.
 
-        For weighted models the residuals are rescaled by the square root of the
-        weights, so they are on the scale of the original dependent variable.
+        Residuals are stored and returned on the scale of the original dependent
+        variable. Observation weights are applied only where an estimating
+        equation or diagnostic requires them.
 
         Returns
         -------
@@ -584,4 +604,4 @@ class ResultAccessorMixin(TidyColumnAccessors):
         fit.resid()[:5]
         ```
         """
-        return self._u_hat.flatten() / np.sqrt(self._weights.flatten())
+        return self._u_hat.flatten()

--- a/pyfixest/estimation/models/_result_accessor_mixin.py
+++ b/pyfixest/estimation/models/_result_accessor_mixin.py
@@ -132,11 +132,9 @@ class ResultAccessorMixin(TidyColumnAccessors):
     _pvalue: np.ndarray
     _conf_int: np.ndarray
     _u_hat: np.ndarray
-    _weights: np.ndarray
     _observation_weights: "ObservationWeights"
     _within_data: "WithinLinearData"
-    _Y: np.ndarray
-    _Y_untransformed: pd.DataFrame
+    _response: np.ndarray
     _coefnames: list[str]
     _method: str
     _drop_intercept: bool
@@ -310,8 +308,8 @@ class ResultAccessorMixin(TidyColumnAccessors):
         fit._r2, fit._adj_r2, fit._r2_within
         ```
         """
-        Y_within = self._within_data.response
-        Y = self._Y_untransformed.to_numpy()
+        Y_within = self._within_data.response.flatten()
+        Y = self._response
         observation_weights = self._observation_weights.values
 
         has_intercept = not self._drop_intercept
@@ -328,8 +326,8 @@ class ResultAccessorMixin(TidyColumnAccessors):
             y_center = np.mean(Y)
             ssy = np.sum((Y - y_center) ** 2)
         else:
-            weights = observation_weights.reshape((-1, 1))
-            ssu = np.sum(weights.flatten() * self._u_hat**2)
+            weights = observation_weights
+            ssu = np.sum(weights * self._u_hat**2)
             y_center = np.average(Y, weights=weights)
             ssy = np.sum(weights * (Y - y_center) ** 2)
         self._rmse = np.sqrt(ssu / self._N)

--- a/pyfixest/estimation/models/fegaussian_.py
+++ b/pyfixest/estimation/models/fegaussian_.py
@@ -79,5 +79,5 @@ class Fegaussian(Feglm):
             residuals=self._u_hat,
             bread=self._bread,
             N=self._N,
-            weights=self._leverage_weights(),
+            weights=self._observation_weights.values,
         )

--- a/pyfixest/estimation/models/fegaussian_.py
+++ b/pyfixest/estimation/models/fegaussian_.py
@@ -75,4 +75,9 @@ class Fegaussian(Feglm):
 
     def _vcov_iid(self):
         # we set gaussian glms to match pf.feols exactly
-        return vcov_iid_ols(residuals=self._u_hat, bread=self._bread, N=self._N)
+        return vcov_iid_ols(
+            residuals=self._u_hat,
+            bread=self._bread,
+            N=self._N,
+            weights=self._leverage_weights(),
+        )

--- a/pyfixest/estimation/models/fegaussian_.py
+++ b/pyfixest/estimation/models/fegaussian_.py
@@ -6,6 +6,7 @@ import pandas as pd
 from pyfixest.core.demean import Preconditioner
 from pyfixest.demeaners import AnyDemeaner
 from pyfixest.estimation.formula.parse import Formula as FixestFormula
+from pyfixest.estimation.internals.demean_ import DemeanedData
 from pyfixest.estimation.internals.families import GAUSSIAN
 from pyfixest.estimation.internals.vcov_ import vcov_iid_ols
 from pyfixest.estimation.models.feglm_ import Feglm
@@ -24,7 +25,7 @@ class Fegaussian(Feglm):
         weights: str | None,
         weights_type: str | None,
         collin_tol: float,
-        lookup_demeaned_data: dict[frozenset[int], pd.DataFrame],
+        lookup_demeaned_data: dict[frozenset[int], DemeanedData],
         tol: float,
         maxiter: int,
         solver: Literal[

--- a/pyfixest/estimation/models/feglm_.py
+++ b/pyfixest/estimation/models/feglm_.py
@@ -8,6 +8,7 @@ import pandas as pd
 
 from pyfixest.core.demean import Preconditioner
 from pyfixest.demeaners import AnyDemeaner
+from pyfixest.estimation.formula.model_matrix import ModelMatrix
 from pyfixest.estimation.formula.parse import Formula as FixestFormula
 from pyfixest.estimation.internals.demean_ import DemeanedData
 from pyfixest.estimation.internals.families import GlmFamily
@@ -77,7 +78,7 @@ class Feglm(Feols):
         separation_check: list[str] | None = None,
         context: int | Mapping[str, Any] = 0,
         accelerate: bool = True,
-    ):
+    ) -> None:
         super().__init__(
             FixestFormula=FixestFormula,
             data=data,
@@ -119,13 +120,13 @@ class Feglm(Feols):
 
         self._Y_hat_response = np.empty(0)
         self.deviance = None
-        self._Xbeta = np.empty(0)
+        self._Xbeta = np.empty((0, 1))
 
         self._method = "feglm"
         self._family = family
         self._inference_dist = family.inference_dist
 
-    def prepare_model_matrix(self):
+    def prepare_model_matrix(self) -> ModelMatrix:
         "Prepare model inputs for estimation."
         model_matrix = super().prepare_model_matrix()
 
@@ -153,47 +154,54 @@ class Feglm(Feols):
 
             # Preserve the established GLM sample-size convention after
             # separation. Frequency-weight policy is handled separately.
-            self._N = model_matrix.dependent.shape[0]
-            self._N_rows = self._N
+            n_rows_after_separation = model_matrix.dependent.shape[0]
+            self._N = n_rows_after_separation
+            self._N_rows = n_rows_after_separation
 
             self.n_separation_na = len(na_separation)
             # possible to have dropped fixed effects level due to separation
-            self._k_fe = self._fe.nunique(axis=0) if self._has_fixef else None
             self._n_fe = np.sum(self._k_fe > 1) if self._has_fixef else 0
 
         return model_matrix
 
-    def to_array(self):
-        "Turn estimation DataFrames to np arrays."
-        self._Y = self._model_matrix.dependent.to_numpy()
-        self._X = self._model_matrix.independent.to_numpy()
-        self._Z = self._X
-        if self._offset_df is not None:
-            self._offset = self._offset_df.to_numpy().reshape((-1, 1))
-        if self._fe is not None:
-            self._fe = self._fe.to_numpy()
-            if self._fe.ndim == 1:
-                self._fe = self._fe.reshape((self._N, 1))
-
-    def get_fit(self):
+    def get_fit(self) -> None:
         "Fit the GLM via IRLS and write results onto self.* attributes."
-        self.to_array()
+        model_matrix = self._model_matrix
+        response = model_matrix.dependent.to_numpy()
+        design = model_matrix.independent.to_numpy()
+        fixed_effects = (
+            None
+            if model_matrix.fixed_effects is None
+            else model_matrix.fixed_effects.to_numpy()
+        )
+        offset = (
+            None
+            if model_matrix.offset is None
+            else model_matrix.offset.to_numpy().reshape((-1, 1))
+        )
+        self._offset = offset
 
         def _demean(
             v: np.ndarray, X: np.ndarray, weights: np.ndarray, tol: float
         ) -> tuple[np.ndarray, np.ndarray]:
-            return self.residualize(v=v, X=X, flist=self._fe, weights=weights, tol=tol)
+            return self.residualize(
+                v=v,
+                X=X,
+                flist=fixed_effects,
+                weights=weights,
+                tol=tol,
+            )
 
         fit = fit_glm_irls(
-            X=self._X,
-            Y=self._Y,
+            X=design,
+            Y=response,
             family=self._family,
             demean=_demean,
             coefnames=self._coefnames,
             collin_tol=self._collin_tol,
-            accelerate=self._accelerate and self._fe is not None,
-            offset=self._offset,
-            weights=self._weights if self._has_weights else None,
+            accelerate=self._accelerate and fixed_effects is not None,
+            offset=offset,
+            weights=self._observation_weights.values,
             solver=self._solver,
             maxiter=self.maxiter,
             tol=self.tol,
@@ -203,54 +211,48 @@ class Feglm(Feols):
         self._coefnames = fit.coefnames
         self._collin_vars = fit.collin_vars
         self._collin_index = fit.collin_index
-        self._X = fit.X
-        self._X_is_empty = self._X.shape[1] == 0
-        self._k = self._X.shape[1]
+        self._working_state = fit.working_state
+        self._X = self._working_state.design_within
+        self._Y = self._working_state.working_response_within
+        self._Z = self._X
+        self._X_is_empty = self._working_state.design_within.shape[1] == 0
+        self._k = self._working_state.design_within.shape[1]
 
         self._beta_hat = fit.beta
-        self._Y_hat_response = fit.mu.flatten()
-        self._Y_hat_link = fit.eta.flatten()
+        self._Y_hat_response = self._working_state.mu
+        self._Y_hat_link = self._working_state.eta
+        self._irls_weights = self._working_state.working_weights
 
-        self._weights = fit.W
-        self._irls_weights = fit.W
-        if self._weights.ndim == 1:
-            self._weights = self._weights.reshape((self._N, 1))
+        self._u_hat_response = self._working_state.response_residuals
+        self._u_hat_working = self._working_state.working_residuals
+        self._u_hat = self._u_hat_working
 
-        self._u_hat_response = (self._Y.flatten() - fit.mu).flatten()
-        e_final = fit.z_tilde - fit.X_tilde @ self._beta_hat
-        self._u_hat_working = (
-            self._u_hat_response
-            if self._method == "feglm-gaussian"
-            else e_final.flatten()
+        self._scores_response = self._u_hat_response[:, None] * fit.X
+        self._scores_working = self._u_hat_working[:, None] * fit.X
+
+        weighted_working_residuals = (
+            self._working_state.working_weights * self._u_hat_working
         )
+        self._scores = self._X * weighted_working_residuals[:, None]
 
-        self._scores_response = self._u_hat_response[:, None] * self._X
-        self._scores_working = self._u_hat_working[:, None] * self._X
-
-        sqrt_W_vec = fit.sqrt_W.flatten()
-        X_wls = sqrt_W_vec[:, None] * fit.X_tilde
-        z_wls = sqrt_W_vec * fit.z_tilde
-
-        self._u_hat = (z_wls - X_wls @ self._beta_hat).flatten()
-        self._Y = z_wls
-        self._X = X_wls
-        self._Z = self._X
-
-        self._scores = self._u_hat[:, None] * self._X
-
-        self._tZX = self._Z.T @ self._X
+        weighted_design = self._working_state.working_weights[:, None] * self._X
+        self._tZX = self._Z.T @ weighted_design
         self._tZXinv = np.linalg.inv(self._tZX)
-        self._Xbeta = fit.eta.reshape(-1, 1)
+        self._Xbeta = self._working_state.eta.reshape(-1, 1)
 
-        self._hessian = X_wls.T @ X_wls
+        self._hessian = self._tZX.copy()
         self.deviance = fit.deviance
         self.convergence = fit.converged
         if self.convergence:
             self._convergence = True
 
-    def _leverage_weights(self) -> np.ndarray | None:
-        """Return no leverage weights while the GLM design stays sqrt-weighted."""
-        return None
+    def _leverage_weights(self) -> np.ndarray:
+        """Return final GLM working weights for HC2/HC3 leverage."""
+        return self._working_state.working_weights
+
+    def _fixef_weights(self) -> np.ndarray | None:
+        """Return working weights when weighted FE recovery historically used them."""
+        return self._working_state.working_weights if self._has_weights else None
 
     def _vcov_iid(self):
         return vcov_iid_glm(bread=self._bread)
@@ -280,7 +282,7 @@ class Feglm(Feols):
         self,
         v: np.ndarray,
         X: np.ndarray,
-        flist: np.ndarray,
+        flist: np.ndarray | None,
         weights: np.ndarray,
         tol: float,
     ) -> tuple[np.ndarray, np.ndarray]:
@@ -380,7 +382,7 @@ class Feglm(Feols):
         self._check_dependent_variable()
 
 
-def _glm_input_checks(drop_singletons: bool, tol: float, maxiter: int):
+def _glm_input_checks(drop_singletons: bool, tol: float, maxiter: int) -> None:
     if not isinstance(drop_singletons, bool):
         raise TypeError("drop_singletons must be logical.")
     if not isinstance(tol, (int, float)):

--- a/pyfixest/estimation/models/feglm_.py
+++ b/pyfixest/estimation/models/feglm_.py
@@ -264,10 +264,19 @@ class Feglm(Feols):
         return self._working_state.eta.reshape(-1, 1)
 
     def _clear_attributes(self) -> None:
-        """Apply base cleanup and drop the IRLS state backing the GLM aliases."""
+        """Apply base cleanup and discard large GLM fit arrays when lean."""
         super()._clear_attributes()
-        if self._lean and hasattr(self, "_working_state"):
-            del self._working_state
+        if self._lean:
+            # The IRLS aliases are read-only views, so the working state
+            # backing them is what has to go.
+            for attr in (
+                "_working_state",
+                "_u_hat_response",
+                "_u_hat_working",
+                "_offset",
+            ):
+                if hasattr(self, attr):
+                    delattr(self, attr)
 
     def _leverage_weights(self) -> np.ndarray:
         """Return final GLM working weights for HC2/HC3 leverage."""

--- a/pyfixest/estimation/models/feglm_.py
+++ b/pyfixest/estimation/models/feglm_.py
@@ -223,6 +223,8 @@ class Feglm(Feols):
         weighted_working_residuals = (
             working_state.working_weights * working_state.working_residuals
         )
+        # The IRLS score is W_i x_i e_i. ``working_weights`` already includes
+        # any user-supplied observation weight.
         self._scores = design_within * weighted_working_residuals[:, None]
 
         weighted_design = working_state.working_weights[:, None] * design_within
@@ -278,12 +280,19 @@ class Feglm(Feols):
                 if hasattr(self, attr):
                     delattr(self, attr)
 
-    def _leverage_weights(self) -> np.ndarray:
-        """Return final GLM working weights for HC2/HC3 leverage."""
+    def _normal_equation_weights(self) -> np.ndarray:
+        """Return the final IRLS weights in the fitted normal equations."""
         return self._working_state.working_weights
 
-    def _fixef_weights(self) -> np.ndarray | None:
-        """Return working weights when weighted FE recovery historically used them."""
+    def _fixef_recovery_weights(self) -> np.ndarray | None:
+        """Return weights used by fixed-effect coefficient recovery.
+
+        At convergence, ``eta - offset - X @ beta`` is the fixed-effect
+        contribution, up to solver tolerance. For weighted fits the recovery
+        solve uses the combined IRLS weights, which already contain the
+        observation weights; applying observation weights again would double
+        count them.
+        """
         return self._working_state.working_weights if self._has_weights else None
 
     def _vcov_iid(self):
@@ -411,13 +420,9 @@ class Feglm(Feols):
         else:
             return yhat
 
-    def _check_dependent_variable(self) -> None:
-        "Validate the dependent variable according to the family's constraints."
-        self._family.check_y(self._model_matrix.dependent)
-
     def _validate_response(self) -> None:
-        """Apply family-specific response validation after matrix preparation."""
-        self._check_dependent_variable()
+        """Validate the prepared response against the family's constraints."""
+        self._family.check_y(self._model_matrix.dependent)
 
 
 def _glm_input_checks(drop_singletons: bool, tol: float, maxiter: int) -> None:

--- a/pyfixest/estimation/models/feglm_.py
+++ b/pyfixest/estimation/models/feglm_.py
@@ -5,6 +5,7 @@ from typing import Any, Literal
 
 import numpy as np
 import pandas as pd
+from numpy.typing import NDArray
 
 from pyfixest.core.demean import Preconditioner
 from pyfixest.demeaners import AnyDemeaner
@@ -120,7 +121,6 @@ class Feglm(Feols):
 
         self._Y_hat_response = np.empty(0)
         self.deviance = None
-        self._Xbeta = np.empty((0, 1))
 
         self._method = "feglm"
         self._family = family
@@ -205,40 +205,69 @@ class Feglm(Feols):
         self._coefnames = fit.coefnames
         self._collin_vars = fit.collin_vars
         self._collin_index = fit.collin_index
-        self._working_state = fit.working_state
-        self._X = self._working_state.design_within
-        self._Y = self._working_state.working_response_within
-        self._Z = self._X
-        self._X_is_empty = self._working_state.design_within.shape[1] == 0
-        self._k = self._working_state.design_within.shape[1]
+
+        working_state = fit.working_state
+        self._working_state = working_state
+        design_within = working_state.design_within
+        self._X_is_empty = design_within.shape[1] == 0
+        self._k = design_within.shape[1]
 
         self._beta_hat = fit.beta
-        self._Y_hat_response = self._working_state.mu
-        self._Y_hat_link = self._working_state.eta
-        self._irls_weights = self._working_state.working_weights
+        self._Y_hat_response = working_state.mu
+        self._Y_hat_link = working_state.eta
 
-        self._u_hat_response = self._working_state.response_residuals
-        self._u_hat_working = self._working_state.working_residuals
+        self._u_hat_response = working_state.response_residuals
+        self._u_hat_working = working_state.working_residuals
         self._u_hat = self._u_hat_working
 
-        self._scores_response = self._u_hat_response[:, None] * fit.X
-        self._scores_working = self._u_hat_working[:, None] * fit.X
-
         weighted_working_residuals = (
-            self._working_state.working_weights * self._u_hat_working
+            working_state.working_weights * working_state.working_residuals
         )
-        self._scores = self._X * weighted_working_residuals[:, None]
+        self._scores = design_within * weighted_working_residuals[:, None]
 
-        weighted_design = self._working_state.working_weights[:, None] * self._X
-        self._tZX = self._Z.T @ weighted_design
+        weighted_design = working_state.working_weights[:, None] * design_within
+        self._tZX = design_within.T @ weighted_design
         self._tZXinv = np.linalg.inv(self._tZX)
-        self._Xbeta = self._working_state.eta.reshape(-1, 1)
 
         self._hessian = self._tZX.copy()
         self.deviance = fit.deviance
         self.convergence = fit.converged
         if self.convergence:
             self._convergence = True
+
+    # Read-only views on the final IRLS state. A GLM never builds the linear
+    # `_within_data`, so these override the base aliases rather than extend them.
+
+    @property
+    def _Y(self) -> NDArray[np.float64]:
+        """Within-scale IRLS working response."""
+        return self._working_state.working_response_within
+
+    @property
+    def _X(self) -> NDArray[np.float64]:
+        """Within-scale IRLS design, not premultiplied by working weights."""
+        return self._working_state.design_within
+
+    @property
+    def _Z(self) -> NDArray[np.float64]:
+        """The IRLS design; a GLM has no instruments."""
+        return self._working_state.design_within
+
+    @property
+    def _irls_weights(self) -> NDArray[np.float64]:
+        """Final IRLS working weights, never the observation weights."""
+        return self._working_state.working_weights
+
+    @property
+    def _Xbeta(self) -> NDArray[np.float64]:
+        """Linear predictor as a column vector."""
+        return self._working_state.eta.reshape(-1, 1)
+
+    def _clear_attributes(self) -> None:
+        """Apply base cleanup and drop the IRLS state backing the GLM aliases."""
+        super()._clear_attributes()
+        if self._lean and hasattr(self, "_working_state"):
+            del self._working_state
 
     def _leverage_weights(self) -> np.ndarray:
         """Return final GLM working weights for HC2/HC3 leverage."""

--- a/pyfixest/estimation/models/feglm_.py
+++ b/pyfixest/estimation/models/feglm_.py
@@ -9,6 +9,7 @@ import pandas as pd
 from pyfixest.core.demean import Preconditioner
 from pyfixest.demeaners import AnyDemeaner
 from pyfixest.estimation.formula.parse import Formula as FixestFormula
+from pyfixest.estimation.internals.demean_ import DemeanedData
 from pyfixest.estimation.internals.families import GlmFamily
 from pyfixest.estimation.internals.fit_glm_ import fit_glm_irls
 from pyfixest.estimation.internals.separation import check_for_separation
@@ -56,7 +57,7 @@ class Feglm(Feols):
         weights: str | None,
         weights_type: str | None,
         collin_tol: float,
-        lookup_demeaned_data: dict[frozenset[int], pd.DataFrame],
+        lookup_demeaned_data: dict[frozenset[int], DemeanedData],
         tol: float,
         maxiter: int,
         solver: Literal[
@@ -136,9 +137,9 @@ class Feglm(Feols):
             and self.separation_check  # not an empty list
         ):
             na_separation = check_for_separation(
-                Y=self._Y,
-                X=self._X,
-                fe=self._fe,
+                Y=model_matrix.dependent,
+                X=model_matrix.independent,
+                fe=model_matrix.fixed_effects,
                 fml=self._fml,
                 data=self._data,
                 demeaner=self._demeaner,
@@ -152,7 +153,7 @@ class Feglm(Feols):
 
             # Preserve the established GLM sample-size convention after
             # separation. Frequency-weight policy is handled separately.
-            self._N = self._Y.shape[0]
+            self._N = model_matrix.dependent.shape[0]
             self._N_rows = self._N
 
             self.n_separation_na = len(na_separation)
@@ -164,11 +165,9 @@ class Feglm(Feols):
 
     def to_array(self):
         "Turn estimation DataFrames to np arrays."
-        self._Y, self._X, self._Z = (
-            self._Y.to_numpy(),
-            self._X.to_numpy(),
-            self._X.to_numpy(),
-        )
+        self._Y = self._model_matrix.dependent.to_numpy()
+        self._X = self._model_matrix.independent.to_numpy()
+        self._Z = self._X
         if self._offset_df is not None:
             self._offset = self._offset_df.to_numpy().reshape((-1, 1))
         if self._fe is not None:
@@ -248,6 +247,10 @@ class Feglm(Feols):
         self.convergence = fit.converged
         if self.convergence:
             self._convergence = True
+
+    def _leverage_weights(self) -> np.ndarray | None:
+        """Return no leverage weights while the GLM design stays sqrt-weighted."""
+        return None
 
     def _vcov_iid(self):
         return vcov_iid_glm(bread=self._bread)
@@ -370,7 +373,7 @@ class Feglm(Feols):
 
     def _check_dependent_variable(self) -> None:
         "Validate the dependent variable according to the family's constraints."
-        self._family.check_y(self._Y)
+        self._family.check_y(self._model_matrix.dependent)
 
     def _validate_response(self) -> None:
         """Apply family-specific response validation after matrix preparation."""

--- a/pyfixest/estimation/models/feglm_.py
+++ b/pyfixest/estimation/models/feglm_.py
@@ -152,12 +152,6 @@ class Feglm(Feols):
             model_matrix = model_matrix.without_rows(na_separation)
             self._publish_model_matrix(model_matrix)
 
-            # Preserve the established GLM sample-size convention after
-            # separation. Frequency-weight policy is handled separately.
-            n_rows_after_separation = model_matrix.dependent.shape[0]
-            self._N = n_rows_after_separation
-            self._N_rows = n_rows_after_separation
-
             self.n_separation_na = len(na_separation)
             # possible to have dropped fixed effects level due to separation
             self._n_fe = np.sum(self._k_fe > 1) if self._has_fixef else 0

--- a/pyfixest/estimation/models/feglm_.py
+++ b/pyfixest/estimation/models/feglm_.py
@@ -295,11 +295,16 @@ class Feglm(Feols):
         np.ndarray
             A flat array with the requested residuals.
         """
+        if type not in ("response", "working"):
+            raise ValueError("type must be one of 'response' or 'working'.")
+        self._require_fit_arrays(
+            "resid",
+            arrays="the response and working residual arrays",
+            remedy="Refit with lean=False to access residuals.",
+        )
         if type == "response":
             return self._u_hat_response.flatten()
-        if type == "working":
-            return self._u_hat_working.flatten()
-        raise ValueError("type must be one of 'response' or 'working'.")
+        return self._u_hat_working.flatten()
 
     def residualize(
         self,
@@ -310,6 +315,7 @@ class Feglm(Feols):
         tol: float,
     ) -> tuple[np.ndarray, np.ndarray]:
         "Residualize v and X by flist using weights."
+        self._require_fit_arrays("residualize", arrays="the demeaning caches")
         if flist is None:
             return v, X
 

--- a/pyfixest/estimation/models/feiv_.py
+++ b/pyfixest/estimation/models/feiv_.py
@@ -8,6 +8,7 @@ from typing import Any, Literal
 
 import numpy as np
 import pandas as pd
+from numpy.typing import NDArray
 
 from pyfixest.core.demean import Preconditioner
 from pyfixest.demeaners import AnyDemeaner, LsmrDemeaner
@@ -266,10 +267,12 @@ class Feiv(Feols):
             endogenous=within_data.endogenous,
         )
 
-    def _set_within_data(self, within_data: WithinLinearData) -> None:
-        """Publish IV within state and stable array compatibility aliases."""
-        super()._set_within_data(within_data)
-        self._endogvar = within_data.endogenous
+    @property
+    def _endogvar(self) -> NDArray[np.float64]:
+        """Within-scale endogenous regressors."""
+        endogenous = self._within_data.endogenous
+        assert endogenous is not None
+        return endogenous
 
     def get_fit(self) -> None:
         """Fit a IV model using a 2SLS estimator."""

--- a/pyfixest/estimation/models/feiv_.py
+++ b/pyfixest/estimation/models/feiv_.py
@@ -572,13 +572,12 @@ class Feiv(Feols):
         ]
         Z = self._model_1st_stage._X[:, iv_positions]
 
-        # Calculate the same weighted cross-product used by the first-stage fit
-        # without relying on a persisted square-root-weighted design.
-        first_stage_weights = self._model_1st_stage._observation_weights.values
+        # Q_zz = Z' A Z uses the observation weights from the first-stage fit.
+        observation_weights = self._model_1st_stage._observation_weights.values
         Q_zz = (
             Z.T @ Z
-            if first_stage_weights is None
-            else Z.T @ (first_stage_weights[:, None] * Z)
+            if observation_weights is None
+            else Z.T @ (observation_weights[:, None] * Z)
         )
 
         # Extract the robust variance-covariance matrix

--- a/pyfixest/estimation/models/feiv_.py
+++ b/pyfixest/estimation/models/feiv_.py
@@ -127,8 +127,8 @@ class Feiv(Feols):
     _eff_F : scalar
         Effective F-statistics of first stage regression as in Olea and Pflueger 2013
     _data: pd.DataFrame
-        The data frame used in the estimation. None if arguments `lean = True` or
-        `store_data = False`.
+        The data frame used in the estimation. Deleted if arguments `lean = True`
+        or `store_data = False`.
 
 
     Raises
@@ -300,6 +300,8 @@ class Feiv(Feols):
 
     def first_stage(self) -> None:
         """Implement First stage regression."""
+        self._require_estimation_data("first_stage")
+
         # Store names of instruments from Z matrix
         self._non_exo_instruments = list(set(self._coefnames_z) - set(self._coefnames))
 
@@ -362,6 +364,22 @@ class Feiv(Feols):
     def _finalize_fit(self) -> None:
         """Fit and retain the first-stage model after second-stage inference."""
         self.first_stage()
+
+    def _require_first_stage_state(self, method: str) -> None:
+        """Reject a first-stage diagnostic once lean storage discarded the fit."""
+        if not hasattr(self, "_model_1st_stage"):
+            raise RuntimeError(
+                f"{method}() is unavailable when lean=True because the retained "
+                "first-stage fit state was discarded."
+            )
+
+    def _clear_attributes(self) -> None:
+        """Apply base cleanup and drop the retained first-stage fit when lean."""
+        super()._clear_attributes()
+        if self._lean:
+            for attr in ("_model_1st_stage", "_X_hat", "_v_hat"):
+                if hasattr(self, attr):
+                    delattr(self, attr)
 
     def IV_Diag(self, statistics: list[str] | None = None):
         """Implement IV diagnostic tests.
@@ -443,6 +461,8 @@ class Feiv(Feols):
 
             ```
         """
+        self._require_first_stage_state("IV_Diag")
+
         # Set default statistics
         iv_diag_stat = ["f_stat", "effective_f"]
 
@@ -489,6 +509,8 @@ class Feiv(Feols):
         """
         iv_diag_statistics = iv_diag_statistics or []
 
+        self._require_first_stage_state("IV_weakness_test")
+
         if "f_stat" in iv_diag_statistics:
             self._p_iv = len(self._non_exo_instruments)
 
@@ -521,6 +543,8 @@ class Feiv(Feols):
 
     def eff_F(self) -> None:
         """Compute Effective F stat (Olea and Pflueger 2013)."""
+        self._require_first_stage_state("eff_F")
+
         # If vcov is iid, redo first stage regression
 
         if self._vcov_type_detail == "iid":

--- a/pyfixest/estimation/models/feiv_.py
+++ b/pyfixest/estimation/models/feiv_.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import warnings
 from collections.abc import Mapping
 from dataclasses import replace
@@ -11,7 +13,9 @@ from pyfixest.core.demean import Preconditioner
 from pyfixest.demeaners import AnyDemeaner, LsmrDemeaner
 from pyfixest.estimation.formula.parse import Formula as FixestFormula
 from pyfixest.estimation.internals.collinearity import drop_multicollinear_variables
+from pyfixest.estimation.internals.demean_ import DemeanedData
 from pyfixest.estimation.internals.fit_ import fit_iv
+from pyfixest.estimation.internals.model_state import WithinLinearData
 from pyfixest.estimation.models.feols_ import Feols
 
 
@@ -20,10 +24,9 @@ class Feiv(Feols):
     Non user-facing class to estimate an IV model using a 2SLS estimator.
 
     Inherits from the Feols class. Users should not directly instantiate this class,
-    but rather use the [feols()](/reference/estimation.api.feols.feols.qmd) function. Note that
-    no demeaning is performed in this class: demeaning is performed in the
-    FixestMulti class (to allow for caching of demeaned variables for multiple
-    estimation).
+    but rather use the [feols()](/reference/estimation.api.feols.feols.qmd)
+    function. This class constructs the second-stage and instrument within
+    arrays through the shared ``DemeanCache`` supplied by the estimation runner.
 
     Parameters
     ----------
@@ -167,7 +170,7 @@ class Feiv(Feols):
         weights: str | None,
         weights_type: str | None,
         collin_tol: float,
-        lookup_demeaned_data: dict[frozenset[int], pd.DataFrame],
+        lookup_demeaned_data: dict[frozenset[int], DemeanedData],
         solver: Literal[
             "np.linalg.lstsq",
             "np.linalg.solve",
@@ -210,59 +213,77 @@ class Feiv(Feols):
         self._supports_cluster_causal_variance = False
         self._support_decomposition = False
 
-    def wls_transform(self) -> None:
-        "Transform variables for WLS estimation."
-        super().wls_transform()
-        if self._has_weights:
-            w = np.sqrt(self._weights)
-            self._endogvar = self._endogvar * w
-            self._Z = self._Z * w
+    def _prepare_within_data(self) -> WithinLinearData:
+        """Return second-stage and instrument arrays on within scale."""
+        linear_data = super()._prepare_within_data()
+        endogenous_frame = self._model_matrix.endogenous
+        instrument_frame = self._model_matrix.instruments
+        assert endogenous_frame is not None
+        assert instrument_frame is not None
 
-    def to_array(self) -> None:
-        "Transform estimation DataFrames to arrays."
-        super().to_array()
-        self._Z = self._Zd.to_numpy()
-        self._endogvar = self._endogvar.to_numpy()
-
-    def demean(self) -> None:
-        "Demean instruments and endogeneous variable."
-        super().demean()
-        if self._has_fixef:
-            self._endogvard, self._Zd, _ = self._demean_cache.demean_yx(
-                self._endogvar,
-                self._Z,
-                self._fe,
-                self._weights.flatten(),
-                self._na_index,
-                self._demeaner,
+        endogenous = endogenous_frame.to_numpy(dtype=np.float64)
+        instruments = instrument_frame.to_numpy(dtype=np.float64)
+        if self._model_matrix.fixed_effects is not None:
+            endogenous, instruments, _ = self._demean_cache.demean_yx(
+                endogenous,
+                instruments,
+                y_names=endogenous_frame.columns,
+                x_names=instrument_frame.columns,
+                fe=self._model_matrix.fixed_effects.to_numpy(),
+                weights=self._observation_weights.values,
+                na_index=self._na_index,
+                demeaner=self._demeaner,
             )
-        else:
-            self._endogvard = self._endogvar
-            self._Zd = self._Z
 
-    def drop_multicol_vars(self) -> None:
-        "Drop multicollinear variables in matrix of instruments Z."
-        super().drop_multicol_vars()
+        return WithinLinearData(
+            response=linear_data.response,
+            design=linear_data.design,
+            instruments=instruments,
+            endogenous=endogenous,
+        )
+
+    def _drop_multicollinear_within_data(
+        self, within_data: WithinLinearData
+    ) -> WithinLinearData:
+        """Drop collinear second-stage and instrument columns on within scale."""
+        within_data = super()._drop_multicollinear_within_data(within_data)
+        assert within_data.instruments is not None
+        assert self._coefnames_z is not None
         (
-            self._Z,
+            instruments,
             self._coefnames_z,
             self._collin_vars_z,
             self._collin_index_z,
         ) = drop_multicollinear_variables(
-            self._Z,
+            within_data.instruments,
             self._coefnames_z,
             self._collin_tol,
         )
+        return WithinLinearData(
+            response=within_data.response,
+            design=within_data.design,
+            instruments=instruments,
+            endogenous=within_data.endogenous,
+        )
+
+    def _set_within_data(self, within_data: WithinLinearData) -> None:
+        """Publish IV within state and stable array compatibility aliases."""
+        super()._set_within_data(within_data)
+        self._endogvar = within_data.endogenous
 
     def get_fit(self) -> None:
         """Fit a IV model using a 2SLS estimator."""
-        self.demean()
-        self.to_array()
-        self.drop_multicol_vars()
-        self.wls_transform()
+        within_data = self._drop_multicollinear_within_data(self._prepare_within_data())
+        self._set_within_data(within_data)
+        assert within_data.instruments is not None
 
-        # Second stage (2SLS) on prepared arrays
-        fit = fit_iv(X=self._X, Z=self._Z, Y=self._Y, solver=self._solver)
+        fit = fit_iv(
+            X=within_data.design,
+            Z=within_data.instruments,
+            Y=within_data.response,
+            weights=self._observation_weights.values,
+            solver=self._solver,
+        )
 
         self._tZX = fit.tZX
         self._tXZ = fit.tXZ
@@ -523,8 +544,14 @@ class Feiv(Feols):
         ]
         Z = self._model_1st_stage._X[:, iv_positions]
 
-        # Calculate the cross-product of the instrument matrix
-        Q_zz = Z.T @ Z
+        # Calculate the same weighted cross-product used by the first-stage fit
+        # without relying on a persisted square-root-weighted design.
+        first_stage_weights = self._model_1st_stage._observation_weights.values
+        Q_zz = (
+            Z.T @ Z
+            if first_stage_weights is None
+            else Z.T @ (first_stage_weights[:, None] * Z)
+        )
 
         # Extract the robust variance-covariance matrix
         vcv = self._model_1st_stage._vcov

--- a/pyfixest/estimation/models/feiv_.py
+++ b/pyfixest/estimation/models/feiv_.py
@@ -338,6 +338,7 @@ class Feiv(Feols):
             collin_tol=self._collin_tol,
             solver=self._solver,
             demeaner=demeaner,
+            store_data=self._store_data,
         )
 
         # Ensure model1 is of type Feols

--- a/pyfixest/estimation/models/felogit_.py
+++ b/pyfixest/estimation/models/felogit_.py
@@ -6,6 +6,7 @@ import pandas as pd
 from pyfixest.core.demean import Preconditioner
 from pyfixest.demeaners import AnyDemeaner
 from pyfixest.estimation.formula.parse import Formula as FixestFormula
+from pyfixest.estimation.internals.demean_ import DemeanedData
 from pyfixest.estimation.internals.families import LOGIT
 from pyfixest.estimation.models.feglm_ import Feglm
 
@@ -23,7 +24,7 @@ class Felogit(Feglm):
         weights: str | None,
         weights_type: str | None,
         collin_tol: float,
-        lookup_demeaned_data: dict[frozenset[int], pd.DataFrame],
+        lookup_demeaned_data: dict[frozenset[int], DemeanedData],
         tol: float,
         maxiter: int,
         solver: Literal[

--- a/pyfixest/estimation/models/feols_.py
+++ b/pyfixest/estimation/models/feols_.py
@@ -31,6 +31,7 @@ from pyfixest.estimation.internals.demean_ import DemeanCache, DemeanedData
 from pyfixest.estimation.internals.families import T_DIST, InferenceDist
 from pyfixest.estimation.internals.fit_ import fit_ols
 from pyfixest.estimation.internals.literals import (
+    HacVcovTypeOptions,
     PredictionErrorOptions,
     PredictionType,
     SolverOptions,
@@ -729,27 +730,27 @@ class Feols(ResultAccessorMixin):
             remedy="Set vcov at estimation time or refit with lean=False.",
         )
 
-        data_to_check: pd.DataFrame | None
+        estimation_data: pd.DataFrame | None
         if data is None:
-            data_to_check = getattr(self, "_data", None)
+            estimation_data = getattr(self, "_data", None)
         else:
             try:
-                data_to_check = _narwhals_to_pandas(data)
+                estimation_data = _narwhals_to_pandas(data)
             except TypeError as e:
                 raise TypeError(
                     f"The data set must be a DataFrame type. Received: {type(data)}"
                 ) from e
-            if len(data_to_check) != self._N_rows:
+            if len(estimation_data) != self._N_rows:
                 raise ValueError(
                     "`data` passed to vcov() must contain exactly the already-filtered "
                     "estimation sample in its original estimation order; expected "
-                    f"{self._N_rows} rows, received {len(data_to_check)}."
+                    f"{self._N_rows} rows, received {len(estimation_data)}."
                 )
 
         # assign estimated fixed effects, and fixed effects nested within cluster.
 
         # deparse vcov input
-        _check_vcov_input(vcov=vcov, vcov_kwargs=vcov_kwargs, data=data_to_check)
+        _check_vcov_input(vcov=vcov, vcov_kwargs=vcov_kwargs, data=estimation_data)
 
         vcov_type, vcov_type_detail, is_clustered, clustervar = _deparse_vcov_input(
             vcov, self._has_fixef, self._is_iv
@@ -757,7 +758,7 @@ class Feols(ResultAccessorMixin):
 
         # Reject before any inference state is overwritten, so a failed update
         # leaves the previous covariance estimate intact.
-        if vcov_type in {"HAC", "CRV"} and data_to_check is None:
+        if vcov_type in {"HAC", "CRV"} and estimation_data is None:
             self._require_estimation_data(
                 "vcov",
                 remedy="Pass the estimation sample via data= or refit with store_data=True.",
@@ -786,7 +787,7 @@ class Feols(ResultAccessorMixin):
             self._vcov = self._ssc * self._vcov_hetero()
 
         elif self._vcov_type == "HAC":
-            assert data_to_check is not None
+            assert estimation_data is not None
             kw = vcov_kwargs or {}
             self._lag = kw.get("lag")
             self._time_id = kw.get("time_id")
@@ -794,10 +795,10 @@ class Feols(ResultAccessorMixin):
             self._ssc, self._df_k, self._df_t = get_ssc(
                 **self._make_ssc_kwargs(
                     vcov_type="HAC",
-                    G=np.unique(data_to_check[self._time_id]).shape[0],
+                    G=np.unique(estimation_data[self._time_id]).shape[0],
                 )  # number of unique time periods T used
             )
-            self._vcov = self._ssc * self._vcov_hac(data=data_to_check)
+            self._vcov = self._ssc * self._vcov_hac(data=estimation_data)
 
         elif self._vcov_type == "nid":
             self._ssc, self._df_k, self._df_t = get_ssc(
@@ -806,9 +807,9 @@ class Feols(ResultAccessorMixin):
             self._vcov = self._ssc * self._vcov_nid()
 
         elif self._vcov_type == "CRV":
-            assert data_to_check is not None
+            assert estimation_data is not None
             prep = prepare_cluster_state(
-                data=data_to_check,
+                data=estimation_data,
                 clustervar=self._clustervar,
                 ssc_dict=self._ssc_dict,
                 fixef=self._fixef,
@@ -821,7 +822,7 @@ class Feols(ResultAccessorMixin):
                 prep=prep,
                 k=self._k,
                 make_ssc_kwargs=self._make_ssc_kwargs,
-                cluster_vcov=partial(self._vcov_crv_cluster, data=data_to_check),
+                cluster_vcov=partial(self._vcov_crv_cluster, data=estimation_data),
             )
         # update p-value, t-stat, standard error, confint
         self.get_inference()
@@ -883,11 +884,11 @@ class Feols(ResultAccessorMixin):
             weights=self._observation_weights.values,
         )
 
-    def _leverage_weights(self) -> np.ndarray | None:
-        """Return weights used by the fitted normal equations."""
+    def _normal_equation_weights(self) -> np.ndarray | None:
+        """Return the row weights in the fitted normal equations."""
         return self._observation_weights.values
 
-    def _fixef_weights(self) -> np.ndarray | None:
+    def _fixef_recovery_weights(self) -> np.ndarray | None:
         """Return weights used by fixed-effect coefficient recovery."""
         return self._observation_weights.values
 
@@ -897,14 +898,12 @@ class Feols(ResultAccessorMixin):
             scores=self._scores,
             X=self._X,
             tZX=self._tZX,
-            # Only the frequency-weight correction divides by the weights.
-            weights=(
+            frequency_weights=(
                 observation_weights.reshape((-1, 1))
                 if observation_weights is not None and self._weights_type == "fweights"
                 else None
             ),
-            leverage_weights=self._leverage_weights(),
-            weights_type=self._weights_type,
+            normal_equation_weights=self._normal_equation_weights(),
             vcov_type_detail=self._vcov_type_detail,
             bread=self._bread,
             is_iv=self._is_iv,
@@ -944,7 +943,7 @@ class Feols(ResultAccessorMixin):
             time_arr=_time_arr,
             panel_arr=_panel_arr,
             lag=cast(int | None, self._lag),
-            vcov_type_detail=cast(Literal["NW", "DK"], self._vcov_type_detail),
+            vcov_type_detail=cast(HacVcovTypeOptions, self._vcov_type_detail),
             bread=self._bread,
             is_iv=self._is_iv,
             tXZ=self._tXZ,
@@ -1850,7 +1849,7 @@ class Feols(ResultAccessorMixin):
         self._require_fit_arrays("fixef", arrays="the fitted arrays")
         self._require_estimation_data("fixef")
 
-        fixef_weights = self._fixef_weights()
+        fixef_recovery_weights = self._fixef_recovery_weights()
 
         Y, X = self._model_spec[_ModelMatrixKey.main].get_model_matrix(
             self._data,
@@ -1888,14 +1887,14 @@ class Feols(ResultAccessorMixin):
             ].transform_state,
         )
         fixed_effect_design = contrast_coding.matrix
-        solve_design = fixed_effect_design
-        if fixef_weights is not None:
-            weights_sqrt = np.sqrt(fixef_weights).flatten()
+        fixed_effect_design_for_recovery = fixed_effect_design
+        if fixef_recovery_weights is not None:
+            weights_sqrt = np.sqrt(fixef_recovery_weights).flatten()
             uhat *= weights_sqrt
             weights_diag = diags(weights_sqrt, 0)
-            solve_design = weights_diag.dot(fixed_effect_design)
+            fixed_effect_design_for_recovery = weights_diag.dot(fixed_effect_design)
 
-        alpha = lsqr(solve_design, uhat, atol=atol, btol=btol)[0]
+        alpha = lsqr(fixed_effect_design_for_recovery, uhat, atol=atol, btol=btol)[0]
 
         self._fixef_coefficients = build_fixed_effects(
             fixed_effect_coefficients=alpha,
@@ -1905,7 +1904,7 @@ class Feols(ResultAccessorMixin):
             ].transform_state,
         )
         self._alpha = alpha
-        self._sumFE = solve_design.dot(alpha)
+        self._sumFE = fixed_effect_design_for_recovery.dot(alpha)
 
         return fixed_effects_to_frame(self._fixef_coefficients)
 

--- a/pyfixest/estimation/models/feols_.py
+++ b/pyfixest/estimation/models/feols_.py
@@ -9,6 +9,7 @@ from typing import Any, Literal, cast
 import formulaic
 import numpy as np
 import pandas as pd
+from numpy.typing import NDArray
 from scipy.sparse import csc_matrix, diags, spmatrix
 from scipy.sparse.linalg import lsqr
 from scipy.stats import chi2, f, t
@@ -432,10 +433,8 @@ class Feols(ResultAccessorMixin):
     def _publish_model_matrix(self, model_matrix):
         """Publish structurally immutable formula and observation-weight state."""
         self._model_matrix = model_matrix
-        self._Y_untransformed = model_matrix.dependent.copy()
+        self._response = model_matrix.dependent.to_numpy(dtype=np.float64).flatten()
         self._fe = model_matrix.fixed_effects
-        self._weights_df = model_matrix.weights
-        self._offset_df = model_matrix.offset
         self._na_index = model_matrix.na_index
         # TODO: set dynamically based on naming set in pyfixest.estimation.formula.factor_interaction._encode_i
         independent = model_matrix.independent
@@ -473,14 +472,6 @@ class Feols(ResultAccessorMixin):
         self._observation_weights = self._set_observation_weights()
         self._N = self._observation_weights.n_effective
         self._N_rows = self._observation_weights.n_rows
-        # Compatibility alias: always observation weights, never solver or
-        # GLM working weights. Canonical code uses `_observation_weights`.
-        values = self._observation_weights.values
-        self._weights = (
-            np.ones((self._N_rows, 1), dtype=np.float64)
-            if values is None
-            else values.reshape((-1, 1))
-        )
 
     def _validate_response(self) -> None:
         """Validate estimator-specific response constraints, if any."""
@@ -557,20 +548,49 @@ class Feols(ResultAccessorMixin):
         )
 
     def _set_within_data(self, within_data: WithinLinearData) -> None:
-        """Publish canonical within data and stable array compatibility aliases."""
+        """Publish canonical within data for this fit."""
         self._within_data = within_data
-        self._Y = within_data.response
-        self._X = within_data.design
-        self._Z = (
+        self._X_is_empty = within_data.design.shape[1] == 0
+        self._k = within_data.design.shape[1]
+
+    # Read-only views on the canonical state objects. They exist so that long
+    # established attribute names keep working, but there is exactly one stored
+    # representation: assigning or deleting them is a programming error.
+
+    @property
+    def _Y(self) -> NDArray[np.float64]:
+        """Within-scale dependent variable, in response units."""
+        return self._within_data.response
+
+    @property
+    def _X(self) -> NDArray[np.float64]:
+        """Within-scale design matrix, not premultiplied by weights."""
+        return self._within_data.design
+
+    @property
+    def _Z(self) -> NDArray[np.float64]:
+        """Within-scale instruments; the design itself outside IV models."""
+        within_data = self._within_data
+        return (
             within_data.design
             if within_data.instruments is None
             else within_data.instruments
         )
-        self._X_is_empty = within_data.design.shape[1] == 0
-        self._k = within_data.design.shape[1]
+
+    @property
+    def _weights(self) -> NDArray[np.float64]:
+        """Observation weights as a column vector.
+
+        Unweighted fits store no weight vector, so the ones column is built on
+        access rather than kept alive for the lifetime of the result.
+        """
+        values = self._observation_weights.values
+        if values is None:
+            return np.ones((self._observation_weights.n_rows, 1), dtype=np.float64)
+        return values.reshape((-1, 1))
 
     def _get_predictors(self) -> None:
-        self._Y_hat_link = self._Y_untransformed.to_numpy().flatten() - self.resid()
+        self._Y_hat_link = self._response - self.resid()
         self._Y_hat_response = self._Y_hat_link
 
     def get_fit(self) -> None:
@@ -803,11 +823,17 @@ class Feols(ResultAccessorMixin):
         return self._observation_weights.values
 
     def _vcov_hetero(self):
+        observation_weights = self._observation_weights.values
         return vcov_hetero(
             scores=self._scores,
             X=self._X,
             tZX=self._tZX,
-            weights=self._weights,
+            # Only the frequency-weight correction divides by the weights.
+            weights=(
+                observation_weights.reshape((-1, 1))
+                if observation_weights is not None and self._weights_type == "fweights"
+                else None
+            ),
             leverage_weights=self._leverage_weights(),
             weights_type=self._weights_type,
             vcov_type_detail=self._vcov_type_detail,
@@ -926,22 +952,22 @@ class Feols(ResultAccessorMixin):
             attributes += ["_data", "_model_matrix"]
 
         if self._lean:
+            # The array aliases are read-only views, so the state objects
+            # backing them are what has to go.
             attributes += [
                 "_data",
-                "_X",
-                "_Y",
-                "_Z",
+                "_within_data",
+                "_observation_weights",
                 "_cluster_df",
                 "_tXZ",
                 "_tZy",
                 "_tZX",
-                "_weights",
                 "_scores",
                 "_tZZinv",
                 "_u_hat",
                 "_Y_hat_link",
                 "_Y_hat_response",
-                "_Y_untransformed",
+                "_response",
                 "_model_matrix",
             ]
 
@@ -1675,7 +1701,7 @@ class Feols(ResultAccessorMixin):
         med.fit(
             X=X,
             Y=Y,
-            weights=self._weights,
+            weights=self._observation_weights.values,
             store=True,
         )
 
@@ -2139,7 +2165,13 @@ class Feols(ResultAccessorMixin):
             )
 
         else:
-            weights = self._weights.flatten()
+            observation_weights = self._observation_weights.values
+            # The demeaning kernel behind the fast path always needs a vector.
+            weights = (
+                np.ones(self._N_rows, dtype=np.float64)
+                if observation_weights is None
+                else observation_weights
+            )
             fval_df = (
                 self._data[self._fixef.split("+")] if self._fixef is not None else None
             )

--- a/pyfixest/estimation/models/feols_.py
+++ b/pyfixest/estimation/models/feols_.py
@@ -1030,19 +1030,21 @@ class Feols(ResultAccessorMixin):
             # backing them are what has to go.
             attributes += [
                 "_data",
+                "_model_matrix",
                 "_within_data",
                 "_observation_weights",
+                "_demean_cache",
+                "_fe",
+                "_response",
                 "_cluster_df",
                 "_tXZ",
                 "_tZy",
                 "_tZX",
-                "_scores",
                 "_tZZinv",
+                "_scores",
                 "_u_hat",
                 "_Y_hat_link",
                 "_Y_hat_response",
-                "_response",
-                "_model_matrix",
             ]
 
         for attr in attributes:

--- a/pyfixest/estimation/models/feols_.py
+++ b/pyfixest/estimation/models/feols_.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import re
 import warnings
 from collections.abc import Mapping
+from functools import partial
 from importlib import import_module
 from typing import Any, Literal, cast
 
@@ -229,8 +230,8 @@ class Feols(ResultAccessorMixin):
         "scipy.sparse.linalg.lsqr"],
         default is "scipy.linalg.solve". Solver to use for the estimation.
     _data: pd.DataFrame
-        The data frame used in the estimation. None if arguments `lean = True` or
-        `store_data = False`.
+        The data frame used in the estimation. Deleted if arguments `lean = True`
+        or `store_data = False`.
     _model_name: str
         The name of the model. Usually just the formula string. If split estimation is used,
         the model name will include the split variable and value.
@@ -321,6 +322,10 @@ class Feols(ResultAccessorMixin):
         self._store_data = store_data
         self._copy_data = copy_data
         self._lean = lean
+        # Storage cleanup runs at the very end of the fit, so `lean` alone does
+        # not say whether the fit arrays are still there. Estimation itself goes
+        # through the same guarded methods.
+        self._fit_state_discarded = False
         self._context = capture_context(context)
 
         self._support_crv3_inference = True
@@ -521,6 +526,7 @@ class Feols(ResultAccessorMixin):
         ``LsmrDemeaner(backend='within', preconditioner=...)`` to skip the
         setup phase on a later fit over the same design.
         """
+        self._require_fit_arrays("preconditioner", arrays="the demeaning caches")
         return self._demean_cache.lookup_preconditioner.get(self._na_index)
 
     def _drop_multicollinear_within_data(
@@ -637,6 +643,33 @@ class Feols(ResultAccessorMixin):
         """Yield this fitted result to the result container."""
         return (self,)
 
+    def _require_fit_arrays(
+        self,
+        method: str,
+        *,
+        arrays: str,
+        remedy: str = "Refit with lean=False.",
+    ) -> None:
+        """Reject a call whose input arrays `lean=True` discarded."""
+        if self._lean and self._fit_state_discarded:
+            raise RuntimeError(
+                f"{method}() is unavailable after fitting with lean=True because "
+                f"{arrays} were discarded. {remedy}"
+            )
+
+    def _require_estimation_data(
+        self,
+        method: str,
+        *,
+        remedy: str = "Refit with store_data=True.",
+    ) -> None:
+        """Reject a call whose estimation data the storage options discarded."""
+        if not hasattr(self, "_data"):
+            raise RuntimeError(
+                f"{method}() is unavailable when store_data=False or lean=True "
+                f"because the estimation data were discarded. {remedy}"
+            )
+
     def vcov(
         self,
         vcov: str | dict[str, str],
@@ -659,8 +692,10 @@ class Feols(ResultAccessorMixin):
         vcov_kwargs : Optional[dict[str, any]]
              Additional keyword arguments for the variance-covariance matrix.
         data: Optional[DataFrameType], optional
-            The data used for estimation. If None, tries to fetch the data from the
-            model object. Defaults to None.
+            The already-filtered estimation sample in its original estimation
+            order. This is required for data-dependent covariance updates when
+            the fitted model does not retain its input data. If None, tries to
+            fetch the data from the model object. Defaults to None.
 
 
         Returns
@@ -688,27 +723,50 @@ class Feols(ResultAccessorMixin):
         See [On Small Sample Corrections](/explanation/ssc.qmd) for how the
         `ssc` adjustments interact with each estimator.
         """
-        # Assuming `data` is the DataFrame in question
+        self._require_fit_arrays(
+            "vcov",
+            arrays="the required estimation arrays",
+            remedy="Set vcov at estimation time or refit with lean=False.",
+        )
 
-        data_to_check = data if data is not None else self._data
-        try:
-            data_to_check = _narwhals_to_pandas(data_to_check)
-        except TypeError as e:
-            raise TypeError(
-                f"The data set must be a DataFrame type. Received: {type(data)}"
-            ) from e
+        data_to_check: pd.DataFrame | None
+        if data is None:
+            data_to_check = getattr(self, "_data", None)
+        else:
+            try:
+                data_to_check = _narwhals_to_pandas(data)
+            except TypeError as e:
+                raise TypeError(
+                    f"The data set must be a DataFrame type. Received: {type(data)}"
+                ) from e
+            if len(data_to_check) != self._N_rows:
+                raise ValueError(
+                    "`data` passed to vcov() must contain exactly the already-filtered "
+                    "estimation sample in its original estimation order; expected "
+                    f"{self._N_rows} rows, received {len(data_to_check)}."
+                )
 
         # assign estimated fixed effects, and fixed effects nested within cluster.
 
         # deparse vcov input
-        _check_vcov_input(vcov=vcov, vcov_kwargs=vcov_kwargs, data=self._data)
+        _check_vcov_input(vcov=vcov, vcov_kwargs=vcov_kwargs, data=data_to_check)
 
-        (
-            self._vcov_type,
-            self._vcov_type_detail,
-            self._is_clustered,
-            self._clustervar,
-        ) = _deparse_vcov_input(vcov, self._has_fixef, self._is_iv)
+        vcov_type, vcov_type_detail, is_clustered, clustervar = _deparse_vcov_input(
+            vcov, self._has_fixef, self._is_iv
+        )
+
+        # Reject before any inference state is overwritten, so a failed update
+        # leaves the previous covariance estimate intact.
+        if vcov_type in {"HAC", "CRV"} and data_to_check is None:
+            self._require_estimation_data(
+                "vcov",
+                remedy="Pass the estimation sample via data= or refit with store_data=True.",
+            )
+
+        self._vcov_type = vcov_type
+        self._vcov_type_detail = vcov_type_detail
+        self._is_clustered = is_clustered
+        self._clustervar = clustervar
 
         self._bread = _compute_bread(
             self._is_iv, self._tXZ, self._tZZinv, self._tZX, self._hessian
@@ -728,6 +786,7 @@ class Feols(ResultAccessorMixin):
             self._vcov = self._ssc * self._vcov_hetero()
 
         elif self._vcov_type == "HAC":
+            assert data_to_check is not None
             kw = vcov_kwargs or {}
             self._lag = kw.get("lag")
             self._time_id = kw.get("time_id")
@@ -735,10 +794,10 @@ class Feols(ResultAccessorMixin):
             self._ssc, self._df_k, self._df_t = get_ssc(
                 **self._make_ssc_kwargs(
                     vcov_type="HAC",
-                    G=np.unique(self._data[self._time_id]).shape[0],
+                    G=np.unique(data_to_check[self._time_id]).shape[0],
                 )  # number of unique time periods T used
             )
-            self._vcov = self._ssc * self._vcov_hac()
+            self._vcov = self._ssc * self._vcov_hac(data=data_to_check)
 
         elif self._vcov_type == "nid":
             self._ssc, self._df_k, self._df_t = get_ssc(
@@ -747,8 +806,9 @@ class Feols(ResultAccessorMixin):
             self._vcov = self._ssc * self._vcov_nid()
 
         elif self._vcov_type == "CRV":
+            assert data_to_check is not None
             prep = prepare_cluster_state(
-                data=data if data is not None else self._data,
+                data=data_to_check,
                 clustervar=self._clustervar,
                 ssc_dict=self._ssc_dict,
                 fixef=self._fixef,
@@ -761,7 +821,7 @@ class Feols(ResultAccessorMixin):
                 prep=prep,
                 k=self._k,
                 make_ssc_kwargs=self._make_ssc_kwargs,
-                cluster_vcov=self._vcov_crv_cluster,
+                cluster_vcov=partial(self._vcov_crv_cluster, data=data_to_check),
             )
         # update p-value, t-stat, standard error, confint
         self.get_inference()
@@ -792,7 +852,11 @@ class Feols(ResultAccessorMixin):
         }
 
     def _vcov_crv_cluster(
-        self, clustid: np.ndarray, cluster_col: np.ndarray
+        self,
+        clustid: np.ndarray,
+        cluster_col: np.ndarray,
+        *,
+        data: pd.DataFrame,
     ) -> np.ndarray:
         "Pick CRV1 / CRV3-fast / CRV3-slow for one cluster column."
         if self._vcov_type_detail == "CRV1":
@@ -803,8 +867,13 @@ class Feols(ResultAccessorMixin):
                 f"CRV3 inference is not for models of type '{self._method}'."
             )
         use_fast = not self._has_fixef and self._method == "feols" and not self._is_iv
-        crv3 = self._vcov_crv3_fast if use_fast else self._vcov_crv3_slow
-        return crv3(clustid=clustid, cluster_col=cluster_col)
+        if use_fast:
+            return self._vcov_crv3_fast(clustid=clustid, cluster_col=cluster_col)
+        return self._vcov_crv3_slow(
+            clustid=clustid,
+            cluster_col=cluster_col,
+            data=data,
+        )
 
     def _vcov_iid(self):
         return vcov_iid_ols(
@@ -843,10 +912,9 @@ class Feols(ResultAccessorMixin):
             tZZinv=self._tZZinv,
         )
 
-    def _vcov_hac(self):
+    def _vcov_hac(self, *, data: pd.DataFrame):
         _time_id = self._time_id
         _panel_id = self._panel_id
-        _data = self._data
 
         if not self._support_hac_inference:
             raise NotImplementedError(
@@ -861,22 +929,22 @@ class Feols(ResultAccessorMixin):
 
         # some data checks on input pandas df
         # time needs to be numeric or date else we cannot sort by time
-        if not np.issubdtype(_data[_time_id], np.number) and not np.issubdtype(
-            _data[_time_id], np.datetime64
+        if not np.issubdtype(data[_time_id], np.number) and not np.issubdtype(
+            data[_time_id], np.datetime64
         ):
             raise ValueError(
                 "The time variable must be numeric or date, else we cannot sort by time."
             )
 
-        _time_arr = _data[_time_id].to_numpy()
-        _panel_arr = _data[_panel_id].to_numpy() if _panel_id is not None else None
+        _time_arr = data[_time_id].to_numpy()
+        _panel_arr = data[_panel_id].to_numpy() if _panel_id is not None else None
 
         return vcov_hac(
             scores=self._scores,
             time_arr=_time_arr,
             panel_arr=_panel_arr,
-            lag=self._lag,
-            vcov_type_detail=self._vcov_type_detail,
+            lag=cast(int | None, self._lag),
+            vcov_type_detail=cast(Literal["NW", "DK"], self._vcov_type_detail),
             bread=self._bread,
             is_iv=self._is_iv,
             tXZ=self._tXZ,
@@ -911,7 +979,13 @@ class Feols(ResultAccessorMixin):
             cluster_col=cluster_col,
         )
 
-    def _vcov_crv3_slow(self, clustid, cluster_col):
+    def _vcov_crv3_slow(
+        self,
+        clustid: np.ndarray,
+        cluster_col: np.ndarray,
+        *,
+        data: pd.DataFrame,
+    ) -> np.ndarray:
         beta_jack = np.zeros((len(clustid), self._k))
 
         # lazy loading to avoid circular import
@@ -920,10 +994,10 @@ class Feols(ResultAccessorMixin):
 
         for ixg, g in enumerate(clustid):
             # direct leave one cluster out implementation
-            data = self._data[~np.equal(g, cluster_col)]
+            refit_data = data[~np.equal(g, cluster_col)]
             fit = fit_(
                 fml=self._fml,
-                data=data,
+                data=refit_data,
                 vcov="iid",
                 weights=self._weights_name,
                 weights_type=self._weights_type,
@@ -974,6 +1048,9 @@ class Feols(ResultAccessorMixin):
         for attr in attributes:
             if hasattr(self, attr):
                 delattr(self, attr)
+
+        if self._lean:
+            self._fit_state_discarded = True
 
     def wald_test(self, R=None, q=None, distribution="F"):
         """
@@ -1187,6 +1264,9 @@ class Feols(ResultAccessorMixin):
                     "Wild cluster bootstrap is not supported for WLS estimation."
                 )
 
+        self._require_fit_arrays("wildboottest", arrays="the fitted arrays")
+        self._require_estimation_data("wildboottest")
+
         cluster_list = []
 
         if cluster is not None and isinstance(cluster, str):
@@ -1380,6 +1460,9 @@ class Feols(ResultAccessorMixin):
             raise ValueError(
                 f"Variable {treatment} not found in the model's coefficients."
             )
+
+        self._require_fit_arrays("ccv", arrays="the fitted arrays")
+        self._require_estimation_data("ccv")
 
         if cluster is None:
             if self._clustervar is None:
@@ -1657,6 +1740,12 @@ class Feols(ResultAccessorMixin):
             only_coef=only_coef,
         )
 
+        self._require_fit_arrays("decompose", arrays="the fitted arrays")
+        # A cluster variable or an absorbed fixed effect is read back from the
+        # estimation sample; the plain covariate case works on arrays alone.
+        if cluster is not None or self._is_clustered or self._has_fixef:
+            self._require_estimation_data("decompose")
+
         nthreads_int = -1 if nthreads is None else nthreads
 
         rng = (
@@ -1748,8 +1837,6 @@ class Feols(ResultAccessorMixin):
         fixed_effects.head()
         ```
         """
-        fixef_weights = self._fixef_weights()
-
         if not self._has_fixef:
             raise ValueError("The regression model does not have fixed effects.")
 
@@ -1757,6 +1844,11 @@ class Feols(ResultAccessorMixin):
             raise NotImplementedError(
                 "The fixef() method is currently not supported for IV models."
             )
+
+        self._require_fit_arrays("fixef", arrays="the fitted arrays")
+        self._require_estimation_data("fixef")
+
+        fixef_weights = self._fixef_weights()
 
         Y, X = self._model_spec[_ModelMatrixKey.main].get_model_matrix(
             self._data,
@@ -1908,6 +2000,11 @@ class Feols(ResultAccessorMixin):
         if interval is not None:
             _validate_literal_argument(interval, PredictionErrorOptions)
 
+        if newdata is None or se_fit or interval == "prediction":
+            self._require_fit_arrays(
+                "predict", arrays="the fitted design and residual arrays"
+            )
+
         if newdata is None:
             # note: no need to worry about fixed effects, as not supported with
             # prediction errors; will throw error later;
@@ -1935,6 +2032,11 @@ class Feols(ResultAccessorMixin):
             # matching how unseen fixed-effect levels are handled below.
             valid_idx = valid_idx[~unseen[valid_idx]]
             if self._has_fixef:
+                # Fixed-effect levels are recovered from the estimation sample.
+                self._require_fit_arrays(
+                    "predict", arrays="the fitted design and residual arrays"
+                )
+                self._require_estimation_data("predict")
                 fe_spec = self._model_spec[_ModelMatrixKey.fixed_effects]
                 check_fe_dtype_compatibility(fe_spec, newdata)
                 # na_action="ignore" keeps unseen-level rows as NaN codes
@@ -2088,6 +2190,9 @@ class Feols(ResultAccessorMixin):
         # check that resampvar in _coefnames
         if resampvar_ not in self._coefnames:
             raise ValueError(f"{resampvar_} not found in the model's coefficients.")
+
+        self._require_fit_arrays("ritest", arrays="the fitted arrays")
+        self._require_estimation_data("ritest")
 
         if cluster is not None and cluster not in self._data:
             raise ValueError(f"The variable {cluster} is not found in the data.")
@@ -2328,6 +2433,7 @@ class Feols(ResultAccessorMixin):
                 "rows cannot safely update the complete fitted-result state; use the "
                 "returned coefficients instead."
             )
+        self._require_fit_arrays("update", arrays="the fitted design arrays")
         if not np.all(X_new[:, 0] == 1):
             X_new = np.column_stack((np.ones(len(X_new)), X_new))
         X_n_plus_1 = np.vstack((self._X, X_new))
@@ -2341,7 +2447,7 @@ class Feols(ResultAccessorMixin):
 def _check_vcov_input(
     vcov: str | dict[str, str],
     vcov_kwargs: dict[str, Any] | None,
-    data: pd.DataFrame,
+    data: pd.DataFrame | None,
 ):
     """
     Check the input for the vcov argument in the Feols class.
@@ -2352,8 +2458,8 @@ def _check_vcov_input(
         The vcov argument passed to the Feols class.
     vcov_kwargs : Optional[dict[str, Any]]
         The vcov_kwargs argument passed to the Feols class.
-    data : pd.DataFrame
-        The data passed to the Feols class.
+    data : pd.DataFrame or None
+        The estimation sample, or None when the fitted model retains none.
 
     Returns
     -------
@@ -2373,6 +2479,11 @@ def _check_vcov_input(
 
     if isinstance(vcov, list):
         assert all(isinstance(v, str) for v in vcov), "vcov list must contain strings"
+        if data is None:
+            raise RuntimeError(
+                "A vcov column list requires estimation data. Pass data= or fit "
+                "with store_data=True."
+            )
         assert all(v in data.columns for v in vcov), (
             "vcov list must contain columns in the data"
         )

--- a/pyfixest/estimation/models/feols_.py
+++ b/pyfixest/estimation/models/feols_.py
@@ -25,14 +25,19 @@ from pyfixest.estimation.formula.formulaic_compat import (
 from pyfixest.estimation.formula.model_matrix import _ModelMatrixKey
 from pyfixest.estimation.formula.parse import Formula as FixestFormula
 from pyfixest.estimation.internals.collinearity import drop_multicollinear_variables
-from pyfixest.estimation.internals.demean_ import DemeanCache
+from pyfixest.estimation.internals.demean_ import DemeanCache, DemeanedData
 from pyfixest.estimation.internals.families import T_DIST, InferenceDist
 from pyfixest.estimation.internals.fit_ import fit_ols
 from pyfixest.estimation.internals.literals import (
     PredictionErrorOptions,
     PredictionType,
     SolverOptions,
+    WeightsTypeOptions,
     _validate_literal_argument,
+)
+from pyfixest.estimation.internals.model_state import (
+    ObservationWeights,
+    WithinLinearData,
 )
 from pyfixest.estimation.internals.vcov_ import (
     vcov_crv1,
@@ -80,10 +85,10 @@ class Feols(ResultAccessorMixin):
     Non user-facing class to estimate a linear regression via OLS.
 
     Users should not directly instantiate this class,
-    but rather use the [feols()](/reference/estimation.api.feols.feols.qmd) function. Note that
-    no demeaning is performed in this class: demeaning is performed in the
-    FixestMulti class (to allow for caching of demeaned variables for multiple
-    estimation).
+    but rather use the [feols()](/reference/estimation.api.feols.feols.qmd)
+    function. This class constructs within-scale arrays through a shared
+    ``DemeanCache``; the estimation runner supplies that cache for reuse across
+    multiple fits.
 
     Parameters
     ----------
@@ -259,7 +264,7 @@ class Feols(ResultAccessorMixin):
         weights: str | None,
         weights_type: str | None,
         collin_tol: float,
-        lookup_demeaned_data: dict[frozenset[int], pd.DataFrame],
+        lookup_demeaned_data: dict[frozenset[int], DemeanedData],
         solver: SolverOptions = "np.linalg.solve",
         demeaner: AnyDemeaner | None = None,
         lookup_preconditioner: dict[frozenset[int], Preconditioner] | None = None,
@@ -425,32 +430,35 @@ class Feols(ResultAccessorMixin):
     # Deliberately untyped: an annotation makes mypy check this body, whose published
     # attribute types are still transitional or loose; see the typing follow-up.
     def _publish_model_matrix(self, model_matrix):
-        """Publish one structurally immutable state through compatibility aliases."""
+        """Publish structurally immutable formula and observation-weight state."""
         self._model_matrix = model_matrix
-        self._Y = model_matrix.dependent
-        self._Y_untransformed = self._Y.copy()
-        self._X = model_matrix.independent
+        self._Y_untransformed = model_matrix.dependent.copy()
         self._fe = model_matrix.fixed_effects
-        self._endogvar = model_matrix.endogenous
-        self._Z = model_matrix.instruments
         self._weights_df = model_matrix.weights
         self._offset_df = model_matrix.offset
         self._na_index = model_matrix.na_index
         # TODO: set dynamically based on naming set in pyfixest.estimation.formula.factor_interaction._encode_i
+        independent = model_matrix.independent
         is_icovar = (
-            self._X.columns.str.contains(r"^.+::.+$") if not self._X.empty else None
+            independent.columns.str.contains(r"^.+::.+$")
+            if not independent.empty
+            else None
         )
         self._icovars = (
-            self._X.columns[is_icovar].tolist()
+            independent.columns[is_icovar].tolist()
             if is_icovar is not None and is_icovar.any()
             else None
         )
-        self._X_is_empty = self._X.shape[0] == 0
+        self._X_is_empty = independent.shape[1] == 0
         self._model_spec = model_matrix.model_spec
 
-        self._coefnames = self._X.columns.tolist()
-        self._coefnames_z = self._Z.columns.tolist() if self._Z is not None else None
-        self._depvar = self._Y.columns[0]
+        self._coefnames = independent.columns.tolist()
+        self._coefnames_z = (
+            model_matrix.instruments.columns.tolist()
+            if model_matrix.instruments is not None
+            else None
+        )
+        self._depvar = model_matrix.dependent.columns[0]
 
         self._has_fixef = self._fe is not None
         self._fixef = (
@@ -462,63 +470,54 @@ class Feols(ResultAccessorMixin):
         self._k_fe = self._fe.nunique(axis=0) if self._has_fixef else None
         self._n_fe = len(self._k_fe) if self._has_fixef else 0
 
-        self._weights = self._set_weights()
-        self._N, self._N_rows = self._set_nobs()
+        self._observation_weights = self._set_observation_weights()
+        self._N = self._observation_weights.n_effective
+        self._N_rows = self._observation_weights.n_rows
+        # Compatibility alias: always observation weights, never solver or
+        # GLM working weights. Canonical code uses `_observation_weights`.
+        values = self._observation_weights.values
+        self._weights = (
+            np.ones((self._N_rows, 1), dtype=np.float64)
+            if values is None
+            else values.reshape((-1, 1))
+        )
 
     def _validate_response(self) -> None:
         """Validate estimator-specific response constraints, if any."""
 
-    def _set_nobs(self) -> tuple[int, int]:
-        """
-        Fetch the number of observations used in fitting the regression model.
+    def _set_observation_weights(self) -> ObservationWeights:
+        """Build canonical user-scale observation weights for this row sample."""
+        n_rows = len(self._model_matrix.dependent)
+        if self._model_matrix.weights is None:
+            return ObservationWeights.unweighted(n_rows=n_rows)
 
-        Returns
-        -------
-        tuple[int, int]
-            A tuple containing the total number of observations and the number of rows
-            in the dependent variable array.
-        """
-        N_rows = len(self._Y)
-        if self._weights_type == "aweights":
-            N = N_rows
-        elif self._weights_type == "fweights":
-            N = np.sum(self._weights)
+        assert self._weights_type in ("aweights", "fweights")
+        weights_kind = cast(WeightsTypeOptions, self._weights_type)
+        return ObservationWeights.from_values(
+            self._model_matrix.weights.to_numpy().reshape(-1),
+            kind=weights_kind,
+        )
 
-        return N, N_rows
+    def _prepare_within_data(self) -> WithinLinearData:
+        """Return fixed-effect-residualized arrays in their original units."""
+        response_frame = self._model_matrix.dependent
+        design_frame = self._model_matrix.independent
+        response = response_frame.to_numpy(dtype=np.float64)
+        design = design_frame.to_numpy(dtype=np.float64)
 
-    def _set_weights(self) -> np.ndarray:
-        """
-        Return the weights used in the regression model.
-
-        Returns
-        -------
-        np.ndarray
-            The weights used in the regression model.
-            If no weights are used, returns an array of ones
-            with the same length as the dependent variable array.
-        """
-        N = len(self._Y)
-
-        if self._weights_df is not None:
-            _weights = self._weights_df.to_numpy()
-        else:
-            _weights = np.ones(N)
-
-        return _weights.reshape((N, 1))
-
-    def demean(self):
-        "Demean the dependent variable and covariates by the fixed effect(s)."
-        if self._has_fixef:
-            self._Yd, self._Xd, _ = self._demean_cache.demean_yx(
-                self._Y,
-                self._X,
-                self._fe,
-                self._weights.flatten(),
-                self._na_index,
-                self._demeaner,
+        if self._model_matrix.fixed_effects is not None:
+            response, design, _ = self._demean_cache.demean_yx(
+                response,
+                design,
+                y_names=response_frame.columns,
+                x_names=design_frame.columns,
+                fe=self._model_matrix.fixed_effects.to_numpy(),
+                weights=self._observation_weights.values,
+                na_index=self._na_index,
+                demeaner=self._demeaner,
             )
-        else:
-            self._Yd, self._Xd = self._Y, self._X
+
+        return WithinLinearData(response=response, design=design)
 
     @property
     def preconditioner(self) -> Preconditioner | None:
@@ -533,36 +532,42 @@ class Feols(ResultAccessorMixin):
         """
         return self._demean_cache.lookup_preconditioner.get(self._na_index)
 
-    def to_array(self):
-        "Convert estimation data frames to np arrays."
-        self._Y, self._X = (
-            self._Yd.to_numpy(),
-            self._Xd.to_numpy(),
-        )
-
-    def wls_transform(self):
-        "Transform model matrices for WLS Estimation."
-        if self._has_weights:
-            w = np.sqrt(self._weights)
-            self._Y = self._Y * w
-            self._X = self._X * w
-
-    def drop_multicol_vars(self):
-        "Detect and drop multicollinear variables."
-        if self._X.shape[1] > 0:
+    def _drop_multicollinear_within_data(
+        self, within_data: WithinLinearData
+    ) -> WithinLinearData:
+        """Return within data after the established unweighted rank check."""
+        design = within_data.design
+        if design.shape[1] > 0:
             (
-                self._X,
+                design,
                 self._coefnames,
                 self._collin_vars,
                 self._collin_index,
             ) = drop_multicollinear_variables(
-                self._X,
+                design,
                 self._coefnames,
                 self._collin_tol,
             )
-        # update X_is_empty
-        self._X_is_empty = self._X.shape[1] == 0
-        self._k = self._X.shape[1] if not self._X_is_empty else 0
+
+        return WithinLinearData(
+            response=within_data.response,
+            design=design,
+            instruments=within_data.instruments,
+            endogenous=within_data.endogenous,
+        )
+
+    def _set_within_data(self, within_data: WithinLinearData) -> None:
+        """Publish canonical within data and stable array compatibility aliases."""
+        self._within_data = within_data
+        self._Y = within_data.response
+        self._X = within_data.design
+        self._Z = (
+            within_data.design
+            if within_data.instruments is None
+            else within_data.instruments
+        )
+        self._X_is_empty = within_data.design.shape[1] == 0
+        self._k = within_data.design.shape[1]
 
     def _get_predictors(self) -> None:
         self._Y_hat_link = self._Y_untransformed.to_numpy().flatten() - self.resid()
@@ -576,17 +581,19 @@ class Feols(ResultAccessorMixin):
         -------
         None
         """
-        self.demean()
-        self.to_array()
-        self.drop_multicol_vars()
-        self.wls_transform()
+        within_data = self._drop_multicollinear_within_data(self._prepare_within_data())
+        self._set_within_data(within_data)
 
         if self._X_is_empty:
-            self._u_hat = self._Y
+            self._u_hat = within_data.response.flatten()
         else:
-            fit = fit_ols(X=self._X, Y=self._Y, solver=self._solver)
+            fit = fit_ols(
+                X=within_data.design,
+                Y=within_data.response,
+                weights=self._observation_weights.values,
+                solver=self._solver,
+            )
 
-            self._Z = self._X
             self._tZX = fit.tZX
             self._tZy = fit.tZy
             self._beta_hat = fit.beta
@@ -745,7 +752,7 @@ class Feols(ResultAccessorMixin):
         self,
         *,
         vcov_type: str,
-        G: int | list[int],
+        G: int | float | list[int],
         vcov_sign: int = 1,
         k_fe_nested: int = 0,
         n_fe_fully_nested: int = 0,
@@ -780,7 +787,16 @@ class Feols(ResultAccessorMixin):
         return crv3(clustid=clustid, cluster_col=cluster_col)
 
     def _vcov_iid(self):
-        return vcov_iid_ols(residuals=self._u_hat, bread=self._bread, N=self._N)
+        return vcov_iid_ols(
+            residuals=self._u_hat,
+            bread=self._bread,
+            N=self._N,
+            weights=self._observation_weights.values,
+        )
+
+    def _leverage_weights(self) -> np.ndarray | None:
+        """Return weights used by the fitted normal equations."""
+        return self._observation_weights.values
 
     def _vcov_hetero(self):
         return vcov_hetero(
@@ -788,6 +804,7 @@ class Feols(ResultAccessorMixin):
             X=self._X,
             tZX=self._tZX,
             weights=self._weights,
+            leverage_weights=self._leverage_weights(),
             weights_type=self._weights_type,
             vcov_type_detail=self._vcov_type_detail,
             bread=self._bread,
@@ -858,6 +875,7 @@ class Feols(ResultAccessorMixin):
         return vcov_crv3_fast(
             X=self._X,
             Y=self._Y,
+            weights=self._observation_weights.values,
             beta_hat=self._beta_hat,
             clustid=clustid,
             cluster_col=cluster_col,
@@ -909,9 +927,6 @@ class Feols(ResultAccessorMixin):
                 "_X",
                 "_Y",
                 "_Z",
-                "_Xd",
-                "_Yd",
-                "_Zd",
                 "_cluster_df",
                 "_tXZ",
                 "_tZy",
@@ -1464,8 +1479,8 @@ class Feols(ResultAccessorMixin):
             X = csc_matrix(X) if output == "sparse" else X
 
         else:
-            Y = self._Y.flatten() / np.sqrt(self._weights.flatten())
-            X = self._X / np.sqrt(self._weights)
+            Y = self._Y.flatten()
+            X = self._X
             xnames = self._coefnames
 
         X = csc_matrix(X) if output == "sparse" else X
@@ -1858,14 +1873,13 @@ class Feols(ResultAccessorMixin):
         if newdata is None:
             # note: no need to worry about fixed effects, as not supported with
             # prediction errors; will throw error later;
-            # divide by sqrt(weights) as self._X is "weighted"
             X = self._X
             y_hat = (
                 self._Y_hat_link
                 if type == "link" or self._method == "feols"
                 else self._Y_hat_response
             )
-            n_observations = self._N
+            n_observations = self._N_rows
         else:
             newdata = _narwhals_to_pandas(newdata).reset_index(drop=True)
             n_observations = newdata.shape[0]

--- a/pyfixest/estimation/models/feols_.py
+++ b/pyfixest/estimation/models/feols_.py
@@ -798,6 +798,10 @@ class Feols(ResultAccessorMixin):
         """Return weights used by the fitted normal equations."""
         return self._observation_weights.values
 
+    def _fixef_weights(self) -> np.ndarray | None:
+        """Return weights used by fixed-effect coefficient recovery."""
+        return self._observation_weights.values
+
     def _vcov_hetero(self):
         return vcov_hetero(
             scores=self._scores,
@@ -1712,7 +1716,7 @@ class Feols(ResultAccessorMixin):
         fixed_effects.head()
         ```
         """
-        weights_sqrt = np.sqrt(self._weights).flatten()
+        fixef_weights = self._fixef_weights()
 
         if not self._has_fixef:
             raise ValueError("The regression model does not have fixed effects.")
@@ -1757,13 +1761,15 @@ class Feols(ResultAccessorMixin):
                 _ModelMatrixKey.fixed_effects
             ].transform_state,
         )
-        D2 = contrast_coding.matrix
-        if self._has_weights:
+        fixed_effect_design = contrast_coding.matrix
+        solve_design = fixed_effect_design
+        if fixef_weights is not None:
+            weights_sqrt = np.sqrt(fixef_weights).flatten()
             uhat *= weights_sqrt
             weights_diag = diags(weights_sqrt, 0)
-            D2 = weights_diag.dot(D2)
+            solve_design = weights_diag.dot(fixed_effect_design)
 
-        alpha = lsqr(D2, uhat, atol=atol, btol=btol)[0]
+        alpha = lsqr(solve_design, uhat, atol=atol, btol=btol)[0]
 
         self._fixef_coefficients = build_fixed_effects(
             fixed_effect_coefficients=alpha,
@@ -1773,7 +1779,7 @@ class Feols(ResultAccessorMixin):
             ].transform_state,
         )
         self._alpha = alpha
-        self._sumFE = D2.dot(alpha)
+        self._sumFE = solve_design.dot(alpha)
 
         return fixed_effects_to_frame(self._fixef_coefficients)
 

--- a/pyfixest/estimation/models/feols_.py
+++ b/pyfixest/estimation/models/feols_.py
@@ -1327,9 +1327,11 @@ class Feols(ResultAccessorMixin):
         fit.ccv(treatment="D", pk=0.05, qk=0.5, n_splits=8, seed=123).head()
         ```
         """
-        assert self._supports_cluster_causal_variance, (
-            "The model does not support the causal cluster variance estimator."
-        )
+        if not self._supports_cluster_causal_variance:
+            raise NotImplementedError(
+                "The causal cluster variance estimator is not supported for models "
+                f"of type '{self._method}'."
+            )
         assert isinstance(treatment, str), "treatment must be a string."
         assert isinstance(cluster, str) or cluster is None, (
             "cluster must be a string or None."
@@ -1342,6 +1344,10 @@ class Feols(ResultAccessorMixin):
         if self._has_fixef:
             raise NotImplementedError(
                 "The causal cluster variance estimator is currently not supported for models with fixed effects."
+            )
+        if self._has_weights:
+            raise NotImplementedError(
+                "The causal cluster variance estimator is currently not supported for models with weights."
             )
 
         if treatment not in self._coefnames:
@@ -2233,7 +2239,8 @@ class Feols(ResultAccessorMixin):
         y_new : np.ndarray
             Outcome values for new data points.
         inplace : bool, optional
-            Whether to update the model object in place. Defaults to False.
+            Must be `False`. In-place updates are unsupported because appending
+            design rows cannot reconstruct the complete fitted-result state.
 
         Returns
         -------
@@ -2244,7 +2251,8 @@ class Feols(ResultAccessorMixin):
         -----
         Updates the coefficients in closed form via the Sherman-Morrison
         identity instead of refitting on the full sample. `X_new` has to include
-        the intercept column. Models with fixed effects are not supported.
+        the intercept column. The returned coefficients do not mutate the fitted
+        result. Models with fixed effects are not supported.
 
         Examples
         --------
@@ -2270,18 +2278,30 @@ class Feols(ResultAccessorMixin):
             raise NotImplementedError(
                 "The update() method is currently not supported for models with fixed effects."
             )
+        if self._method != "feols":
+            raise NotImplementedError(
+                "The update() method is currently only supported for OLS models."
+            )
+        if self._is_iv:
+            raise NotImplementedError(
+                "The update() method is currently not supported for IV models."
+            )
+        if self._has_weights:
+            raise NotImplementedError(
+                "The update() method is currently not supported for models with weights."
+            )
+        if inplace:
+            raise NotImplementedError(
+                "update(..., inplace=True) is not supported because appending design "
+                "rows cannot safely update the complete fitted-result state; use the "
+                "returned coefficients instead."
+            )
         if not np.all(X_new[:, 0] == 1):
             X_new = np.column_stack((np.ones(len(X_new)), X_new))
         X_n_plus_1 = np.vstack((self._X, X_new))
         epsi_n_plus_1 = y_new - X_new @ self._beta_hat
         gamma_n_plus_1 = np.linalg.inv(X_n_plus_1.T @ X_n_plus_1) @ X_new.T
         beta_n_plus_1 = self._beta_hat + gamma_n_plus_1 @ epsi_n_plus_1
-        if inplace:
-            self._X = X_n_plus_1
-            self._Y = np.append(self._Y, y_new)
-            self._beta_hat = beta_n_plus_1
-            self._u_hat = self._Y - self._X @ self._beta_hat
-            self._N += X_new.shape[0]
 
         return beta_n_plus_1
 

--- a/pyfixest/estimation/models/fepois_.py
+++ b/pyfixest/estimation/models/fepois_.py
@@ -10,6 +10,7 @@ from scipy.special import gammaln
 from pyfixest.core.demean import Preconditioner
 from pyfixest.demeaners import AnyDemeaner
 from pyfixest.estimation.formula.parse import Formula as FixestFormula
+from pyfixest.estimation.internals.demean_ import DemeanedData
 from pyfixest.estimation.internals.families import POISSON
 from pyfixest.estimation.internals.literals import (
     SolverOptions,
@@ -104,7 +105,7 @@ class Fepois(Feglm):
         weights: str | None,
         weights_type: str | None,
         collin_tol: float,
-        lookup_demeaned_data: dict[frozenset[int], pd.DataFrame],
+        lookup_demeaned_data: dict[frozenset[int], DemeanedData],
         tol: float,
         maxiter: int,
         solver: SolverOptions = "np.linalg.solve",
@@ -152,7 +153,7 @@ class Fepois(Feglm):
 
     def get_fit(self) -> None:
         "Fit via Feglm IRLS, then add Poisson-specific post-fit summary stats."
-        y_orig = np.asarray(self._Y).flatten()
+        y_orig = self._model_matrix.dependent.to_numpy().flatten()
         user_weights = self._weights.flatten().copy()
 
         super().get_fit()

--- a/pyfixest/estimation/models/fepois_.py
+++ b/pyfixest/estimation/models/fepois_.py
@@ -159,7 +159,7 @@ class Fepois(Feglm):
         "Fit via Feglm IRLS, then add Poisson-specific post-fit summary stats."
         y_orig = self._model_matrix.dependent.to_numpy().flatten()
         observation_weights = self._observation_weights.values
-        user_weights = (
+        poisson_summary_weights = (
             np.ones_like(y_orig, dtype=np.float64)
             if observation_weights is None
             else observation_weights
@@ -168,11 +168,11 @@ class Fepois(Feglm):
         super().get_fit()
 
         self._y_hat_null = np.full_like(
-            y_orig, np.average(y_orig, weights=user_weights), dtype=float
+            y_orig, np.average(y_orig, weights=poisson_summary_weights), dtype=float
         )
 
         self._loglik = np.sum(
-            user_weights
+            poisson_summary_weights
             * (
                 y_orig * np.log(self._Y_hat_response)
                 - self._Y_hat_response
@@ -186,7 +186,7 @@ class Fepois(Feglm):
             self._pseudo_r2 = None
         else:
             self._loglik_null = np.sum(
-                user_weights
+                poisson_summary_weights
                 * (
                     y_orig * np.log(self._y_hat_null)
                     - self._y_hat_null
@@ -195,11 +195,13 @@ class Fepois(Feglm):
             )
             self._pseudo_r2 = 1 - (self._loglik / self._loglik_null)
         self._pearson_chi2 = np.sum(
-            user_weights * (y_orig - self._Y_hat_response) ** 2 / self._Y_hat_response
+            poisson_summary_weights
+            * (y_orig - self._Y_hat_response) ** 2
+            / self._Y_hat_response
         )
 
         self.deviance = self._family.deviance(
-            y_orig, self._Y_hat_response, user_weights
+            y_orig, self._Y_hat_response, poisson_summary_weights
         )
 
     def _clear_attributes(self) -> None:

--- a/pyfixest/estimation/models/fepois_.py
+++ b/pyfixest/estimation/models/fepois_.py
@@ -79,8 +79,8 @@ class Fepois(Feglm):
     weights_type : Optional[str]
         Type of weights variable.
     _data: pd.DataFrame
-        The data frame used in the estimation. None if arguments `lean = True` or
-        `store_data = False`.
+        The data frame used in the estimation. Deleted if arguments `lean = True`
+        or `store_data = False`.
 
     Examples
     --------

--- a/pyfixest/estimation/models/fepois_.py
+++ b/pyfixest/estimation/models/fepois_.py
@@ -32,21 +32,25 @@ class Fepois(Feglm):
 
     Inherits from the Feglm class. Users should not directly instantiate this class,
     but rather use the [fepois()](/reference/estimation.api.fepois.fepois.qmd) function.
-    Note that no demeaning is performed in this class: demeaning is performed in the
-    FixestMulti class (to allow for caching of demeaned variables for multiple estimation).
+    IRLS residualization is orchestrated by ``Feglm`` through the shared
+    ``DemeanCache`` supplied by the estimation runner.
 
     The method implements the algorithm from Stata's `ppmlhdfe` module.
 
     Attributes
     ----------
     _Y : np.ndarray
-        The demeaned dependent variable, a two-dimensional numpy array.
+        Final within-scale IRLS working response. It is not multiplied by the
+        square root of the working weights.
     _X : np.ndarray
-        The demeaned independent variables, a two-dimensional numpy array.
-    _fe : np.ndarray
-        Fixed effects, a two-dimensional numpy array or None.
-    weights : np.ndarray
-        Weights, a one-dimensional numpy array or None.
+        Final within-scale IRLS design. It is not multiplied by the square root
+        of the working weights.
+    _fe : pd.DataFrame or None
+        Formula-scale fixed effects.
+    _weights : np.ndarray
+        Compatibility alias containing observation weights only.
+    _irls_weights : np.ndarray
+        Final IRLS working weights.
     coefnames : list[str]
         Names of the coefficients in the design matrix X.
     drop_singletons : bool
@@ -119,7 +123,7 @@ class Fepois(Feglm):
         sample_split_value: str | int | None = None,
         separation_check: list[str] | None = None,
         offset: str | None = None,
-    ):
+    ) -> None:
         super().__init__(
             FixestFormula=FixestFormula,
             data=data,
@@ -154,7 +158,12 @@ class Fepois(Feglm):
     def get_fit(self) -> None:
         "Fit via Feglm IRLS, then add Poisson-specific post-fit summary stats."
         y_orig = self._model_matrix.dependent.to_numpy().flatten()
-        user_weights = self._weights.flatten().copy()
+        observation_weights = self._observation_weights.values
+        user_weights = (
+            np.ones_like(y_orig, dtype=np.float64)
+            if observation_weights is None
+            else observation_weights
+        )
 
         super().get_fit()
 

--- a/pyfixest/estimation/models/fepois_.py
+++ b/pyfixest/estimation/models/fepois_.py
@@ -202,6 +202,12 @@ class Fepois(Feglm):
             y_orig, self._Y_hat_response, user_weights
         )
 
+    def _clear_attributes(self) -> None:
+        """Apply GLM cleanup and discard the Poisson null-fit array when lean."""
+        super()._clear_attributes()
+        if self._lean and hasattr(self, "_y_hat_null"):
+            del self._y_hat_null
+
     def predict(
         self,
         newdata: DataFrameType | None = None,

--- a/pyfixest/estimation/models/feprobit_.py
+++ b/pyfixest/estimation/models/feprobit_.py
@@ -6,6 +6,7 @@ import pandas as pd
 from pyfixest.core.demean import Preconditioner
 from pyfixest.demeaners import AnyDemeaner
 from pyfixest.estimation.formula.parse import Formula as FixestFormula
+from pyfixest.estimation.internals.demean_ import DemeanedData
 from pyfixest.estimation.internals.families import PROBIT
 from pyfixest.estimation.models.feglm_ import Feglm
 
@@ -23,7 +24,7 @@ class Feprobit(Feglm):
         weights: str | None,
         weights_type: str | None,
         collin_tol: float,
-        lookup_demeaned_data: dict[frozenset[int], pd.DataFrame],
+        lookup_demeaned_data: dict[frozenset[int], DemeanedData],
         tol: float,
         maxiter: int,
         solver: Literal[

--- a/pyfixest/estimation/plan_.py
+++ b/pyfixest/estimation/plan_.py
@@ -10,6 +10,7 @@ from pyfixest.core.demean import Preconditioner
 from pyfixest.estimation.api.utils import _ALL_SAMPLE, _AllSampleSentinel
 from pyfixest.estimation.config import EstimationConfig
 from pyfixest.estimation.formula.parse import Formula as FixestFormula
+from pyfixest.estimation.internals.demean_ import DemeanedData
 from pyfixest.estimation.internals.vcov_utils import _get_vcov_type
 from pyfixest.estimation.models.fegaussian_ import Fegaussian
 from pyfixest.estimation.models.feiv_ import Feiv
@@ -292,7 +293,7 @@ def _build_model_kwargs(
 def fit_one(
     spec: ModelSpec,
     *,
-    lookup_demeaned_data: dict[frozenset[int], pd.DataFrame],
+    lookup_demeaned_data: dict[frozenset[int], DemeanedData],
     lookup_preconditioner: dict[frozenset[int], Preconditioner],
     vcov: str | dict[str, str] | None,
     vcov_kwargs: dict[str, str | int] | None,

--- a/pyfixest/estimation/quantreg/QuantregMulti.py
+++ b/pyfixest/estimation/quantreg/QuantregMulti.py
@@ -222,9 +222,8 @@ class QuantregMulti:
         for quantreg in self.all_quantregs.values():
             quantreg._clear_attributes()
 
-        del_attributes = ["_X", "_Y"]
+        # `_X` and `_Y` are read-only views, so their backing state is dropped.
         for quantreg in self.all_quantregs.values():
-            for attr in del_attributes:
-                if hasattr(quantreg, attr):
-                    delattr(quantreg, attr)
+            if hasattr(quantreg, "_within_data"):
+                del quantreg._within_data
         gc.collect()

--- a/pyfixest/estimation/quantreg/quantreg_.py
+++ b/pyfixest/estimation/quantreg/quantreg_.py
@@ -9,6 +9,8 @@ from scipy.linalg import cho_factor, solve_triangular
 
 from pyfixest.demeaners import AnyDemeaner
 from pyfixest.estimation.formula.parse import Formula as FixestFormula
+from pyfixest.estimation.internals.collinearity import drop_multicollinear_variables
+from pyfixest.estimation.internals.demean_ import DemeanedData
 from pyfixest.estimation.internals.literals import (
     QuantregMethodOptions,
     SolverOptions,
@@ -69,7 +71,7 @@ class Quantreg(Feols):
         weights: str | None,
         weights_type: str | None,
         collin_tol: float,
-        lookup_demeaned_data: dict[frozenset[int], pd.DataFrame],
+        lookup_demeaned_data: dict[frozenset[int], DemeanedData],
         solver: SolverOptions = "np.linalg.solve",
         demeaner: AnyDemeaner | None = None,
         store_data: bool = True,
@@ -177,12 +179,29 @@ class Quantreg(Feols):
             raise ValueError(f"`method` must be one of {{{valid}}}") from exc
 
     def to_array(self):
-        "Turn estimation DataFrames to np arrays."
-        self._Y, self._X, self._Z = (
-            self._Y.to_numpy(),
-            self._X.to_numpy(),
-            self._X.to_numpy(),
-        )
+        "Publish quantile-regression arrays from the immutable formula state."
+        response = self._model_matrix.dependent.to_numpy(dtype=np.float64)
+        design = self._model_matrix.independent.to_numpy(dtype=np.float64)
+        self._Y = response
+        self._X = design
+        self._Z = design
+
+    def drop_multicol_vars(self):
+        "Detect and drop multicollinear quantile-regression covariates."
+        if self._X.shape[1] > 0:
+            (
+                self._X,
+                self._coefnames,
+                self._collin_vars,
+                self._collin_index,
+            ) = drop_multicollinear_variables(
+                self._X,
+                self._coefnames,
+                self._collin_tol,
+            )
+        self._Z = self._X
+        self._X_is_empty = self._X.shape[1] == 0
+        self._k = self._X.shape[1]
 
     def prepare_model_matrix(self):
         "Prepare model inputs for estimation."
@@ -393,12 +412,20 @@ class Quantreg(Feols):
 
     def _vcov_iid(self):
         return vcov_iid_qreg(
-            X=self._X, Y=self._Y, u_hat=self._u_hat, q=self._quantile, N=self._N
+            X=self._X,
+            Y=self._Y,
+            u_hat=self._u_hat,
+            q=self._quantile,
+            N=self._N_rows,
         )
 
     def _vcov_hetero(self):
         return vcov_hetero_qreg(
-            X=self._X, Y=self._Y, u_hat=self._u_hat, q=self._quantile, N=self._N
+            X=self._X,
+            Y=self._Y,
+            u_hat=self._u_hat,
+            q=self._quantile,
+            N=self._N_rows,
         )
 
     def _vcov_nid(self) -> np.ndarray:
@@ -414,7 +441,7 @@ class Quantreg(Feols):
             Y=self._Y,
             beta_hat=self._beta_hat,
             q=self._quantile,
-            N=self._N,
+            N=self._N_rows,
             method=cast(QuantregMethodOptions, self._method),
             fit=self._fit,
         )

--- a/pyfixest/estimation/quantreg/quantreg_.py
+++ b/pyfixest/estimation/quantreg/quantreg_.py
@@ -451,6 +451,7 @@ class Quantreg(Feols):
     @property
     def objective_value(self):
         "Compute the total loss of the quantile regression model."
+        self._require_fit_arrays("objective_value", arrays="the residual arrays")
         return np.sum(np.abs(self._u_hat) * (self._quantile - (self._u_hat < 0)))
 
     def get_performance(self):

--- a/pyfixest/estimation/quantreg/quantreg_.py
+++ b/pyfixest/estimation/quantreg/quantreg_.py
@@ -219,6 +219,20 @@ class Quantreg(Feols):
         self._hessian = self._X.T @ self._X
         self._bread = np.linalg.inv(self._hessian)
 
+    def _clear_attributes(self) -> None:
+        """Apply base cleanup and discard quantile solver arrays when lean."""
+        super()._clear_attributes()
+        if self._lean:
+            for attr in (
+                "_x_final",
+                "_s_final",
+                "_z_final",
+                "_w_final",
+                "_y_final",
+            ):
+                if hasattr(self, attr):
+                    delattr(self, attr)
+
     def fit_qreg_fn(
         self,
         X: np.ndarray,

--- a/pyfixest/estimation/quantreg/quantreg_.py
+++ b/pyfixest/estimation/quantreg/quantreg_.py
@@ -9,7 +9,6 @@ from scipy.linalg import cho_factor, solve_triangular
 
 from pyfixest.demeaners import AnyDemeaner
 from pyfixest.estimation.formula.parse import Formula as FixestFormula
-from pyfixest.estimation.internals.collinearity import drop_multicollinear_variables
 from pyfixest.estimation.internals.demean_ import DemeanedData
 from pyfixest.estimation.internals.literals import (
     QuantregMethodOptions,
@@ -179,29 +178,14 @@ class Quantreg(Feols):
             raise ValueError(f"`method` must be one of {{{valid}}}") from exc
 
     def to_array(self):
-        "Publish quantile-regression arrays from the immutable formula state."
-        response = self._model_matrix.dependent.to_numpy(dtype=np.float64)
-        design = self._model_matrix.independent.to_numpy(dtype=np.float64)
-        self._Y = response
-        self._X = design
-        self._Z = design
+        "Publish quantile-regression within data from the formula state."
+        # Quantile regression supports neither fixed effects nor weights, so
+        # the shared preparation reduces to the formula arrays themselves.
+        self._set_within_data(self._prepare_within_data())
 
     def drop_multicol_vars(self):
         "Detect and drop multicollinear quantile-regression covariates."
-        if self._X.shape[1] > 0:
-            (
-                self._X,
-                self._coefnames,
-                self._collin_vars,
-                self._collin_index,
-            ) = drop_multicollinear_variables(
-                self._X,
-                self._coefnames,
-                self._collin_tol,
-            )
-        self._Z = self._X
-        self._X_is_empty = self._X.shape[1] == 0
-        self._k = self._X.shape[1]
+        self._set_within_data(self._drop_multicollinear_within_data(self._within_data))
 
     def prepare_model_matrix(self):
         "Prepare model inputs for estimation."

--- a/pyfixest/estimation/runner.py
+++ b/pyfixest/estimation/runner.py
@@ -8,6 +8,7 @@ import pandas as pd
 from pyfixest.core.demean import Preconditioner
 from pyfixest.estimation.config import EstimationConfig
 from pyfixest.estimation.FixestMulti_ import FixestMulti
+from pyfixest.estimation.internals.demean_ import DemeanedData
 from pyfixest.estimation.models.feiv_ import Feiv
 from pyfixest.estimation.models.feols_ import Feols
 from pyfixest.estimation.models.fepois_ import Fepois
@@ -81,7 +82,7 @@ def run_estimation(
 
     _NO_CACHE_KEY: Any = object()
     prev_cache_key: Any = _NO_CACHE_KEY
-    lookup_demeaned_data: dict[frozenset[int], pd.DataFrame] = {}
+    lookup_demeaned_data: dict[frozenset[int], DemeanedData] = {}
     lookup_preconditioner: dict[frozenset[int], Preconditioner] = {}
 
     for spec in specs:

--- a/tests/test_demean.py
+++ b/tests/test_demean.py
@@ -774,6 +774,40 @@ def test_demean_model_caching(benchmark, demeaner):
     assert np.allclose(Yd1, Yd2)
     assert np.allclose(Xd1, Xd2)
 
+    # A complete cache hit still follows the requested order, including the
+    # empty-design case used by fixed-effect-only specifications.
+    _, Xd_reordered, _ = DemeanCache(lookup_dict).demean_yx(
+        Y=Y.to_numpy(),
+        X=X[["x2", "x1"]].to_numpy(),
+        y_names=Y.columns,
+        x_names=("x2", "x1"),
+        fe=fe.to_numpy(),
+        weights=weights,
+        na_index=frozenset(),
+        demeaner=demeaner,
+    )
+    Yd_empty, Xd_empty, _ = DemeanCache(lookup_dict).demean_yx(
+        Y=Y.to_numpy(),
+        X=np.empty((N, 0)),
+        y_names=Y.columns,
+        x_names=(),
+        fe=fe.to_numpy(),
+        weights=weights,
+        na_index=frozenset(),
+        demeaner=demeaner,
+    )
+    np.testing.assert_allclose(
+        Xd_reordered,
+        Xd1[:, ::-1],
+        err_msg="complete cache hit changed demeaned design order",
+    )
+    np.testing.assert_allclose(
+        Yd_empty,
+        Yd1,
+        err_msg="empty-design cache hit changed demeaned response",
+    )
+    assert Xd_empty.shape == (N, 0)
+
     # Add new variable and verify partial caching
     X_new = pd.DataFrame(
         {
@@ -812,6 +846,7 @@ def test_demean_model_caching(benchmark, demeaner):
     cached_data = lookup_dict[frozenset()]
     assert isinstance(cached_data, DemeanedData)
     assert cached_data.columns == ("y", "x1", "x2", "x4", "x3")
+    assert not cached_data.values.flags.writeable
 
 
 @pytest.mark.parametrize(

--- a/tests/test_demean.py
+++ b/tests/test_demean.py
@@ -9,7 +9,7 @@ import pyfixest as pf
 from pyfixest.core import demean as demean_rs
 from pyfixest.core.demean import demean_within
 from pyfixest.demeaners import LsmrDemeaner, MapDemeaner, _resolve_preconditioner
-from pyfixest.estimation.internals.demean_ import DemeanCache
+from pyfixest.estimation.internals.demean_ import DemeanCache, DemeanedData
 from pyfixest.estimation.numba.demean_nb import demean as demean_numba
 from tests._torch_test_utils import HAS_TORCH, torch_param
 
@@ -622,16 +622,19 @@ def test_demean_model_no_fixed_effects(benchmark, demeaner):
     """Test DemeanCache.demean_yx when there are no fixed effects."""
     # Create sample data
     N = 1000
-    Y = pd.DataFrame({"y": np.random.randn(N)})
-    X = pd.DataFrame({"x1": np.random.randn(N), "x2": np.random.randn(N)})
+    rng = np.random.default_rng(42)
+    Y = pd.DataFrame({"y": rng.normal(size=N)})
+    X = pd.DataFrame({"x1": rng.normal(size=N), "x2": rng.normal(size=N)})
     weights = np.ones(N)
     cache = DemeanCache()
 
     # Test without fixed effects
     Yd, Xd, _ = benchmark(
         cache.demean_yx,
-        Y=Y,
-        X=X,
+        Y=Y.to_numpy(),
+        X=X.to_numpy(),
+        y_names=Y.columns,
+        x_names=X.columns,
         fe=None,
         weights=weights,
         na_index=frozenset(),
@@ -639,10 +642,9 @@ def test_demean_model_no_fixed_effects(benchmark, demeaner):
     )
 
     # When no fixed effects, output should equal input
-    assert np.allclose(Y.values, Yd.values)
-    assert np.allclose(X.values, Xd.values)
-    assert Yd.columns.equals(Y.columns)
-    assert Xd.columns.equals(X.columns)
+    assert np.allclose(Y.values, Yd)
+    assert np.allclose(X.values, Xd)
+    assert cache.lookup_demeaned_data == {}
 
 
 @pytest.mark.parametrize("demeaner", MODEL_DEMEANERS)
@@ -662,27 +664,27 @@ def test_demean_model_with_fixed_effects(benchmark, demeaner):
     # Run demean_yx
     Yd, Xd, _ = benchmark(
         cache.demean_yx,
-        Y=Y,
-        X=X,
-        fe=fe,
+        Y=Y.to_numpy(),
+        X=X.to_numpy(),
+        y_names=Y.columns,
+        x_names=X.columns,
+        fe=fe.to_numpy(),
         weights=weights,
         na_index=frozenset(),
         demeaner=demeaner,
     )
 
     # Verify results are different from input (since we're demeaning)
-    assert not np.allclose(Y.values, Yd.values)
-    assert not np.allclose(X.values, Xd.values)
-
-    # Verify column names are preserved
-    assert Yd.columns.equals(Y.columns)
-    assert Xd.columns.equals(X.columns)
+    assert not np.allclose(Y.values, Yd)
+    assert not np.allclose(X.values, Xd)
 
     # Verify results are cached in lookup_dict
     assert frozenset() in lookup_dict
     cached_data = lookup_dict[frozenset()]
-    assert np.allclose(cached_data[Y.columns].values, Yd.values)
-    assert np.allclose(cached_data[X.columns].values, Xd.values)
+    assert isinstance(cached_data, DemeanedData)
+    assert cached_data.columns == ("y", "x1", "x2")
+    assert np.allclose(cached_data.values[:, :1], Yd)
+    assert np.allclose(cached_data.values[:, 1:], Xd)
 
 
 @pytest.mark.parametrize("demeaner", MODEL_DEMEANERS)
@@ -700,27 +702,31 @@ def test_demean_model_with_weights(benchmark, demeaner):
     # Run with weights
     Yd, Xd, _ = benchmark(
         cache.demean_yx,
-        Y=Y,
-        X=X,
-        fe=fe,
+        Y=Y.to_numpy(),
+        X=X.to_numpy(),
+        y_names=Y.columns,
+        x_names=X.columns,
+        fe=fe.to_numpy(),
         weights=weights,
         na_index=frozenset(),
         demeaner=demeaner,
     )
 
-    # Run without weights for comparison (fresh cache to avoid cache hit)
+    # Run the explicit unweighted fast path (fresh cache to avoid cache hit)
     Yd_unweighted, Xd_unweighted, _ = DemeanCache().demean_yx(
-        Y=Y,
-        X=X,
-        fe=fe,
-        weights=np.ones(N),
+        Y=Y.to_numpy(),
+        X=X.to_numpy(),
+        y_names=Y.columns,
+        x_names=X.columns,
+        fe=fe.to_numpy(),
+        weights=None,
         na_index=frozenset(),
         demeaner=demeaner,
     )
 
     # Results should be different with weights vs without
-    assert not np.allclose(Yd.values, Yd_unweighted.values)
-    assert not np.allclose(Xd.values, Xd_unweighted.values)
+    assert not np.allclose(Yd, Yd_unweighted)
+    assert not np.allclose(Xd, Xd_unweighted)
 
 
 @pytest.mark.parametrize("demeaner", MODEL_DEMEANERS)
@@ -734,49 +740,78 @@ def test_demean_model_caching(benchmark, demeaner):
     fe = pd.DataFrame({"fe1": rng.integers(0, 10, N)})
     weights = np.ones(N)
     lookup_dict = {}
+    first_cache = DemeanCache(lookup_dict)
+    assert first_cache.lookup_demeaned_data is lookup_dict
 
     # First run - should compute and cache
-    Yd1, Xd1, _ = DemeanCache(lookup_dict).demean_yx(
-        Y=Y,
-        X=X,
-        fe=fe,
+    Yd1, Xd1, _ = first_cache.demean_yx(
+        Y=Y.to_numpy(),
+        X=X.to_numpy(),
+        y_names=Y.columns,
+        x_names=X.columns,
+        fe=fe.to_numpy(),
         weights=weights,
         na_index=frozenset(),
         demeaner=demeaner,
     )
 
     # Second run - should use cache (shared lookup, fresh per-model cache)
+    second_cache = DemeanCache(lookup_dict)
+    assert second_cache.lookup_demeaned_data is lookup_dict
     Yd2, Xd2, _ = benchmark(
-        DemeanCache(lookup_dict).demean_yx,
-        Y=Y,
-        X=X,
-        fe=fe,
+        second_cache.demean_yx,
+        Y=Y.to_numpy(),
+        X=X.to_numpy(),
+        y_names=Y.columns,
+        x_names=X.columns,
+        fe=fe.to_numpy(),
         weights=weights,
         na_index=frozenset(),
         demeaner=demeaner,
     )
 
     # Results should be identical
-    assert np.allclose(Yd1.values, Yd2.values)
-    assert np.allclose(Xd1.values, Xd2.values)
+    assert np.allclose(Yd1, Yd2)
+    assert np.allclose(Xd1, Xd2)
 
     # Add new variable and verify partial caching
-    X_new = X.copy()
-    X_new["x3"] = rng.normal(0, 1, N)
+    X_new = pd.DataFrame(
+        {
+            "x4": rng.normal(0, 1, N),
+            "x1": X["x1"],
+            "x3": rng.normal(0, 1, N),
+            "x2": X["x2"],
+        }
+    )
 
     _, Xd3, _ = DemeanCache(lookup_dict).demean_yx(
-        Y=Y,
-        X=X_new,
-        fe=fe,
+        Y=Y.to_numpy(),
+        X=X_new.to_numpy(),
+        y_names=Y.columns,
+        x_names=X_new.columns,
+        fe=fe.to_numpy(),
+        weights=weights,
+        na_index=frozenset(),
+        demeaner=demeaner,
+    )
+    _, Xd3_fresh, _ = DemeanCache().demean_yx(
+        Y=Y.to_numpy(),
+        X=X_new.to_numpy(),
+        y_names=Y.columns,
+        x_names=X_new.columns,
+        fe=fe.to_numpy(),
         weights=weights,
         na_index=frozenset(),
         demeaner=demeaner,
     )
 
-    # Original columns should match previous results
-    assert np.allclose(Xd3[["x1", "x2"]].values, Xd2.values)
-    # New column should be different
-    assert "x3" in Xd3.columns
+    # Requested output order matches an independent solve, while the shared
+    # cache keeps first-seen insertion order and all earlier columns.
+    assert np.allclose(Xd3, Xd3_fresh)
+    assert np.allclose(Xd3[:, [1, 3]], Xd2)
+    cached_data = lookup_dict[frozenset()]
+    assert isinstance(cached_data, DemeanedData)
+    assert cached_data.columns == ("y", "x1", "x2", "x4", "x3")
 
 
 @pytest.mark.parametrize(
@@ -806,9 +841,11 @@ def test_demean_model_maxiter_convergence_failure(demeaner):
     # Should fail with very small maxiter
     with pytest.raises(ValueError, match="Demeaning failed after 1 iterations"):
         DemeanCache().demean_yx(
-            Y=Y,
-            X=X,
-            fe=fe,
+            Y=Y.to_numpy(),
+            X=X.to_numpy(),
+            y_names=Y.columns,
+            x_names=X.columns,
+            fe=fe.to_numpy(),
             weights=weights,
             na_index=frozenset(),
             demeaner=demeaner,

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -423,7 +423,13 @@ def test_errors_ccv():
 
     # error when fixed effects in estimation
     fit = feols("Y ~ D | f1", data=data)
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(NotImplementedError, match=r"not supported.*fixed effects"):
+        fit.ccv(treatment="D", pk=0.05, qk=0.5, n_splits=10, seed=929)
+
+    # weighted CCV needs a separately defined estimating equation
+    data["observation_weight"] = np.linspace(0.5, 2.0, len(data))
+    fit = feols("Y ~ D", data=data, weights="observation_weight")
+    with pytest.raises(NotImplementedError, match=r"not supported.*weights"):
         fit.ccv(treatment="D", pk=0.05, qk=0.5, n_splits=10, seed=929)
 
     # error when treatment not found
@@ -449,13 +455,49 @@ def test_errors_ccv():
     pois_data = get_data(model="Fepois").dropna()
     pois_data["D"] = np.random.choice([0, 1], size=len(pois_data))
     fit = fepois("Y ~ D", data=pois_data)
-    with pytest.raises(AssertionError):
+    with pytest.raises(
+        NotImplementedError, match=r"not supported for models of type 'fepois'"
+    ):
         fit.ccv(treatment="D", pk=0.05, qk=0.5, n_splits=10, seed=929)
 
     # same for IV
     fit = feols("Y ~ 1 | D ~ Z1", data=data)
-    with pytest.raises(AssertionError):
+    with pytest.raises(
+        NotImplementedError, match=r"not supported for models of type 'feols'"
+    ):
         fit.ccv(treatment="D", pk=0.05, qk=0.5, n_splits=10, seed=929)
+
+
+def test_weighted_update_is_explicitly_unsupported():
+    data = get_data().dropna(subset=["Y", "X1", "weights"])
+    fit = feols("Y ~ X1", data=data, weights="weights")
+
+    with pytest.raises(NotImplementedError, match=r"update.*not supported.*weights"):
+        fit.update(X_new=np.ones((1, 2)), y_new=np.ones(1))
+
+
+def test_iv_update_is_explicitly_unsupported():
+    data = get_data().dropna(subset=["Y", "X1", "Z1"])
+    fit = feols("Y ~ 1 + [X1 ~ Z1]", data=data)
+
+    with pytest.raises(NotImplementedError, match=r"update.*not supported.*IV"):
+        fit.update(X_new=np.ones((1, fit._k)), y_new=np.ones(1))
+
+
+def test_non_ols_update_is_explicitly_unsupported():
+    poisson_data = get_data(model="Fepois").dropna()
+    linear_data = get_data().dropna()
+    binary_data = poisson_data.copy()
+    binary_data["Y"] = (binary_data["Y"] > binary_data["Y"].median()).astype(int)
+    models = (
+        pf.fepois("Y ~ X1", data=poisson_data),
+        pf.feglm("Y ~ X1", data=binary_data, family="logit"),
+        pf.quantreg("Y ~ X1", data=linear_data),
+    )
+
+    for fit in models:
+        with pytest.raises(NotImplementedError, match=r"update.*only supported.*OLS"):
+            fit.update(X_new=np.ones((1, fit._k)), y_new=np.ones(1))
 
 
 def test_errors_confint():

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -56,12 +56,22 @@ def test_cluster_na():
         feols(fml="Y ~ X1", data=data, vcov={"CRV1": "f3"})
 
 
-def test_cluster_but_no_data():
-    """Test if AttributeError if self._data is not stored."""
+def test_cluster_vcov_without_stored_or_explicit_data_is_informative():
+    """Data-dependent vcov updates explain how to supply stripped data."""
     data = get_data()
     fit = feols("Y ~ X1", data=data, store_data=False)
-    with pytest.raises(AttributeError):
+    with pytest.raises(RuntimeError, match=r"store_data=False.*Pass.*data="):
         fit.vcov({"CRV1": "f2"})
+
+
+def test_vcov_column_list_without_data_is_informative():
+    """A column-list vcov cannot be validated without the estimation sample."""
+    data = get_data()
+    fit = feols("Y ~ X1", data=data, store_data=False)
+    with pytest.raises(
+        RuntimeError, match=r"vcov column list requires estimation data"
+    ):
+        fit.vcov(["f2"])
 
 
 def test_error_hc23_fe():

--- a/tests/test_estimator_state_lifecycle.py
+++ b/tests/test_estimator_state_lifecycle.py
@@ -19,6 +19,7 @@ from pyfixest.estimation.formula.model_matrix import ModelMatrix, create_model_m
 from pyfixest.estimation.formula.parse import Formula
 from pyfixest.estimation.internals.demean_ import DemeanedData
 from pyfixest.estimation.internals.model_state import (
+    GlmWorkingState,
     ObservationWeights,
     WithinLinearData,
 )
@@ -280,3 +281,43 @@ def test_multiple_estimation_shares_array_native_demean_cache(
     assert all(isinstance(model._within_data, WithinLinearData) for model in models)
     assert all(model._Y is model._within_data.response for model in models)
     assert all(model._X is model._within_data.design for model in models)
+
+
+def test_feglm_keeps_observation_and_working_weights_distinct() -> None:
+    """The stable observation-weight alias is never replaced by IRLS weights."""
+    rng = np.random.default_rng(8675309)
+    n_obs = 160
+    covariate = rng.normal(size=n_obs)
+    probability = 1 / (1 + np.exp(-(-0.2 + 0.8 * covariate)))
+    observation_weights = np.linspace(0.5, 2.0, n_obs)
+    data = pd.DataFrame(
+        {
+            "y": rng.binomial(1, probability),
+            "x": covariate,
+            "observation_weight": observation_weights,
+        }
+    )
+
+    fit = pf.feglm(
+        "y ~ x",
+        data=data,
+        family="logit",
+        weights="observation_weight",
+        vcov="iid",
+        iwls_tol=1e-10,
+    )
+
+    working = fit._working_state
+    assert isinstance(working, GlmWorkingState)
+    np.testing.assert_allclose(fit._weights.flatten(), observation_weights)
+    np.testing.assert_allclose(fit._observation_weights.values, observation_weights)
+    np.testing.assert_allclose(fit._irls_weights, working.working_weights)
+    assert not np.allclose(working.working_weights, observation_weights)
+    assert fit._X is working.design_within
+    assert fit._Y is working.working_response_within
+    np.testing.assert_allclose(fit.resid("response"), working.response_residuals)
+    np.testing.assert_allclose(fit.resid("working"), working.working_residuals)
+    np.testing.assert_allclose(
+        fit._scores,
+        fit._X * (working.working_weights * working.working_residuals)[:, None],
+    )

--- a/tests/test_estimator_state_lifecycle.py
+++ b/tests/test_estimator_state_lifecycle.py
@@ -7,13 +7,21 @@ and row-sample seams locked here are not observable from those suites.
 
 from __future__ import annotations
 
+from dataclasses import FrozenInstanceError
+
 import numpy as np
 import pandas as pd
 import pytest
 
 import pyfixest as pf
+from pyfixest.estimation.FixestMulti_ import FixestMulti
 from pyfixest.estimation.formula.model_matrix import ModelMatrix, create_model_matrix
 from pyfixest.estimation.formula.parse import Formula
+from pyfixest.estimation.internals.demean_ import DemeanedData
+from pyfixest.estimation.internals.model_state import (
+    ObservationWeights,
+    WithinLinearData,
+)
 
 
 @pytest.fixture
@@ -50,6 +58,102 @@ def lifecycle_data() -> pd.DataFrame:
     )
 
 
+@pytest.mark.parametrize(
+    ("weights_type", "expected_n"),
+    [("aweights", 24), ("fweights", 52)],
+)
+def test_feols_keeps_formula_within_and_weight_domains_distinct(
+    lifecycle_data: pd.DataFrame,
+    weights_type: str,
+    expected_n: int,
+) -> None:
+    """A weighted FE fit retains within arrays and response-scale residuals."""
+    fit = pf.feols(
+        "y ~ x | fe",
+        data=lifecycle_data,
+        weights="weight",
+        weights_type=weights_type,
+        vcov="iid",
+    )
+
+    assert isinstance(fit._model_matrix, ModelMatrix)
+    assert isinstance(fit._model_matrix.dependent, pd.DataFrame)
+    assert isinstance(fit._observation_weights, ObservationWeights)
+    assert isinstance(fit._within_data, WithinLinearData)
+    assert fit._Y is fit._within_data.response
+    assert fit._X is fit._within_data.design
+    assert fit._Z is fit._within_data.design
+    assert not hasattr(fit, "_Yd")
+    assert not hasattr(fit, "_Xd")
+
+    weights = lifecycle_data["weight"].to_numpy(dtype=np.float64)
+    np.testing.assert_array_equal(fit._observation_weights.values, weights)
+    np.testing.assert_array_equal(fit._weights.flatten(), weights)
+    assert fit._observation_weights.kind == weights_type
+    assert expected_n == fit._N
+
+    weighted_group_mean = (lifecycle_data["y"] * lifecycle_data["weight"]).groupby(
+        lifecycle_data["fe"]
+    ).transform("sum") / lifecycle_data["weight"].groupby(
+        lifecycle_data["fe"]
+    ).transform("sum")
+    expected_y_within = lifecycle_data["y"] - weighted_group_mean
+    np.testing.assert_allclose(fit._within_data.response.flatten(), expected_y_within)
+    assert not np.allclose(
+        fit._within_data.response.flatten(),
+        expected_y_within * np.sqrt(weights),
+    )
+
+    residuals = fit._within_data.response.flatten() - fit._X @ fit._beta_hat
+    np.testing.assert_allclose(fit._u_hat, residuals)
+    np.testing.assert_allclose(fit.resid(), residuals)
+    np.testing.assert_allclose(
+        fit._scores,
+        fit._X * (weights * residuals)[:, None],
+    )
+    np.testing.assert_allclose(fit._hessian, fit._X.T @ (weights[:, None] * fit._X))
+
+    with pytest.raises(FrozenInstanceError):
+        fit._within_data.response = fit._within_data.design  # type: ignore[misc]
+
+
+def test_weighted_iv_keeps_each_econometric_role_on_within_scale(
+    lifecycle_data: pd.DataFrame,
+) -> None:
+    """IV state names response, design, endogenous, and instrument roles."""
+    fit = pf.feols(
+        "y ~ x + [endog ~ z] | fe",
+        data=lifecycle_data,
+        weights="weight",
+        weights_type="aweights",
+        vcov="iid",
+    )
+
+    within = fit._within_data
+    assert isinstance(within, WithinLinearData)
+    assert within.instruments is not None
+    assert within.endogenous is not None
+    assert fit._Y is within.response
+    assert fit._X is within.design
+    assert fit._Z is within.instruments
+    assert fit._endogvar is within.endogenous
+    assert not hasattr(fit, "_Yd")
+    assert not hasattr(fit, "_Xd")
+    assert not hasattr(fit, "_Zd")
+    assert not hasattr(fit, "_endogvard")
+
+    weights = lifecycle_data["weight"].to_numpy(dtype=np.float64)
+    weighted_design = weights[:, None] * within.design
+    weighted_response = weights[:, None] * within.response
+    np.testing.assert_allclose(fit._tZX, within.instruments.T @ weighted_design)
+    np.testing.assert_allclose(fit._tZy, within.instruments.T @ weighted_response)
+    np.testing.assert_allclose(
+        fit._scores,
+        within.instruments * (weights * fit._u_hat)[:, None],
+    )
+    np.testing.assert_allclose(fit.resid(), fit._u_hat)
+
+
 def test_formula_data_remains_canonical_after_linear_fit(
     lifecycle_data: pd.DataFrame,
 ) -> None:
@@ -81,6 +185,17 @@ def test_formula_data_remains_canonical_after_linear_fit(
         lifecycle_data.loc[:, ["weight"]],
     )
     assert fit._model_spec is model_matrix.model_spec
+
+
+def test_unweighted_effective_n_remains_integer_for_prediction_errors(
+    lifecycle_data: pd.DataFrame,
+) -> None:
+    """An integer physical row count remains usable by prediction allocation."""
+    fit = pf.feols("y ~ x", data=lifecycle_data, vcov="iid")
+
+    assert isinstance(fit._N, int)
+    assert isinstance(fit._observation_weights.n_effective, int)
+    assert fit.predict(se_fit=True).shape == (len(lifecycle_data),)
 
 
 def test_glm_separation_replaces_formula_data_with_filtered_state() -> None:
@@ -137,3 +252,31 @@ def test_model_matrix_without_rows_returns_filtered_copy(
     assert filtered.instruments is None
     assert filtered.offset is None
     assert len(model_matrix.dependent) == len(lifecycle_data)
+
+
+def test_multiple_estimation_shares_array_native_demean_cache(
+    lifecycle_data: pd.DataFrame,
+) -> None:
+    """Multiple fits share one ordered array cache without DataFrame round trips."""
+    fit = pf.feols(
+        "y ~ sw(x, x2) | fe",
+        data=lifecycle_data,
+        weights="weight",
+        vcov="iid",
+    )
+
+    assert isinstance(fit, FixestMulti)
+    models = list(fit.all_fitted_models.values())
+    assert len(models) == 2
+
+    demeaned_caches = [model._demean_cache.lookup_demeaned_data for model in models]
+    preconditioner_caches = [
+        model._demean_cache.lookup_preconditioner for model in models
+    ]
+    assert demeaned_caches[0] is demeaned_caches[1]
+    assert preconditioner_caches[0] is preconditioner_caches[1]
+    assert demeaned_caches[0]
+    assert all(isinstance(value, DemeanedData) for value in demeaned_caches[0].values())
+    assert all(isinstance(model._within_data, WithinLinearData) for model in models)
+    assert all(model._Y is model._within_data.response for model in models)
+    assert all(model._X is model._within_data.design for model in models)

--- a/tests/test_estimator_state_lifecycle.py
+++ b/tests/test_estimator_state_lifecycle.py
@@ -118,6 +118,31 @@ def test_feols_keeps_formula_within_and_weight_domains_distinct(
         fit._within_data.response = fit._within_data.design  # type: ignore[misc]
 
 
+@pytest.mark.parametrize("alias", ["_Y", "_X", "_Z", "_weights"])
+def test_array_aliases_are_read_only_views(
+    lifecycle_data: pd.DataFrame,
+    alias: str,
+) -> None:
+    """The typed state objects stay the single writable representation."""
+    fit = pf.feols("y ~ x | fe", data=lifecycle_data, vcov="iid")
+
+    with pytest.raises(AttributeError):
+        setattr(fit, alias, np.zeros((fit._N_rows, 1)))
+    with pytest.raises(AttributeError):
+        delattr(fit, alias)
+
+
+def test_unweighted_weight_alias_is_materialized_on_access(
+    lifecycle_data: pd.DataFrame,
+) -> None:
+    """An unweighted fit stores no weight vector but still exposes one."""
+    fit = pf.feols("y ~ x | fe", data=lifecycle_data, vcov="iid")
+
+    assert fit._observation_weights.values is None
+    np.testing.assert_array_equal(fit._weights, np.ones((fit._N_rows, 1)))
+    assert fit._weights is not fit._weights
+
+
 def test_weighted_iv_keeps_each_econometric_role_on_within_scale(
     lifecycle_data: pd.DataFrame,
 ) -> None:

--- a/tests/test_estimator_state_lifecycle.py
+++ b/tests/test_estimator_state_lifecycle.py
@@ -596,3 +596,165 @@ def test_lean_vcov_fails_with_storage_guidance(
 
     with pytest.raises(RuntimeError, match=r"vcov\(\).*lean=True.*discarded"):
         fit.vcov("HC1")
+
+
+STORAGE_STATE_FIELDS = frozenset(
+    {
+        "_data",
+        "_model_matrix",
+        "_within_data",
+        "_observation_weights",
+        "_demean_cache",
+        "_fe",
+        "_response",
+        "_X",
+        "_Y",
+        "_Z",
+        "_weights",
+        "_scores",
+        "_u_hat",
+    }
+)
+
+
+@pytest.mark.parametrize(
+    ("fit_kwargs", "missing_fields"),
+    [
+        ({}, frozenset()),
+        ({"store_data": False}, frozenset({"_data", "_model_matrix"})),
+        ({"lean": True}, STORAGE_STATE_FIELDS),
+    ],
+    ids=["retained", "store_data_false", "lean"],
+)
+def test_storage_options_delete_expected_state(
+    lifecycle_data: pd.DataFrame,
+    fit_kwargs: dict[str, bool],
+    missing_fields: frozenset[str],
+) -> None:
+    """Distinguish data-only cleanup from lean fit-state cleanup."""
+    fit = pf.feols("y ~ x | fe", data=lifecycle_data, vcov="iid", **fit_kwargs)
+
+    observed_fields = frozenset(
+        field for field in STORAGE_STATE_FIELDS if hasattr(fit, field)
+    )
+    assert observed_fields == STORAGE_STATE_FIELDS - missing_fields
+    if fit_kwargs.get("lean"):
+        # Retained so that predict(newdata=...) keeps working without fixed
+        # effects, and so that row alignment stays checkable.
+        for field in ("_model_spec", "_context", "_na_index"):
+            assert hasattr(fit, field)
+    assert np.isfinite(fit.coef()).all()
+
+
+def test_iv_first_stage_respects_store_data_false(
+    lifecycle_data: pd.DataFrame,
+) -> None:
+    """A retained IV first stage must not hide a copy of stripped input data."""
+    fit = pf.feols(
+        "y ~ x + [endog ~ z] | fe",
+        data=lifecycle_data,
+        vcov="hetero",
+        store_data=False,
+    )
+
+    first_stage = fit._model_1st_stage
+    assert not hasattr(first_stage, "_data")
+    assert not hasattr(first_stage, "_model_matrix")
+    assert hasattr(first_stage, "_within_data")
+    assert hasattr(first_stage, "_X")
+    fit.IV_Diag()
+    assert np.isfinite(fit._eff_F)
+    with pytest.raises(RuntimeError, match=r"first_stage\(\).*store_data=False"):
+        fit.first_stage()
+
+
+def test_iv_effective_f_uses_retained_arrays_without_stored_data(
+    lifecycle_data: pd.DataFrame,
+) -> None:
+    """IID first-stage diagnostics need retained arrays, not formula data."""
+    stripped = pf.feols(
+        "y ~ x + [endog ~ z] | fe",
+        data=lifecycle_data,
+        vcov="iid",
+        store_data=False,
+    )
+    retained = pf.feols(
+        "y ~ x + [endog ~ z] | fe",
+        data=lifecycle_data,
+        vcov="iid",
+    )
+
+    stripped.IV_Diag()
+    retained.IV_Diag()
+
+    np.testing.assert_allclose(stripped._eff_F, retained._eff_F)
+    assert not hasattr(stripped._model_1st_stage, "_data")
+
+
+def test_lean_iv_discards_retained_first_stage_arrays(
+    lifecycle_data: pd.DataFrame,
+) -> None:
+    """Lean IV results retain diagnostics but no nested fitted-data graph."""
+    fit = pf.feols(
+        "y ~ x + [endog ~ z] | fe",
+        data=lifecycle_data,
+        vcov="hetero",
+        lean=True,
+    )
+
+    assert not hasattr(fit, "_model_1st_stage")
+    assert not hasattr(fit, "_X_hat")
+    assert not hasattr(fit, "_v_hat")
+    # `_endogvar` is a read-only view on the discarded within data.
+    assert not hasattr(fit, "_endogvar")
+    assert np.isfinite(fit._f_stat_1st_stage)
+    with pytest.raises(RuntimeError, match=r"IV_Diag\(\).*lean=True"):
+        fit.IV_Diag()
+
+
+def test_glm_lean_discards_formula_and_working_state() -> None:
+    """Lean GLM results discard both canonical input and working fit arrays."""
+    data = pd.DataFrame({"y": [0, 1, 0, 1, 1, 0], "x": np.arange(6.0)})
+    fit = pf.feglm("y ~ x", data=data, family="logit", lean=True, vcov="iid")
+
+    discarded = (
+        "_model_matrix",
+        "_observation_weights",
+        "_demean_cache",
+        "_working_state",
+        "_u_hat_response",
+        "_u_hat_working",
+        "_offset",
+    )
+    assert all(not hasattr(fit, attr) for attr in discarded)
+    # The IRLS aliases are read-only views on the discarded working state.
+    assert not hasattr(fit, "_irls_weights")
+    assert not hasattr(fit, "_Xbeta")
+    assert np.isfinite(fit.coef()).all()
+
+
+def test_poisson_lean_discards_offset_and_null_fit_arrays() -> None:
+    """Lean Poisson results do not retain offset or null-fit row arrays."""
+    data = pd.DataFrame(
+        {
+            "y": [0, 1, 2, 1, 3, 2],
+            "x": np.arange(6.0),
+            "offset": np.linspace(0.1, 0.6, 6),
+        }
+    )
+    fit = pf.fepois("y ~ x", data=data, offset="offset", lean=True, vcov="iid")
+
+    assert not hasattr(fit, "_offset")
+    assert not hasattr(fit, "_y_hat_null")
+    assert np.isfinite(fit.coef()).all()
+
+
+def test_quantreg_lean_discards_solver_arrays() -> None:
+    """Lean quantile results do not retain row-sized solver outputs."""
+    data = pd.DataFrame({"y": [0.2, 1.1, 1.8, 3.2, 3.9, 5.1], "x": np.arange(6.0)})
+    with pytest.warns(FutureWarning, match="experimental"):
+        fit = pf.quantreg("y ~ x", data=data, lean=True, vcov="iid", maxiter=100)
+
+    solver_arrays = ("_x_final", "_s_final", "_z_final", "_w_final", "_y_final")
+    assert all(not hasattr(fit, attr) for attr in solver_arrays)
+    assert np.isfinite(fit.coef()).all()

--- a/tests/test_estimator_state_lifecycle.py
+++ b/tests/test_estimator_state_lifecycle.py
@@ -7,6 +7,7 @@ and row-sample seams locked here are not observable from those suites.
 
 from __future__ import annotations
 
+from copy import deepcopy
 from dataclasses import FrozenInstanceError
 
 import numpy as np
@@ -346,3 +347,252 @@ def test_feglm_keeps_observation_and_working_weights_distinct() -> None:
         fit._scores,
         fit._X * (working.working_weights * working.working_residuals)[:, None],
     )
+
+
+LEAN_REJECTION_CASES = [
+    ("resid", "y ~ x | fe", lambda fit: fit.resid()),
+    ("get_performance", "y ~ x | fe", lambda fit: fit.get_performance()),
+    ("predict", "y ~ x | fe", lambda fit: fit.predict()),
+    ("fixef", "y ~ x | fe", lambda fit: fit.fixef()),
+    ("preconditioner", "y ~ x | fe", lambda fit: fit.preconditioner),
+    ("ccv", "y ~ x", lambda fit: fit.ccv(treatment="x")),
+    (
+        "decompose",
+        "y ~ x + x2",
+        lambda fit: fit.decompose(decomp_var="x", only_coef=True),
+    ),
+    ("wildboottest", "y ~ x + x2", lambda fit: fit.wildboottest(param="x", reps=11)),
+    ("ritest", "y ~ x + x2", lambda fit: fit.ritest(resampvar="x", reps=11)),
+    (
+        "update",
+        "y ~ x + x2",
+        lambda fit: fit.update(np.ones((1, 3)), np.zeros(1)),
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ("method", "fml", "call"),
+    LEAN_REJECTION_CASES,
+    ids=[case[0] for case in LEAN_REJECTION_CASES],
+)
+def test_lean_results_reject_state_dependent_methods(
+    lifecycle_data: pd.DataFrame,
+    method: str,
+    fml: str,
+    call,
+) -> None:
+    """Discarded fit arrays produce a remedy, not an AttributeError."""
+    fit = pf.feols(fml, data=lifecycle_data, vcov="iid", lean=True)
+
+    with pytest.raises(RuntimeError, match=rf"{method}\(\).*lean=True.*discarded"):
+        call(fit)
+
+
+STORE_DATA_REJECTION_CASES = [
+    ("fixef", "y ~ x | fe", lambda fit, data: fit.fixef()),
+    ("predict", "y ~ x | fe", lambda fit, data: fit.predict(newdata=data)),
+    ("ccv", "y ~ x", lambda fit, data: fit.ccv(treatment="x")),
+    (
+        "decompose",
+        "y ~ x + x2 | fe",
+        lambda fit, data: fit.decompose(decomp_var="x", only_coef=True),
+    ),
+    (
+        "wildboottest",
+        "y ~ x + x2",
+        lambda fit, data: fit.wildboottest(param="x", reps=11),
+    ),
+    ("ritest", "y ~ x + x2", lambda fit, data: fit.ritest(resampvar="x", reps=11)),
+    (
+        "first_stage",
+        "y ~ x + [endog ~ z] | fe",
+        lambda fit, data: fit.first_stage(),
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ("method", "fml", "call"),
+    STORE_DATA_REJECTION_CASES,
+    ids=[case[0] for case in STORE_DATA_REJECTION_CASES],
+)
+def test_store_data_false_results_reject_data_dependent_methods(
+    lifecycle_data: pd.DataFrame,
+    method: str,
+    fml: str,
+    call,
+) -> None:
+    """Methods that read the estimation sample say how to supply it again."""
+    fit = pf.feols(fml, data=lifecycle_data, vcov="iid", store_data=False)
+
+    with pytest.raises(RuntimeError, match=rf"{method}\(\).*store_data=False"):
+        call(fit, lifecycle_data)
+
+
+def test_lean_glm_rejects_residualize_and_residuals() -> None:
+    """A lean GLM keeps neither its IRLS residuals nor its demeaning caches."""
+    data = pd.DataFrame({"y": [0, 1, 0, 1, 1, 0], "x": np.arange(6.0)})
+    fit = pf.feglm("y ~ x", data=data, family="logit", vcov="iid", lean=True)
+
+    with pytest.raises(
+        RuntimeError, match=r"resid\(\).*lean=True.*residual arrays were discarded"
+    ):
+        fit.resid("response")
+    with pytest.raises(RuntimeError, match=r"residualize\(\).*lean=True.*discarded"):
+        fit.residualize(
+            v=np.zeros((6, 1)),
+            X=np.ones((6, 1)),
+            flist=None,
+            weights=np.ones((6, 1)),
+            tol=1e-06,
+        )
+
+
+def test_lean_quantreg_rejects_objective_value() -> None:
+    """The quantile loss needs residuals that lean storage discarded."""
+    data = pd.DataFrame({"y": [0.2, 1.1, 1.8, 3.2, 3.9, 5.1], "x": np.arange(6.0)})
+    with pytest.warns(FutureWarning, match="experimental"):
+        fit = pf.quantreg("y ~ x", data=data, lean=True, vcov="iid", maxiter=100)
+
+    with pytest.raises(RuntimeError, match=r"objective_value\(\).*lean=True"):
+        _ = fit.objective_value
+
+
+@pytest.mark.parametrize("method", ["IV_Diag", "IV_weakness_test", "eff_F"])
+def test_lean_iv_rejects_first_stage_diagnostics(
+    lifecycle_data: pd.DataFrame,
+    method: str,
+) -> None:
+    """First-stage diagnostics need the retained first-stage fit."""
+    fit = pf.feols(
+        "y ~ x + [endog ~ z] | fe",
+        data=lifecycle_data,
+        vcov="hetero",
+        lean=True,
+    )
+
+    assert not hasattr(fit, "_model_1st_stage")
+    assert np.isfinite(fit._f_stat_1st_stage)
+    with pytest.raises(RuntimeError, match=rf"{method}\(\).*lean=True"):
+        getattr(fit, method)()
+
+
+def test_lean_results_predict_new_data_without_fixed_effects(
+    lifecycle_data: pd.DataFrame,
+) -> None:
+    """Lean results keep the formula spec and context needed for prediction."""
+    lean_fit = pf.feols("y ~ x + x2", data=lifecycle_data, vcov="iid", lean=True)
+    retained_fit = pf.feols("y ~ x + x2", data=lifecycle_data, vcov="iid")
+
+    np.testing.assert_allclose(
+        lean_fit.predict(newdata=lifecycle_data),
+        retained_fit.predict(newdata=lifecycle_data),
+    )
+
+
+def test_store_data_false_allows_array_only_vcov_updates(
+    lifecycle_data: pd.DataFrame,
+) -> None:
+    """Array-only covariance updates do not require retained formula data."""
+    stripped = pf.feols("y ~ x", data=lifecycle_data, vcov="iid", store_data=False)
+    expected = pf.feols("y ~ x", data=lifecycle_data, vcov="HC1")
+
+    stripped.vcov("HC1")
+
+    np.testing.assert_allclose(stripped._vcov, expected._vcov)
+    assert not hasattr(stripped, "_data")
+
+
+def test_store_data_false_vcov_uses_explicit_estimation_sample(
+    lifecycle_data: pd.DataFrame,
+) -> None:
+    """Data-dependent covariance updates use the documented data argument."""
+    stripped = pf.feols("y ~ x | fe", data=lifecycle_data, vcov="iid", store_data=False)
+    expected = pf.feols("y ~ x | fe", data=lifecycle_data, vcov={"CRV1": "fe"})
+
+    metadata_before = deepcopy(
+        (
+            stripped._vcov_type,
+            stripped._vcov_type_detail,
+            stripped._is_clustered,
+            stripped._clustervar,
+            stripped._G,
+            stripped._df_k,
+            stripped._df_t,
+        )
+    )
+    arrays_before = {
+        attr: getattr(stripped, attr).copy()
+        for attr in (
+            "_bread",
+            "_ssc",
+            "_vcov",
+            "_se",
+            "_tstat",
+            "_pvalue",
+            "_conf_int",
+        )
+    }
+
+    with pytest.raises(RuntimeError, match=r"store_data=False.*Pass.*data="):
+        stripped.vcov({"CRV1": "fe"})
+
+    assert (
+        stripped._vcov_type,
+        stripped._vcov_type_detail,
+        stripped._is_clustered,
+        stripped._clustervar,
+        stripped._G,
+        stripped._df_k,
+        stripped._df_t,
+    ) == metadata_before
+    for attr, value in arrays_before.items():
+        np.testing.assert_array_equal(getattr(stripped, attr), value)
+
+    stripped.vcov({"CRV1": "fe"}, data=lifecycle_data)
+
+    np.testing.assert_allclose(stripped._vcov, expected._vcov)
+    assert not hasattr(stripped, "_data")
+
+
+def test_vcov_rejects_unfiltered_explicit_data(
+    lifecycle_data: pd.DataFrame,
+) -> None:
+    """An explicit covariance sample must align with the fitted row arrays."""
+    data = lifecycle_data.copy()
+    data.loc[data.index[0], "y"] = np.nan
+    estimation_sample = data.dropna(subset=["y", "x", "fe"])
+    stripped = pf.feols(
+        "y ~ x | fe",
+        data=data,
+        vcov="iid",
+        store_data=False,
+    )
+    expected = pf.feols(
+        "y ~ x | fe",
+        data=estimation_sample,
+        vcov={"CRV1": "fe"},
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"already-filtered estimation sample.*original estimation order; "
+            r"expected 23 rows, received 24"
+        ),
+    ):
+        stripped.vcov({"CRV1": "fe"}, data=data)
+
+    stripped.vcov({"CRV1": "fe"}, data=estimation_sample)
+    np.testing.assert_allclose(stripped._vcov, expected._vcov)
+
+
+def test_lean_vcov_fails_with_storage_guidance(
+    lifecycle_data: pd.DataFrame,
+) -> None:
+    """Lean results explain that covariance inputs were intentionally discarded."""
+    fit = pf.feols("y ~ x", data=lifecycle_data, vcov="iid", lean=True)
+
+    with pytest.raises(RuntimeError, match=r"vcov\(\).*lean=True.*discarded"):
+        fit.vcov("HC1")

--- a/tests/test_feols_feglm_internally.py
+++ b/tests/test_feols_feglm_internally.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pandas as pd
 import pytest
 from scipy.stats import norm
 
@@ -35,16 +36,163 @@ fml_list = [
 fml_ols_vs_gaussian = ["Y ~ X1", "Y ~ X1 + C(f1)", "Y ~ X1 * X2"]
 
 
+@pytest.mark.parametrize("family", ["gaussian", "logit", "probit", "poisson"])
+def test_glm_keeps_formula_observation_and_working_domains_distinct(family):
+    """Retain formula inputs and observation weights beside final IWLS state."""
+    rng = np.random.default_rng(918273)
+    n_groups = 12
+    group_size = 15
+    n_obs = n_groups * group_size
+    fixed_effect = np.repeat(np.arange(n_groups), group_size)
+    covariate = rng.normal(size=n_obs)
+    linear_predictor = -0.2 + 0.7 * covariate + 0.05 * fixed_effect
+
+    if family == "gaussian":
+        response = linear_predictor + rng.normal(scale=0.5, size=n_obs)
+    elif family == "poisson":
+        # Strict positivity prevents a group from being removed for separation.
+        response = rng.poisson(np.exp(linear_predictor)) + 1
+    else:
+        probability = 1 / (1 + np.exp(-linear_predictor))
+        response = rng.binomial(1, probability)
+
+    observation_weights = np.linspace(0.5, 2.0, n_obs)
+    data = pd.DataFrame(
+        {
+            "y": response,
+            "x": covariate,
+            "fe": fixed_effect,
+            "weight": observation_weights,
+        }
+    )
+    fit = pf.feglm(
+        "y ~ x | fe",
+        data=data,
+        family=family,
+        weights="weight",
+        vcov="hetero",
+        separation_check=[],
+        iwls_tol=1e-10,
+    )
+
+    assert isinstance(fit._model_matrix.dependent, pd.DataFrame)
+    assert isinstance(fit._model_matrix.independent, pd.DataFrame)
+    assert isinstance(fit._fe, pd.DataFrame)
+    np.testing.assert_allclose(
+        fit._observation_weights.values,
+        observation_weights,
+    )
+    np.testing.assert_allclose(fit._weights.flatten(), observation_weights)
+
+    working = fit._working_state
+    assert fit._X is working.design_within
+    assert fit._Y is working.working_response_within
+    assert fit._Z is working.design_within
+    assert fit._irls_weights is working.working_weights
+    assert not hasattr(working, "sqrt_working_weights")
+    assert not hasattr(working, "design_solver")
+    assert not hasattr(working, "response_solver")
+
+    np.testing.assert_allclose(fit.resid("response"), working.response_residuals)
+    np.testing.assert_allclose(fit.resid("working"), working.working_residuals)
+    np.testing.assert_allclose(
+        fit._scores,
+        working.design_within
+        * (working.working_weights * working.working_residuals)[:, None],
+    )
+    expected_hessian = working.design_within.T @ (
+        working.working_weights[:, None] * working.design_within
+    )
+    np.testing.assert_allclose(fit._hessian, expected_hessian)
+    np.testing.assert_allclose(fit._leverage_weights(), working.working_weights)
+    np.testing.assert_allclose(fit._fixef_weights(), working.working_weights)
+
+    for group in np.unique(fixed_effect):
+        group_rows = fixed_effect == group
+        group_weights = working.working_weights[group_rows]
+        np.testing.assert_allclose(
+            group_weights @ working.design_within[group_rows],
+            0,
+            atol=1e-8,
+        )
+        np.testing.assert_allclose(
+            group_weights @ working.working_response_within[group_rows],
+            0,
+            atol=1e-8,
+        )
+
+    if family == "gaussian":
+        np.testing.assert_allclose(working.working_weights, observation_weights)
+    else:
+        assert not np.allclose(working.working_weights, observation_weights)
+
+
+@pytest.mark.parametrize("vcov", ["HC2", "HC3"])
+def test_feglm_frequency_weight_leverage_matches_expanded_sample(vcov):
+    """Use observation counts, not IRLS weights, in fweight HC leverage."""
+    rng = np.random.default_rng(102938)
+    covariate = np.linspace(-1.5, 1.5, 80)
+    probability = 1 / (1 + np.exp(-(-0.15 + 0.8 * covariate)))
+    aggregated = pd.DataFrame(
+        {
+            "y": rng.binomial(1, probability),
+            "x": covariate,
+            "count": rng.integers(1, 5, size=len(covariate)),
+        }
+    )
+    expanded = aggregated.loc[aggregated.index.repeat(aggregated["count"])].copy()
+
+    fit_frequency = pf.feglm(
+        "y ~ x",
+        data=aggregated,
+        family="logit",
+        weights="count",
+        weights_type="fweights",
+        vcov=vcov,
+        iwls_tol=1e-11,
+    )
+    fit_expanded = pf.feglm(
+        "y ~ x",
+        data=expanded,
+        family="logit",
+        vcov=vcov,
+        iwls_tol=1e-11,
+    )
+
+    np.testing.assert_allclose(
+        fit_frequency.coef(),
+        fit_expanded.coef(),
+        atol=1e-10,
+        err_msg="Frequency-weighted logit coefficients differ from row expansion.",
+    )
+    # Collapsing duplicate rows changes floating-point accumulation order and
+    # therefore the final IWLS stopping point at roughly the low 1e-6 scale.
+    np.testing.assert_allclose(
+        fit_frequency._vcov,
+        fit_expanded._vcov,
+        atol=1e-9,
+        rtol=5e-6,
+        err_msg=f"Frequency-weighted logit {vcov} differs from row expansion.",
+    )
+
+
 @pytest.mark.parametrize("fml", fml_ols_vs_gaussian)
 @pytest.mark.parametrize("inference", ["iid", "hetero", {"CRV1": "f1"}])
 @pytest.mark.parametrize("dropna", [True])
-def test_ols_vs_gaussian_glm(fml, inference, dropna):
+@pytest.mark.parametrize("weights", [None, "weights"])
+def test_ols_vs_gaussian_glm(fml, inference, dropna, weights):
     data = pf.get_data()
     if dropna:
         data = data.dropna()
 
-    fit_ols = pf.feols(fml=fml, data=data, vcov=inference)
-    fit_gaussian = pf.feglm(fml=fml, data=data, family="gaussian", vcov=inference)
+    fit_ols = pf.feols(fml=fml, data=data, vcov=inference, weights=weights)
+    fit_gaussian = pf.feglm(
+        fml=fml,
+        data=data,
+        family="gaussian",
+        vcov=inference,
+        weights=weights,
+    )
 
     check_absolute_diff(
         fit_ols.coef().xs("X1"), fit_gaussian.coef().xs("X1"), tol=1e-10

--- a/tests/test_feols_feglm_internally.py
+++ b/tests/test_feols_feglm_internally.py
@@ -176,6 +176,47 @@ def test_feglm_frequency_weight_leverage_matches_expanded_sample(vcov):
     )
 
 
+def test_feglm_frequency_weight_sample_size_survives_separation():
+    """Recompute effective and physical sample sizes in their distinct domains."""
+    aggregated = pd.DataFrame(
+        {
+            "y": [0, 0, 0, 0, 1, 0, 1, 0, 1, 1, 1, 0],
+            "x": [-1.2, -0.4, 0.7, -1.1, -0.2, 0.9, -0.8, 0.1, 1.2, -0.9, 0.4, 1.4],
+            "fe": np.repeat(list("abcd"), 3),
+            "count": [1, 3, 2, 2, 1, 4, 1, 2, 3, 3, 2, 1],
+        }
+    )
+    expanded = aggregated.loc[aggregated.index.repeat(aggregated["count"])].copy()
+
+    with pytest.warns(UserWarning, match="observations removed because of separation"):
+        fit_frequency = pf.feglm(
+            "y ~ x | fe",
+            data=aggregated,
+            family="logit",
+            weights="count",
+            weights_type="fweights",
+            vcov="HC1",
+            separation_check=["fe"],
+            iwls_tol=1e-11,
+        )
+    with pytest.warns(UserWarning, match="observations removed because of separation"):
+        fit_expanded = pf.feglm(
+            "y ~ x | fe",
+            data=expanded,
+            family="logit",
+            vcov="HC1",
+            separation_check=["fe"],
+            iwls_tol=1e-11,
+        )
+
+    assert fit_frequency._N == fit_expanded._N == 19
+    assert fit_frequency._N_rows == 9
+    assert fit_expanded._N_rows == 19
+    assert fit_frequency._observation_weights.n_effective == 19
+    np.testing.assert_allclose(fit_frequency.coef(), fit_expanded.coef(), atol=1e-10)
+    np.testing.assert_allclose(fit_frequency._vcov, fit_expanded._vcov, atol=1e-10)
+
+
 @pytest.mark.parametrize("fml", fml_ols_vs_gaussian)
 @pytest.mark.parametrize("inference", ["iid", "hetero", {"CRV1": "f1"}])
 @pytest.mark.parametrize("dropna", [True])

--- a/tests/test_feols_feglm_internally.py
+++ b/tests/test_feols_feglm_internally.py
@@ -104,8 +104,8 @@ def test_glm_keeps_formula_observation_and_working_domains_distinct(family):
         working.working_weights[:, None] * working.design_within
     )
     np.testing.assert_allclose(fit._hessian, expected_hessian)
-    np.testing.assert_allclose(fit._leverage_weights(), working.working_weights)
-    np.testing.assert_allclose(fit._fixef_weights(), working.working_weights)
+    np.testing.assert_allclose(fit._normal_equation_weights(), working.working_weights)
+    np.testing.assert_allclose(fit._fixef_recovery_weights(), working.working_weights)
 
     for group in np.unique(fixed_effect):
         group_rows = fixed_effect == group

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import pyfixest.estimation.internals.fit_ as fit_module
+from pyfixest.estimation.internals.fit_ import fit_iv, fit_ols
+
+
+@pytest.fixture
+def ols_arrays() -> tuple[np.ndarray, np.ndarray]:
+    X = np.array(
+        [
+            [1.0, -1.0],
+            [1.0, 0.0],
+            [1.0, 0.5],
+            [1.0, 2.0],
+            [1.0, 3.0],
+        ]
+    )
+    Y = np.array([[0.5], [1.0], [1.25], [2.5], [4.0]])
+    return X, Y
+
+
+@pytest.fixture
+def iv_arrays() -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    X = np.array(
+        [
+            [1.0, -1.0],
+            [1.0, 0.5],
+            [1.0, 2.0],
+            [1.0, 3.0],
+            [1.0, 1.5],
+        ]
+    )
+    Z = np.array(
+        [
+            [1.0, -0.5, 1.0],
+            [1.0, 0.0, -1.0],
+            [1.0, 1.5, 0.5],
+            [1.0, 2.5, 2.0],
+            [1.0, 1.0, -0.5],
+        ]
+    )
+    Y = np.array([[0.5], [1.0], [2.5], [4.0], [2.0]])
+    return X, Z, Y
+
+
+@pytest.mark.parametrize(
+    "weights",
+    [None, np.array([0.5, 1.0, 1.5, 2.0, 3.0])],
+    ids=("unweighted", "weighted"),
+)
+def test_fit_ols_matches_direct_equations_without_mutating_inputs(
+    ols_arrays: tuple[np.ndarray, np.ndarray],
+    weights: np.ndarray | None,
+) -> None:
+    X, Y = ols_arrays
+    X_before = X.copy()
+    Y_before = Y.copy()
+    weights_before = None if weights is None else weights.copy()
+    X.setflags(write=False)
+    Y.setflags(write=False)
+    if weights is not None:
+        weights.setflags(write=False)
+
+    fit = fit_ols(X=X, Y=Y, weights=weights)
+
+    weight_values = np.ones(X.shape[0]) if weights is None else weights.reshape(-1)
+    expected_tXX = X.T @ (weight_values[:, None] * X)
+    expected_tXy = X.T @ (weight_values[:, None] * Y)
+    expected_beta = np.linalg.solve(expected_tXX, expected_tXy).flatten()
+    expected_residuals = Y.flatten() - X @ expected_beta
+
+    np.testing.assert_allclose(fit.beta, expected_beta, err_msg="OLS coefficients")
+    np.testing.assert_allclose(
+        fit.residuals,
+        expected_residuals,
+        err_msg="OLS response-scale residuals",
+    )
+    np.testing.assert_allclose(
+        fit.scores,
+        X * (weight_values * expected_residuals)[:, None],
+        err_msg="OLS weighted scores",
+    )
+    np.testing.assert_allclose(
+        fit.hessian,
+        expected_tXX,
+        err_msg="OLS weighted Hessian",
+    )
+    np.testing.assert_allclose(
+        fit.tZX,
+        expected_tXX,
+        err_msg="OLS weighted X'X",
+    )
+    np.testing.assert_allclose(
+        fit.tZy,
+        expected_tXy,
+        err_msg="OLS weighted X'Y",
+    )
+    np.testing.assert_array_equal(X, X_before, err_msg="fit_ols mutated X")
+    np.testing.assert_array_equal(Y, Y_before, err_msg="fit_ols mutated Y")
+    if weights is not None:
+        np.testing.assert_array_equal(
+            weights,
+            weights_before,
+            err_msg="fit_ols mutated weights",
+        )
+
+
+@pytest.mark.parametrize(
+    "weights",
+    [None, np.array([[0.5], [1.0], [1.5], [2.0], [3.0]])],
+    ids=("unweighted", "weighted"),
+)
+def test_fit_iv_matches_direct_equations_without_mutating_inputs(
+    iv_arrays: tuple[np.ndarray, np.ndarray, np.ndarray],
+    weights: np.ndarray | None,
+) -> None:
+    X, Z, Y = iv_arrays
+    X_before = X.copy()
+    Z_before = Z.copy()
+    Y_before = Y.copy()
+    weights_before = None if weights is None else weights.copy()
+    X.setflags(write=False)
+    Z.setflags(write=False)
+    Y.setflags(write=False)
+    if weights is not None:
+        weights.setflags(write=False)
+
+    fit = fit_iv(X=X, Z=Z, Y=Y, weights=weights)
+
+    weight_values = np.ones(X.shape[0]) if weights is None else weights.reshape(-1)
+    expected_tZX = Z.T @ (weight_values[:, None] * X)
+    expected_tXZ = X.T @ (weight_values[:, None] * Z)
+    expected_tZy = Z.T @ (weight_values[:, None] * Y)
+    expected_tZZ = Z.T @ (weight_values[:, None] * Z)
+    expected_tZZinv = np.linalg.inv(expected_tZZ)
+    projection = expected_tXZ @ expected_tZZinv
+    expected_beta = np.linalg.solve(
+        projection @ expected_tZX,
+        projection @ expected_tZy,
+    ).flatten()
+    expected_residuals = Y.flatten() - X @ expected_beta
+
+    np.testing.assert_allclose(fit.beta, expected_beta, err_msg="IV coefficients")
+    np.testing.assert_allclose(
+        fit.residuals,
+        expected_residuals,
+        err_msg="IV response-scale residuals",
+    )
+    np.testing.assert_allclose(
+        fit.scores,
+        Z * (weight_values * expected_residuals)[:, None],
+        err_msg="IV weighted scores",
+    )
+    np.testing.assert_allclose(
+        fit.hessian,
+        expected_tZZ,
+        err_msg="IV weighted Z'Z",
+    )
+    np.testing.assert_allclose(
+        fit.tZX,
+        expected_tZX,
+        err_msg="IV weighted Z'X",
+    )
+    np.testing.assert_allclose(
+        fit.tXZ,
+        expected_tXZ,
+        err_msg="IV weighted X'Z",
+    )
+    np.testing.assert_allclose(
+        fit.tZy,
+        expected_tZy,
+        err_msg="IV weighted Z'Y",
+    )
+    np.testing.assert_allclose(
+        fit.tZZinv,
+        expected_tZZinv,
+        err_msg="inverse IV weighted Z'Z",
+    )
+    np.testing.assert_array_equal(X, X_before, err_msg="fit_iv mutated X")
+    np.testing.assert_array_equal(Z, Z_before, err_msg="fit_iv mutated Z")
+    np.testing.assert_array_equal(Y, Y_before, err_msg="fit_iv mutated Y")
+    if weights is not None:
+        np.testing.assert_array_equal(
+            weights,
+            weights_before,
+            err_msg="fit_iv mutated weights",
+        )
+
+
+@pytest.mark.parametrize("fit_name", ["ols", "iv"])
+def test_unweighted_fit_does_not_compute_sqrt_weights(
+    monkeypatch: pytest.MonkeyPatch,
+    ols_arrays: tuple[np.ndarray, np.ndarray],
+    iv_arrays: tuple[np.ndarray, np.ndarray, np.ndarray],
+    fit_name: str,
+) -> None:
+    def unexpected_sqrt(_: np.ndarray) -> np.ndarray:
+        raise AssertionError("the unweighted path must not transform unit weights")
+
+    monkeypatch.setattr(fit_module.np, "sqrt", unexpected_sqrt)
+    if fit_name == "ols":
+        X, Y = ols_arrays
+        fit_ols(X=X, Y=Y, weights=None)
+    else:
+        X, Z, Y = iv_arrays
+        fit_iv(X=X, Z=Z, Y=Y, weights=None)

--- a/tests/test_model_state.py
+++ b/tests/test_model_state.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 
 from pyfixest.estimation.internals.model_state import (
+    GlmWorkingState,
     ObservationWeights,
     WithinLinearData,
 )
@@ -94,3 +95,33 @@ def test_within_linear_data_is_structurally_immutable() -> None:
     assert not hasattr(state, "__dict__")
     with pytest.raises(FrozenInstanceError):
         state.response = design  # type: ignore[misc]
+
+
+def test_glm_working_state_names_every_persisted_domain() -> None:
+    working_response = np.arange(3.0)
+    design = np.arange(6.0).reshape(3, 2)
+    working_weights = np.array([1.0, 2.0, 3.0])
+    eta = np.array([-1.0, 0.0, 1.0])
+    mu = np.array([0.2, 0.5, 0.8])
+    response_residuals = np.array([-0.2, 0.5, 0.2])
+    working_residuals = np.array([-1.0, 1.0, 0.5])
+
+    state = GlmWorkingState(
+        working_response_within=working_response,
+        design_within=design,
+        working_weights=working_weights,
+        eta=eta,
+        mu=mu,
+        response_residuals=response_residuals,
+        working_residuals=working_residuals,
+    )
+
+    assert state.working_response_within is working_response
+    assert state.design_within is design
+    assert state.working_weights is working_weights
+    assert state.eta is eta
+    assert state.mu is mu
+    assert state.response_residuals is response_residuals
+    assert state.working_residuals is working_residuals
+    assert not hasattr(state, "sqrt_weights")
+    assert not hasattr(state, "__dict__")

--- a/tests/test_model_state.py
+++ b/tests/test_model_state.py
@@ -1,0 +1,96 @@
+from dataclasses import FrozenInstanceError
+
+import numpy as np
+import pytest
+
+from pyfixest.estimation.internals.model_state import (
+    ObservationWeights,
+    WithinLinearData,
+)
+
+
+def test_observation_weights_unweighted_fast_path() -> None:
+    weights = ObservationWeights.unweighted(n_rows=4)
+
+    assert weights.values is None
+    assert weights.kind is None
+    assert weights.n_rows == 4
+    assert weights.n_effective == 4
+    assert isinstance(weights.n_effective, int)
+    assert not weights.is_weighted
+    assert not hasattr(weights, "__dict__")
+
+
+@pytest.mark.parametrize(
+    ("kind", "expected_n"),
+    [("aweights", 3.0), ("fweights", 6.0)],
+)
+def test_observation_weights_keep_canonical_user_values(kind, expected_n) -> None:
+    user_weights = np.array([[1.0], [2.0], [3.0]])
+
+    weights = ObservationWeights.from_values(user_weights, kind=kind)
+
+    np.testing.assert_array_equal(weights.values, user_weights.flatten())
+    assert weights.kind == kind
+    assert weights.n_rows == 3
+    assert weights.n_effective == expected_n
+    assert isinstance(weights.n_effective, int if kind == "aweights" else float)
+    assert weights.is_weighted
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        (
+            {
+                "values": None,
+                "kind": "aweights",
+                "n_rows": 2,
+                "n_effective": 2.0,
+            },
+            "Unweighted observations cannot have a weight kind",
+        ),
+        (
+            {
+                "values": np.ones(2),
+                "kind": None,
+                "n_rows": 2,
+                "n_effective": 2.0,
+            },
+            "Weighted observations must declare a weight kind",
+        ),
+        (
+            {
+                "values": np.ones(2),
+                "kind": "pweights",
+                "n_rows": 2,
+                "n_effective": 2.0,
+            },
+            "Weight kind must be 'aweights' or 'fweights'",
+        ),
+    ],
+)
+def test_observation_weights_reject_inconsistent_state(kwargs, message) -> None:
+    with pytest.raises(ValueError, match=message):
+        ObservationWeights(**kwargs)
+
+
+def test_within_linear_data_is_structurally_immutable() -> None:
+    response = np.arange(3.0)[:, None]
+    design = np.column_stack((np.ones(3), np.arange(3.0)))
+    instruments = np.arange(6.0).reshape(3, 2)
+    endogenous = np.arange(3.0)[:, None]
+    state = WithinLinearData(
+        response=response,
+        design=design,
+        instruments=instruments,
+        endogenous=endogenous,
+    )
+
+    assert state.response is response
+    assert state.design is design
+    assert state.instruments is instruments
+    assert state.endogenous is endogenous
+    assert not hasattr(state, "__dict__")
+    with pytest.raises(FrozenInstanceError):
+        state.response = design  # type: ignore[misc]

--- a/tests/test_model_state.py
+++ b/tests/test_model_state.py
@@ -69,6 +69,42 @@ def test_observation_weights_keep_canonical_user_values(kind, expected_n) -> Non
             },
             "Weight kind must be 'aweights' or 'fweights'",
         ),
+        (
+            {
+                "values": None,
+                "kind": None,
+                "n_rows": -1,
+                "n_effective": -1,
+            },
+            "n_rows must be non-negative",
+        ),
+        (
+            {
+                "values": np.ones((2, 1)),
+                "kind": "aweights",
+                "n_rows": 2,
+                "n_effective": 2,
+            },
+            "Observation weight values must be a flat array",
+        ),
+        (
+            {
+                "values": np.ones(3),
+                "kind": "aweights",
+                "n_rows": 2,
+                "n_effective": 2,
+            },
+            "Observation weights must contain one value per row",
+        ),
+        (
+            {
+                "values": np.ones(2),
+                "kind": "fweights",
+                "n_rows": 2,
+                "n_effective": 3,
+            },
+            "n_effective must match the observation-weight semantics",
+        ),
     ],
 )
 def test_observation_weights_reject_inconsistent_state(kwargs, message) -> None:

--- a/tests/test_others.py
+++ b/tests/test_others.py
@@ -89,11 +89,12 @@ def test_coef_update():
     np.testing.assert_allclose(updated_coefs, full_coefs)
 
 
-def test_coef_update_inplace():
+def test_coef_update_inplace_is_explicitly_unsupported():
     rng = np.random.default_rng(1234)
     data = get_data().dropna(subset=["Y", "X1", "X2"])
     data_subsample = data.sample(frac=0.3, random_state=1234)
     m = feols("Y ~ X1 + X2", data=data_subsample)
+    original_coef = m.coef().copy()
     new_points_id = rng.choice(
         data.index.difference(data_subsample.index), 5, replace=False
     )
@@ -105,16 +106,10 @@ def test_coef_update_inplace():
         ],
         data.loc[new_points_id]["Y"].values,
     )
-    m.update(X_new, y_new, inplace=True)
-    full_coefs = (
-        feols(
-            "Y ~ X1 + X2",
-            data=data.loc[data_subsample.index.append(pd.Index(new_points_id))],
-        )
-        .coef()
-        .values
-    )
-    np.testing.assert_allclose(m.coef().values, full_coefs)
+    with pytest.raises(NotImplementedError, match=r"inplace=True.*not supported"):
+        m.update(X_new, y_new, inplace=True)
+
+    pd.testing.assert_series_equal(m.coef(), original_coef)
 
 
 def test_rename_categoricals():

--- a/tests/test_poisson.py
+++ b/tests/test_poisson.py
@@ -106,7 +106,7 @@ def test_against_fixest(fml):
     fit_r = fixest.fepois(ro.Formula(fml), data=data, vcov=vcov, glm_tol=iwls_tol)
 
     np.testing.assert_allclose(
-        fit_r.rx2("irls_weights").reshape(-1, 1), fit._weights, atol=1e-08, rtol=1e-07
+        fit_r.rx2("irls_weights"), fit._irls_weights, atol=1e-08, rtol=1e-07
     )
     np.testing.assert_allclose(
         fit_r.rx2("linear.predictors").reshape(-1, 1),

--- a/tests/test_vs_fixest.py
+++ b/tests/test_vs_fixest.py
@@ -74,6 +74,41 @@ def data_fepois(N=1000, seed=7651, beta_type="2", error_type="2"):
     )
 
 
+def _make_frequency_weighted_linear_data():
+    """Return deterministic aggregate linear and IV data (seed 20260901)."""
+    rng = np.random.default_rng(20260901)
+    n_per_group = 12
+    fixed_effect = np.repeat(list("abcd"), n_per_group)
+    fixed_effect_value = np.repeat([-0.8, -0.2, 0.3, 0.9], n_per_group)
+    x = rng.normal(size=4 * n_per_group)
+    z = rng.normal(size=4 * n_per_group)
+    d = (
+        0.9 * z
+        + 0.3 * x
+        + 0.25 * fixed_effect_value
+        + rng.normal(scale=0.35, size=len(x))
+    )
+    y = (
+        1.0
+        + 0.8 * d
+        - 0.5 * x
+        + fixed_effect_value
+        + rng.normal(scale=0.45, size=len(x))
+    )
+
+    data = pd.DataFrame(
+        {
+            "y": y,
+            "x": x,
+            "d": d,
+            "z": z,
+            "fe": fixed_effect,
+            "fweights": rng.integers(1, 5, size=len(x)),
+        }
+    )
+    return data
+
+
 rng = np.random.default_rng(8760985)
 
 
@@ -541,6 +576,71 @@ def test_single_fit_fepois(
         r_predict_link[0:5],
         1e-06,
         "py_predict_link != r_predict_link",
+    )
+
+
+@pytest.mark.against_r_core
+@pytest.mark.parametrize(
+    "fml",
+    [
+        "y ~ x",
+        "y ~ x | fe",
+        "y ~ x | d ~ z",
+        "y ~ x | fe | d ~ z",
+    ],
+)
+def test_frequency_weighted_linear_models_against_fixest(fml):
+    """Compare fweight OLS and IV covariance to R fixest literal expansion."""
+    data = _make_frequency_weighted_linear_data()
+    expanded_data = (
+        data.loc[data.index.repeat(data["fweights"])]
+        .drop(columns="fweights")
+        .reset_index(drop=True)
+    )
+    py_ssc = ssc(k_adj=True, G_adj=True)
+    r_ssc = fixest.ssc(True, "nonnested", False, True, "min", "min")
+
+    py_fit = pf.feols(
+        fml=fml,
+        data=data,
+        weights="fweights",
+        weights_type="fweights",
+        vcov="hetero",
+        ssc=py_ssc,
+    )
+    r_fit = fixest.feols(ro.Formula(fml), data=expanded_data, vcov="hetero", ssc=r_ssc)
+
+    ro.globalenv[".fweight_r_fit"] = r_fit
+    r_coefficient_names = list(ro.r("names(coef(.fweight_r_fit))"))
+    r_vcov_names = list(ro.r("rownames(vcov(.fweight_r_fit))"))
+    py_coefficient_names = list(py_fit.coef().index)
+    is_iv = "d ~ z" in fml
+    r_name_by_py_name = {
+        "Intercept": "(Intercept)",
+        "d": "fit_d" if is_iv else "d",
+    }
+    r_order = [
+        r_coefficient_names.index(r_name_by_py_name.get(name, name))
+        for name in py_coefficient_names
+    ]
+    r_vcov_order = [
+        r_vcov_names.index(r_name_by_py_name.get(name, name))
+        for name in py_coefficient_names
+    ]
+
+    np.testing.assert_allclose(
+        py_fit.coef().to_numpy(),
+        np.asarray(stats.coef(r_fit))[r_order],
+        rtol=0,
+        atol=1e-8,
+        err_msg="Fweight coefficients differ from the R fixest literal expansion",
+    )
+    np.testing.assert_allclose(
+        py_fit._vcov,
+        np.asarray(stats.vcov(r_fit))[np.ix_(r_vcov_order, r_vcov_order)],
+        rtol=0,
+        atol=1e-7,
+        err_msg="Fweight covariance differs from the R fixest literal expansion",
     )
 
 

--- a/tests/test_vs_fixest.py
+++ b/tests/test_vs_fixest.py
@@ -1531,6 +1531,62 @@ def test_singleton_dropping():
     # )
 
 
+@pytest.mark.against_r_core
+@pytest.mark.parametrize("fml", ["Y ~ X1", "Y ~ X1 | f1"])
+@pytest.mark.parametrize("vcov", ["iid", "hetero"])
+def test_fepois_frequency_weights_against_fixest(data_fepois, fml, vcov):
+    """Compare FEPoisson fweights with the literal expansion in R fixest."""
+    data = data_fepois.dropna().copy()
+    # A fixed-effect level holding a single physical row with a frequency
+    # weight above one is a singleton for pyfixest but not after literal
+    # expansion. Keeping only levels with more than one physical row makes the
+    # comparison independent of that deliberate deviation.
+    data = data.loc[data.groupby("f1")["f1"].transform("size") > 1]
+    data = data.reset_index(drop=True)
+    data["fweights"] = np.arange(len(data)) % 4 + 1
+    expanded_data = (
+        data.loc[data.index.repeat(data["fweights"])]
+        .drop(columns="fweights")
+        .reset_index(drop=True)
+    )
+    py_ssc = ssc(k_adj=True, G_adj=True)
+    r_ssc = fixest.ssc(True, "nonnested", False, True, "min", "min")
+
+    py_fit = pf.fepois(
+        fml=fml,
+        data=data,
+        weights="fweights",
+        weights_type="fweights",
+        vcov=vcov,
+        ssc=py_ssc,
+        iwls_tol=1e-10,
+        iwls_maxiter=100,
+    )
+    r_fit = fixest.fepois(
+        ro.Formula(fml),
+        data=expanded_data,
+        vcov=vcov,
+        ssc=r_ssc,
+        glm_tol=1e-10,
+        glm_iter=100,
+    )
+
+    np.testing.assert_allclose(
+        py_fit.coef().to_numpy(),
+        np.asarray(stats.coef(r_fit)),
+        rtol=0,
+        atol=1e-6,
+        err_msg="FEPoisson fweights differ from the R fixest literal expansion",
+    )
+    np.testing.assert_allclose(
+        py_fit._vcov,
+        np.asarray(stats.vcov(r_fit)),
+        rtol=0,
+        atol=1e-6,
+        err_msg="FEPoisson fweight covariance differs from the R fixest literal expansion",
+    )
+
+
 @pytest.fixture(scope="module")
 def ssc_data():
     data = {}

--- a/tests/test_wls_types.py
+++ b/tests/test_wls_types.py
@@ -1,7 +1,42 @@
 import numpy as np
+import pandas as pd
 import pytest
 
 import pyfixest as pf
+
+
+def _make_frequency_weight_data():
+    """Return aggregate rows and their literal frequency-weight expansion."""
+    x = np.array([-1.5, -0.5, 0.5, 1.5, -1.4, -0.4, 0.6, 1.4, -1.6, -0.6, 0.4, 1.6])
+    z = np.array([-1.0, 1.0, -1.0, 1.0, 1.0, -1.0, -1.0, 1.0, -1.0, -1.0, 1.0, 1.0])
+    first_stage_error = np.array(
+        [0.3, -0.2, 0.1, -0.1, -0.25, 0.2, -0.15, 0.05, 0.12, -0.18, 0.22, -0.08]
+    )
+    structural_error = np.array(
+        [0.2, -0.4, 0.3, -0.1, -0.25, 0.35, -0.2, 0.15, 0.28, -0.32, 0.18, -0.12]
+    )
+    fixef = np.repeat(["a", "b", "c"], 4)
+    fixef_effect = np.repeat([-0.8, 0.4, 1.1], 4)
+    count = np.array([1, 3, 2, 4, 2, 1, 3, 2, 4, 1, 2, 3])
+    endogenous = 1.1 * z + 0.25 * x + 0.15 * fixef_effect + first_stage_error
+    response = 1.0 + 1.4 * endogenous - 0.6 * x + fixef_effect + structural_error
+
+    aggregate = pd.DataFrame(
+        {
+            "y": response,
+            "x": x,
+            "d": endogenous,
+            "z": z,
+            "fe": fixef,
+            "count": count,
+        }
+    )
+    expanded = (
+        aggregate.loc[aggregate.index.repeat(count)]
+        .drop(columns="count")
+        .reset_index(drop=True)
+    )
+    return aggregate, expanded
 
 
 def _assert_fit_equal(fit1, fit2, vcov_types, rtol=1e-5):
@@ -68,6 +103,60 @@ def test_fweights_ols(fml, cols, vcov_types):
     _assert_fit_equal(fit_raw, fit_agg, vcov_types)
 
 
+@pytest.mark.parametrize(
+    "fml,vcov_types,performance_attributes",
+    [
+        ("y ~ x", ["iid", "HC1", "HC2", "HC3"], ["_rmse", "_r2", "_adj_r2"]),
+        (
+            "y ~ x | fe",
+            ["iid", "HC1"],
+            ["_rmse", "_r2", "_adj_r2", "_r2_within", "_adj_r2_within"],
+        ),
+    ],
+)
+def test_fweights_ols_matches_literal_expansion(
+    fml, vcov_types, performance_attributes
+):
+    """Frequency-weighted OLS state matches literally repeated observations."""
+    aggregate, expanded = _make_frequency_weight_data()
+    counts = aggregate["count"].to_numpy(dtype=np.int64)
+
+    fit_weighted = pf.feols(
+        fml,
+        data=aggregate,
+        weights="count",
+        weights_type="fweights",
+        vcov="iid",
+    )
+    fit_expanded = pf.feols(fml, data=expanded, vcov="iid")
+
+    _assert_fit_equal(fit_weighted, fit_expanded, vcov_types, rtol=1e-10)
+    assert len(expanded) == fit_weighted._N
+    assert fit_weighted._N_rows == len(aggregate)
+
+    np.testing.assert_allclose(
+        np.repeat(fit_weighted.resid(), counts),
+        fit_expanded.resid(),
+        rtol=1e-10,
+        atol=1e-10,
+    )
+    np.testing.assert_allclose(
+        fit_weighted.resid(),
+        fit_weighted._within_data.response.flatten()
+        - fit_weighted._X @ fit_weighted._beta_hat,
+        rtol=1e-10,
+        atol=1e-10,
+    )
+
+    for attribute in performance_attributes:
+        np.testing.assert_allclose(
+            getattr(fit_weighted, attribute),
+            getattr(fit_expanded, attribute),
+            rtol=1e-10,
+            atol=1e-10,
+        )
+
+
 @pytest.mark.skip(reason="Poisson fweights has a separate bug - see issue #367")
 @pytest.mark.parametrize(
     "fml,fe_col",
@@ -102,40 +191,83 @@ def test_fweights_poisson(fml, fe_col):
     _assert_fit_equal(fit_raw, fit_agg, vcov_types)
 
 
-@pytest.mark.skip(reason="Not implemented yet.")
-def test_fweights_iv():
-    data = pf.get_data()
-    data2_w = (
-        data[["Y", "X1", "Z1"]]
-        .groupby(["Y", "X1", "Z1"])
-        .size()
-        .reset_index()
-        .rename(columns={0: "count"})
-    )
+@pytest.mark.parametrize("fml", ["y ~ x + [d ~ z]", "y ~ x + [d ~ z] | fe"])
+def test_fweights_iv_matches_literal_expansion(fml):
+    """Frequency-weighted IV and first-stage state match repeated observations."""
+    aggregate, expanded = _make_frequency_weight_data()
+    counts = aggregate["count"].to_numpy(dtype=np.int64)
 
-    fit1 = pf.feols("Y ~ 1 | X1 ~ Z1", data=data)
-    fit2 = pf.feols(
-        "Y ~ 1 | X1 ~ Z1", data=data2_w, weights="count", weights_type="fweights"
-    )
-    np.testing.assert_allclose(fit1.tidy().values, fit2.tidy().values)
-
-    data3_w = (
-        data[["Y", "X1", "Z1", "f1"]]
-        .groupby(["Y", "X1", "Z1", "f1"])
-        .size()
-        .reset_index()
-        .rename(columns={0: "count"})
-    )
-
-    fit3 = pf.feols("Y ~ 1 | f1 | X1 ~ Z1 ", data=data.dropna(), vcov={"CRV1": "f1"})
-    fit4 = pf.feols(
-        "Y ~ 1 | f1 | X1 ~ Z1",
-        data=data3_w.dropna(),
+    fit_weighted = pf.feols(
+        fml,
+        data=aggregate,
         weights="count",
         weights_type="fweights",
-        vcov={"CRV1": "f1"},
+        vcov="hetero",
     )
-    np.testing.assert_allclose(fit3.tidy().values, fit4.tidy().values)
+    fit_expanded = pf.feols(fml, data=expanded, vcov="hetero")
+
+    np.testing.assert_allclose(
+        fit_weighted.coef().values,
+        fit_expanded.coef().values,
+        rtol=1e-10,
+        atol=1e-10,
+    )
+    np.testing.assert_allclose(
+        fit_weighted._vcov, fit_expanded._vcov, rtol=1e-10, atol=1e-10
+    )
+    np.testing.assert_allclose(
+        np.repeat(fit_weighted.resid(), counts),
+        fit_expanded.resid(),
+        rtol=1e-10,
+        atol=1e-10,
+    )
+
+    np.testing.assert_allclose(
+        fit_weighted._pi_hat, fit_expanded._pi_hat, rtol=1e-10, atol=1e-10
+    )
+    np.testing.assert_allclose(
+        np.repeat(fit_weighted._X_hat, counts),
+        fit_expanded._X_hat,
+        rtol=1e-10,
+        atol=1e-10,
+    )
+    np.testing.assert_allclose(
+        np.repeat(fit_weighted._v_hat, counts),
+        fit_expanded._v_hat,
+        rtol=1e-10,
+        atol=1e-10,
+    )
+    np.testing.assert_allclose(
+        fit_weighted._X_hat,
+        fit_weighted._model_1st_stage._X @ fit_weighted._pi_hat,
+        rtol=1e-10,
+        atol=1e-10,
+    )
+    np.testing.assert_allclose(
+        fit_weighted._v_hat,
+        fit_weighted._model_1st_stage._within_data.response.flatten()
+        - fit_weighted._X_hat,
+        rtol=1e-10,
+        atol=1e-10,
+    )
+    np.testing.assert_allclose(
+        fit_weighted._f_stat_1st_stage,
+        fit_expanded._f_stat_1st_stage,
+        rtol=1e-10,
+        atol=1e-10,
+    )
+    np.testing.assert_allclose(
+        fit_weighted._p_value_1st_stage,
+        fit_expanded._p_value_1st_stage,
+        rtol=1e-10,
+        atol=1e-10,
+    )
+
+    fit_weighted.IV_Diag()
+    fit_expanded.IV_Diag()
+    np.testing.assert_allclose(
+        fit_weighted._eff_F, fit_expanded._eff_F, rtol=1e-10, atol=1e-10
+    )
 
 
 def test_aweights():

--- a/tests/test_wls_types.py
+++ b/tests/test_wls_types.py
@@ -157,6 +157,49 @@ def test_fweights_ols_matches_literal_expansion(
         )
 
 
+def test_fweights_singleton_detection_counts_physical_rows():
+    """Singleton detection stays physical-row based under frequency weights.
+
+    An aggregate row that is alone in its fixed-effect level is dropped as a
+    singleton even though its frequency weight stands for several observations.
+    This is a deliberate deviation from the literal expansion, where that level
+    holds more than one row and therefore survives; changing it would move the
+    sample size, degrees of freedom, and standard errors of every
+    frequency-weighted fixed-effect fit.
+    """
+    aggregate = pd.DataFrame(
+        {
+            "y": [1.0, 2.0, 3.0, 2.5, 1.5, 3.5, 2.0],
+            "x": [-1.0, 0.5, 1.5, -0.5, 1.0, 0.25, -1.5],
+            "fe": ["a", "a", "a", "b", "b", "b", "c"],
+            "count": [1, 2, 3, 2, 1, 2, 2],
+        }
+    )
+    expanded = (
+        aggregate.loc[aggregate.index.repeat(aggregate["count"])]
+        .drop(columns="count")
+        .reset_index(drop=True)
+    )
+
+    with pytest.warns(UserWarning, match=r"1 singleton fixed effect\(s\) dropped"):
+        fit_weighted = pf.feols(
+            "y ~ x | fe",
+            data=aggregate,
+            weights="count",
+            weights_type="fweights",
+            vcov="iid",
+        )
+    fit_expanded = pf.feols("y ~ x | fe", data=expanded, vcov="iid")
+
+    dropped_count = int(aggregate.loc[aggregate["fe"] == "c", "count"].sum())
+    effective_n = int(aggregate["count"].sum()) - dropped_count
+
+    assert fit_weighted._N_rows == len(aggregate) - 1
+    assert effective_n == fit_weighted._N
+    # The same level is not a singleton once the rows are literally repeated.
+    assert fit_expanded._N_rows == len(expanded)
+
+
 @pytest.mark.parametrize(
     "fml,fe_col",
     [

--- a/tests/test_wls_types.py
+++ b/tests/test_wls_types.py
@@ -157,7 +157,6 @@ def test_fweights_ols_matches_literal_expansion(
         )
 
 
-@pytest.mark.skip(reason="Poisson fweights has a separate bug - see issue #367")
 @pytest.mark.parametrize(
     "fml,fe_col",
     [
@@ -177,13 +176,15 @@ def test_fweights_poisson(fml, fe_col):
         data[cols].groupby(cols).size().reset_index().rename(columns={0: "count"})
     )
 
-    fit_raw = pf.fepois(fml, data=data, vcov="iid")
+    fit_raw = pf.fepois(fml, data=data, vcov="iid", iwls_tol=1e-12, iwls_maxiter=100)
     fit_agg = pf.fepois(
         fml,
         data=data_agg,
         weights="count",
         weights_type="fweights",
         vcov="iid",
+        iwls_tol=1e-12,
+        iwls_maxiter=100,
     )
 
     # Poisson only supports HC1 for hetero-robust SEs


### PR DESCRIPTION
Separates formula data, within-transformed arrays, observation weights, and GLM working state in the shared estimation core. Solver weighting stays local; stored residuals retain response units and scores carry weights explicitly. This enables Poisson/GLM frequency weights (#367) without repurposing observation-weight state.

The review follow-up makes the correctness argument visible: normal-equation weights are distinct from frequency counts, score/leverage formulas sit beside their calculations, and cache ordering and shared-buffer ownership are explicit. Complete cache hits avoid an unnecessary concatenation; no measured speedup is claimed.

- Getter-only aliases prevent rebinding, not arbitrary array mutation. Shared demeaned cache buffers are explicitly read-only.
- Weighted `ccv()` and `update(inplace=True)` remain rejected; singleton detection retains physical-row behavior.
- Storage/lifecycle completion and transactional covariance updates belong to dependent #1501. #1499 is unchanged; no later stack layers were rewritten.

Local follow-up verification: 1,355 release-contract cases passed; targeted tests 130 passed, two CUDA skips; Ruff, mypy, and whitespace checks passed. On `b909582c`, Linux Python and R core-other/extended/HAC CI passed. The fixest job stopped at a quantile NID standard-error preflight failure, now under diagnosis; its canonical suite did not run. macOS/docs CI remains pending. Earlier macOS CI had Torch/MPS failures. Human review remains required.
