### PR TITLE
fix(estimation): estimation-state contracts for refits, storage, and unsupported paths

### DIFF
--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -219,6 +219,13 @@ We also removed:
 
 - Removed `pf.dtable()`; use `maketables.DTable()` directly instead.
 
+Storage options:
+
+- `store_data=False` and `lean=True` now apply to multiple-estimation
+  containers; `FixestMulti.vcov()` accepts a common explicit estimation sample;
+  default multi-quantile results retain the arrays needed for prediction and
+  covariance updates.
+
 ### Bug Fixes
 
 - `lean=True` results keep the formula specification and evaluation context, so

--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -61,6 +61,9 @@ fit3 = pf.feols("Y ~ X1 + X2 | f1", data = df)
   non-OLS models instead of mixing scales.
 - Non-Poisson GLMs reject `CRV3` instead of silently refitting through the
   Poisson jackknife. Poisson `CRV3` remains supported.
+- CRV3 jackknife and slow randomization-inference refits now replay the
+  original estimation options (weights, small-sample corrections, singleton
+  handling, solver, demeaner, offset, IRLS tolerances).
 - `tidy()`, `confint()`, and `summary()` gain an `inference_type` argument.
   `confint()` takes `"regular"` (pointwise, the default), `"simult"`
   (simultaneous / joint intervals), or `"savi"`; `tidy()` and `summary()` take

--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -59,6 +59,8 @@ fit3 = pf.feols("Y ~ X1 + X2 | f1", data = df)
 - Weighted models now reject `ccv()` explicitly. `Feols.update()` remains a
   coefficient-only calculation and rejects `inplace=True`, weights, IV, and
   non-OLS models instead of mixing scales.
+- Non-Poisson GLMs reject `CRV3` instead of silently refitting through the
+  Poisson jackknife. Poisson `CRV3` remains supported.
 - `tidy()`, `confint()`, and `summary()` gain an `inference_type` argument.
   `confint()` takes `"regular"` (pointwise, the default), `"simult"`
   (simultaneous / joint intervals), or `"savi"`; `tidy()` and `summary()` take

--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -55,6 +55,9 @@ fit3 = pf.feols("Y ~ X1 + X2 | f1", data = df)
   read-only views over the typed state objects.
 - Internal demeaning and covariance code now names column-order, normal-equation,
   and frequency-replication invariants explicitly alongside their formulas.
+- Post-fit covariance updates now prepare covariance metadata and derived
+  inference before publishing them. Multiple-estimation and quantile-process
+  updates likewise prepare every child before changing any child.
 
 ### Inference Types
 
@@ -240,6 +243,8 @@ We also removed:
   while Matplotlib, Seaborn, and Lets-Plot load only when plotting.
 - Weighted fixed-effect contributions (`_sumFE`) are now stored in response
   units.
+- Gaussian GLM performance measures now use the estimator's unpremultiplied
+  within response and observation weights, including weighted fixed-effect fits.
 - `IV_Diag()` no longer relabels the main model's covariance type when computing
   the effective F statistic.
 - CCV auxiliary fits now retain the original demeaner configuration.

--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -230,6 +230,8 @@ We also removed:
   while Matplotlib, Seaborn, and Lets-Plot load only when plotting.
 - Weighted fixed-effect contributions (`_sumFE`) are now stored in response
   units.
+- `IV_Diag()` no longer relabels the main model's covariance type when computing
+  the effective F statistic.
 - CCV auxiliary fits now retain the original demeaner configuration.
 - IR separation checks now use the configured demeaner backend.
 - Fixes `confint()` when `keep` or `drop` requests coefficients in an order

--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -219,13 +219,6 @@ We also removed:
 
 - Removed `pf.dtable()`; use `maketables.DTable()` directly instead.
 
-Storage options:
-
-- `store_data=False` and `lean=True` now apply to multiple-estimation
-  containers; `FixestMulti.vcov()` accepts a common explicit estimation sample;
-  default multi-quantile results retain the arrays needed for prediction and
-  covariance updates.
-
 ### Bug Fixes
 
 - `lean=True` results keep the formula specification and evaluation context, so
@@ -236,6 +229,10 @@ Storage options:
 - `store_data=False` and `lean=True` now apply to retained IV first stages; lean
   fits also discard demeaning caches, GLM working state, and quantile solver
   outputs.
+- `store_data=False` and `lean=True` now apply to multiple-estimation
+  containers; `FixestMulti.vcov()` accepts a common explicit estimation sample;
+  default multi-quantile results retain the arrays needed for prediction and
+  covariance updates.
 - Fitted models and non-plotting DiD and reporting paths no longer import
   plotting dependencies eagerly. `ritest()` loads its numerical helpers on use,
   while Matplotlib, Seaborn, and Lets-Plot load only when plotting.

--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -228,6 +228,8 @@ We also removed:
 - Fitted models and non-plotting DiD and reporting paths no longer import
   plotting dependencies eagerly. `ritest()` loads its numerical helpers on use,
   while Matplotlib, Seaborn, and Lets-Plot load only when plotting.
+- Weighted fixed-effect contributions (`_sumFE`) are now stored in response
+  units.
 - CCV auxiliary fits now retain the original demeaner configuration.
 - IR separation checks now use the configured demeaner backend.
 - Fixes `confint()` when `keep` or `drop` requests coefficients in an order

--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -64,6 +64,10 @@ fit3 = pf.feols("Y ~ X1 + X2 | f1", data = df)
 - CRV3 jackknife and slow randomization-inference refits now replay the
   original estimation options (weights, small-sample corrections, singleton
   handling, solver, demeaner, offset, IRLS tolerances).
+- Randomization inference rejects non-OLS/non-Poisson results, the wild
+  bootstrap rejects non-OLS results, and `decompose()` rejects non-OLS results,
+  instead of reinterpreting GLM working state or quantile solver outputs as OLS
+  arrays.
 - `tidy()`, `confint()`, and `summary()` gain an `inference_type` argument.
   `confint()` takes `"regular"` (pointwise, the default), `"simult"`
   (simultaneous / joint intervals), or `"savi"`; `tidy()` and `summary()` take

--- a/docs/developer/architecture.md
+++ b/docs/developer/architecture.md
@@ -289,11 +289,14 @@ fixed effects. Array-only covariance updates remain available after
 through the documented `vcov(data=...)` argument. Explicit covariance data must
 already be filtered to the fitted row sample and retain its estimation order. A
 row-count check rejects length mismatches but cannot establish row identity or
-ordering. `FixestMulti.vcov(data=...)` validates one common sample for every
-child before any child is updated. Lean results reject post-fit covariance updates because
-their numerical arrays have been discarded. Every other method that needs
-discarded state raises an informative error naming the storage option and its
-remedy.
+ordering. Single-model covariance updates compute covariance metadata and
+derived inference on a detached candidate before publishing any fields.
+`FixestMulti.vcov(data=...)` validates one common sample, and both multiple-
+estimation containers prepare every child before publishing any child, while
+preserving the child objects themselves. Lean results reject post-fit covariance
+updates because their numerical arrays have been discarded. Every other method
+that needs discarded state raises an informative error naming the storage option
+and its remedy.
 
 Keeping canonical arrays unpremultiplied favors readability without moving
 weight work out of the numerical hot path: each solver still performs the same

--- a/docs/developer/architecture.md
+++ b/docs/developer/architecture.md
@@ -263,19 +263,36 @@ fixed effects, but rejects `inplace=True`: design rows alone cannot reconstruct
 the complete formula, prediction, inference, and performance state of a fitted
 result.
 
-Storage policy follows the full result graph. Retained IV first stages honor
-`store_data=False`, and lean results discard within state, GLM working state,
-demeaning caches, quantile solver outputs, and large first-stage arrays. Lean
-results do keep the formula specification and evaluation context, so
-`predict(newdata=...)` still works for models without fixed effects. Array-only
-covariance updates remain available after `store_data=False`; cluster and HAC
-updates require the estimation sample through the documented `vcov(data=...)`
-argument. Explicit covariance data must already be filtered to the fitted row
-sample and retain its estimation order; a row-count check rejects misaligned
-inputs before covariance dispatch. Lean results reject post-fit covariance
-updates because their numerical arrays have been discarded. Every other method
-that needs discarded state raises an informative error naming the storage
-option and its remedy.
+Post-estimation paths reject the estimators they cannot represent instead of
+reading their arrays as OLS state. Non-Poisson GLMs reject `CRV3` until their
+leave-cluster-out refits can retain the original family and solver
+configuration; Poisson keeps its longstanding jackknife-refit path.
+Randomization inference rejects non-OLS/non-Poisson results, and the wild
+bootstrap and `decompose()` reject non-OLS results, so none of them
+reinterprets GLM working state or quantile solver outputs as linear-model
+arrays. Poisson CRV3 and slow randomization refits replay the original
+estimation options. A prebuilt LSMR preconditioner is the sole exception: its
+factorization belongs to one fixed-effect design, so refits keep its variant
+but rebuild it for the changed row set. Weighted `fixef()` stores `_sumFE` in
+response units, and `IV_Diag()` leaves the outer model's covariance label
+untouched.
+
+Storage policy follows the full result graph. Multiple-estimation containers
+keep no copy of the input frame under `store_data=False` or `lean=True`,
+retained IV first stages honor `store_data=False`, and lean results discard
+within state, GLM working state, demeaning caches, quantile solver outputs, and
+large first-stage arrays. Lean results do keep the formula specification and
+evaluation context, so `predict(newdata=...)` still works for models without
+fixed effects. Array-only covariance updates remain available after
+`store_data=False`; cluster and HAC updates require the estimation sample
+through the documented `vcov(data=...)` argument. Explicit covariance data must
+already be filtered to the fitted row sample and retain its estimation order; a
+row-count check rejects misaligned inputs before covariance dispatch, and
+`FixestMulti.vcov(data=...)` validates one common sample for every child before
+any child is updated. Lean results reject post-fit covariance updates because
+their numerical arrays have been discarded. Every other method that needs
+discarded state raises an informative error naming the storage option and its
+remedy.
 
 Keeping canonical arrays unpremultiplied favors readability without moving
 weight work out of the numerical hot path: each solver still performs the same

--- a/pyfixest/estimation/FixestMulti_.py
+++ b/pyfixest/estimation/FixestMulti_.py
@@ -13,6 +13,7 @@ from pyfixest.estimation.models.feiv_ import Feiv
 from pyfixest.estimation.models.feols_ import Feols
 from pyfixest.estimation.models.fepois_ import Fepois
 from pyfixest.estimation.plan_ import ParsedFormula
+from pyfixest.utils.dev_utils import DataFrameType, _narwhals_to_pandas
 
 
 class FixestMulti(TidyColumnAccessors):
@@ -67,10 +68,11 @@ class FixestMulti(TidyColumnAccessors):
         context : Mapping[str, Any]
             Captured evaluation scope (from `capture_context`).
         """
-        self._config = config
         self._parsed = parsed
-        self._data = data
-        self._context = context
+        if config.store_data and not config.lean:
+            self._config = config
+            self._data = data
+            self._context = context
 
         self.all_fitted_models: dict[str, Feols | Fepois | Feiv] = {}
 
@@ -119,7 +121,8 @@ class FixestMulti(TidyColumnAccessors):
         self,
         vcov: str | dict[str, str],
         vcov_kwargs: dict[str, str | int] | None = None,
-    ):
+        data: DataFrameType | None = None,
+    ) -> FixestMulti:
         """
         Update regression inference "on the fly".
 
@@ -137,13 +140,54 @@ class FixestMulti(TidyColumnAccessors):
             for CRV1 inference or {"CRV3": "clustervar"} for CRV3 inference.
         vcov_kwargs : Optional[dict[str, any]]
              Additional keyword arguments for the variance-covariance matrix.
+        data : DataFrameType, optional
+            The common, already-filtered estimation sample in its original order.
+            Required for data-dependent covariance updates when the fitted models
+            were created with `store_data=False`. Defaults to None.
 
         Returns
         -------
-            An instance of the "Fixest" class with updated inference.
+        FixestMulti
+            This result container with updated inference.
         """
+        data_to_forward = data
+        if data is not None:
+            try:
+                data_to_forward = _narwhals_to_pandas(data)
+            except TypeError as exc:
+                raise TypeError(
+                    f"The data set must be a DataFrame type. Received: {type(data)}"
+                ) from exc
+
+            models = list(self.all_fitted_models.values())
+            expected_rows = sorted({model._N_rows for model in models})
+            received_rows = len(data_to_forward)
+            if any(n_rows != received_rows for n_rows in expected_rows):
+                raise ValueError(
+                    "`data` passed to FixestMulti.vcov() must contain the common, "
+                    "already-filtered estimation sample in its original order for "
+                    "every child model; expected child row counts "
+                    f"{expected_rows}, received {received_rows}. Fetch each child "
+                    "model and call vcov(..., data=...) separately when estimation "
+                    "samples differ."
+                )
+
+            reference = models[0] if models else None
+            if reference is not None and any(
+                model._sample_split_var != reference._sample_split_var
+                or model._sample_split_value != reference._sample_split_value
+                or model._na_index != reference._na_index
+                for model in models[1:]
+            ):
+                raise ValueError(
+                    "`data` cannot be forwarded by FixestMulti.vcov() because its "
+                    "child models use different estimation samples. Fetch each "
+                    "child model and call vcov(..., data=...) with that model's "
+                    "already-filtered estimation sample instead."
+                )
+
         for fxst in self.all_fitted_models.values():
-            fxst.vcov(vcov=vcov, vcov_kwargs=vcov_kwargs)
+            fxst.vcov(vcov=vcov, vcov_kwargs=vcov_kwargs, data=data_to_forward)
         return self
 
     def tidy(self) -> pd.DataFrame:

--- a/pyfixest/estimation/FixestMulti_.py
+++ b/pyfixest/estimation/FixestMulti_.py
@@ -186,8 +186,17 @@ class FixestMulti(TidyColumnAccessors):
                     "already-filtered estimation sample instead."
                 )
 
-        for fxst in self.all_fitted_models.values():
-            fxst.vcov(vcov=vcov, vcov_kwargs=vcov_kwargs, data=data_to_forward)
+        models = list(self.all_fitted_models.values())
+        candidates = [
+            model._prepare_vcov_update(
+                vcov=vcov,
+                vcov_kwargs=vcov_kwargs,
+                data=data_to_forward,
+            )
+            for model in models
+        ]
+        for model, candidate in zip(models, candidates, strict=True):
+            model._publish_vcov_update(candidate)
         return self
 
     def tidy(self) -> pd.DataFrame:

--- a/pyfixest/estimation/models/_result_accessor_mixin.py
+++ b/pyfixest/estimation/models/_result_accessor_mixin.py
@@ -10,10 +10,7 @@ from pyfixest.errors import EmptyVcovError
 
 if TYPE_CHECKING:
     from pyfixest.estimation.internals.families import InferenceDist
-    from pyfixest.estimation.internals.model_state import (
-        ObservationWeights,
-        WithinLinearData,
-    )
+    from pyfixest.estimation.internals.model_state import ObservationWeights
 from pyfixest.estimation.internals.literals import (
     InferenceType,
     _validate_literal_argument,
@@ -133,7 +130,6 @@ class ResultAccessorMixin(TidyColumnAccessors):
     _conf_int: np.ndarray
     _u_hat: np.ndarray
     _observation_weights: "ObservationWeights"
-    _within_data: "WithinLinearData"
     _response: np.ndarray
     _coefnames: list[str]
     _method: str
@@ -153,6 +149,11 @@ class ResultAccessorMixin(TidyColumnAccessors):
     _r2_within: float
     _adj_r2_within: float
     _vcov_type: str
+
+    @property
+    def _Y(self) -> np.ndarray:
+        """Estimator-specific within-response view."""
+        raise NotImplementedError
 
     def _require_fit_arrays(
         self,
@@ -324,7 +325,12 @@ class ResultAccessorMixin(TidyColumnAccessors):
         self._require_fit_arrays(
             "get_performance", arrays="the response and within arrays"
         )
-        Y_within = self._within_data.response.flatten()
+        # Shared result code must use the estimator's within-response view:
+        # linear models expose WithinLinearData, while Gaussian GLMs expose the
+        # final unpremultiplied IRLS working response through the same alias.
+        # For Gaussian GLMs this is within(y - offset); the global denominator
+        # below deliberately remains centered on the raw response y.
+        Y_within = self._Y.flatten()
         Y = self._response
         observation_weights = self._observation_weights.values
 

--- a/pyfixest/estimation/models/feglm_.py
+++ b/pyfixest/estimation/models/feglm_.py
@@ -118,6 +118,7 @@ class Feglm(Feols):
         self._support_crv3_inference = False
         self._support_iid_inference = True
         self._support_hac_inference = True
+        self._supports_wildboottest = False
         self._supports_cluster_causal_variance = False
         self._support_decomposition = False
 

--- a/pyfixest/estimation/models/feglm_.py
+++ b/pyfixest/estimation/models/feglm_.py
@@ -113,7 +113,9 @@ class Feglm(Feols):
         self.separation_check = separation_check
         self._accelerate = accelerate
 
-        self._support_crv3_inference = True
+        # The inherited slow jackknife refits with the linear/Poisson APIs and
+        # cannot yet preserve a generic GLM family's estimation contract.
+        self._support_crv3_inference = False
         self._support_iid_inference = True
         self._support_hac_inference = True
         self._supports_cluster_causal_variance = False

--- a/pyfixest/estimation/models/feiv_.py
+++ b/pyfixest/estimation/models/feiv_.py
@@ -549,7 +549,6 @@ class Feiv(Feols):
         # If vcov is iid, redo first stage regression
 
         if self._vcov_type_detail == "iid":
-            self._vcov_type_detail = "hetero"
             self._model_1st_stage.vcov("hetero")
 
         # Compute Effective F stat by Olea and Pflueger 2013

--- a/pyfixest/estimation/models/feols_.py
+++ b/pyfixest/estimation/models/feols_.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import re
 import warnings
 from collections.abc import Mapping
+from copy import copy as shallow_copy
 from dataclasses import replace
 from functools import partial
 from importlib import import_module
@@ -725,6 +726,71 @@ class Feols(ResultAccessorMixin):
         See [On Small Sample Corrections](/explanation/ssc.qmd) for how the
         `ssc` adjustments interact with each estimator.
         """
+        candidate = self._prepare_vcov_update(
+            vcov=vcov,
+            vcov_kwargs=vcov_kwargs,
+            data=data,
+        )
+        self._publish_vcov_update(candidate)
+        return self
+
+    def _prepare_vcov_update(
+        self,
+        *,
+        vcov: str | dict[str, str],
+        vcov_kwargs: dict[str, str | int] | None,
+        data: DataFrameType | None,
+    ) -> Feols:
+        """Compute a covariance update without changing this fitted result.
+
+        The candidate shares fitted input arrays with this result. Covariance
+        callbacks treat those arrays as inputs and allocate their outputs, so
+        only the candidate's inference fields change during computation.
+        """
+        candidate = shallow_copy(self)
+        candidate._compute_vcov_update(
+            vcov=vcov,
+            vcov_kwargs=vcov_kwargs,
+            data=data,
+        )
+        return candidate
+
+    def _publish_vcov_update(self, candidate: Feols) -> None:
+        """Publish a completely computed covariance and inference state."""
+        inference_attributes = (
+            "_vcov_type",
+            "_vcov_type_detail",
+            "_is_clustered",
+            "_clustervar",
+            "_bread",
+            "_ssc",
+            "_df_k",
+            "_df_t",
+            "_vcov",
+            "_lag",
+            "_time_id",
+            "_panel_id",
+            "_cluster_df",
+            "_G",
+            "_se",
+            "_tstat",
+            "_pvalue",
+            "_conf_int",
+        )
+        for attribute in inference_attributes:
+            if hasattr(candidate, attribute):
+                setattr(self, attribute, getattr(candidate, attribute))
+            elif hasattr(self, attribute):
+                delattr(self, attribute)
+
+    def _compute_vcov_update(
+        self,
+        *,
+        vcov: str | dict[str, str],
+        vcov_kwargs: dict[str, str | int] | None,
+        data: DataFrameType | None,
+    ) -> None:
+        """Compute covariance and derived inference on this candidate."""
         self._require_fit_arrays(
             "vcov",
             arrays="the required estimation arrays",
@@ -757,8 +823,7 @@ class Feols(ResultAccessorMixin):
             vcov, self._has_fixef, self._is_iv
         )
 
-        # Reject before any inference state is overwritten, so a failed update
-        # leaves the previous covariance estimate intact.
+        # Cluster and HAC estimators need columns from the estimation sample.
         if vcov_type in {"HAC", "CRV"} and estimation_data is None:
             self._require_estimation_data(
                 "vcov",
@@ -827,8 +892,6 @@ class Feols(ResultAccessorMixin):
             )
         # update p-value, t-stat, standard error, confint
         self.get_inference()
-
-        return self
 
     def _make_ssc_kwargs(
         self,

--- a/pyfixest/estimation/models/feols_.py
+++ b/pyfixest/estimation/models/feols_.py
@@ -1933,7 +1933,7 @@ class Feols(ResultAccessorMixin):
             ].transform_state,
         )
         self._alpha = alpha
-        self._sumFE = solve_design.dot(alpha)
+        self._sumFE = fixed_effect_design.dot(alpha)
 
         return fixed_effects_to_frame(self._fixef_coefficients)
 

--- a/pyfixest/estimation/models/feols_.py
+++ b/pyfixest/estimation/models/feols_.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import re
 import warnings
 from collections.abc import Mapping
+from dataclasses import replace
 from functools import partial
 from importlib import import_module
 from typing import Any, Literal, cast
@@ -15,7 +16,7 @@ from scipy.sparse import csc_matrix, diags, spmatrix
 from scipy.sparse.linalg import lsqr
 from scipy.stats import chi2, f, t
 
-from pyfixest.core.demean import Preconditioner
+from pyfixest.core.demean import Preconditioner, WithinPreconditionerName
 from pyfixest.demeaners import AnyDemeaner, LsmrDemeaner, MapDemeaner
 from pyfixest.errors import VcovTypeNotSupportedError
 from pyfixest.estimation.api.utils import _ALL_SAMPLE, _AllSampleSentinel
@@ -979,6 +980,43 @@ class Feols(ResultAccessorMixin):
             cluster_col=cluster_col,
         )
 
+    def _estimation_refit_kwargs(self) -> dict[str, Any]:
+        """Return options needed to replay this estimator on modified data."""
+        demeaner = self._demeaner
+        if isinstance(demeaner, LsmrDemeaner) and isinstance(
+            demeaner.preconditioner, Preconditioner
+        ):
+            # A prebuilt factorization belongs to the original FE design. Keep
+            # its algorithmic variant, but rebuild it for the changed row set.
+            preconditioner = cast(
+                WithinPreconditionerName,
+                demeaner.preconditioner.variant.lower(),
+            )
+            demeaner = replace(demeaner, preconditioner=preconditioner)
+
+        return {
+            "weights": self._weights_name,
+            "weights_type": self._weights_type,
+            "ssc": dict(self._ssc_dict),
+            "fixef_rm": "singleton" if self._drop_singletons else "none",
+            "solver": self._solver,
+            "demeaner": demeaner,
+            "drop_intercept": self._drop_intercept,
+            "collin_tol": self._collin_tol,
+            "context": self._context,
+        }
+
+    def _crv3_refit(self, data: pd.DataFrame) -> Feols:
+        """Replay OLS for one leave-one-cluster-out sample."""
+        # lazy loading to avoid circular import
+        fixest_module = import_module("pyfixest.estimation")
+        return fixest_module.feols(
+            fml=self._fml,
+            data=data,
+            vcov="iid",
+            **self._estimation_refit_kwargs(),
+        )
+
     def _vcov_crv3_slow(
         self,
         clustid: np.ndarray,
@@ -988,20 +1026,10 @@ class Feols(ResultAccessorMixin):
     ) -> np.ndarray:
         beta_jack = np.zeros((len(clustid), self._k))
 
-        # lazy loading to avoid circular import
-        fixest_module = import_module("pyfixest.estimation")
-        fit_ = fixest_module.feols if self._method == "feols" else fixest_module.fepois
-
         for ixg, g in enumerate(clustid):
             # direct leave one cluster out implementation
             refit_data = data[~np.equal(g, cluster_col)]
-            fit = fit_(
-                fml=self._fml,
-                data=refit_data,
-                vcov="iid",
-                weights=self._weights_name,
-                weights_type=self._weights_type,
-            )
+            fit = self._crv3_refit(data=refit_data)
             beta_jack[ixg, :] = fit.coef().to_numpy()
 
         # optional: beta_bar in MNW (2022)
@@ -2269,6 +2297,7 @@ class Feols(ResultAccessorMixin):
                 type=type,
                 rng=rng,
                 model=self._method,
+                refit_kwargs=self._estimation_refit_kwargs(),
             )
 
         else:

--- a/pyfixest/estimation/models/feols_.py
+++ b/pyfixest/estimation/models/feols_.py
@@ -1293,6 +1293,9 @@ class Feols(ResultAccessorMixin):
                 raise NotImplementedError(
                     "Wild cluster bootstrap is not supported for WLS estimation."
                 )
+            raise NotImplementedError(
+                "Wild cluster bootstrap is only supported for unweighted OLS models."
+            )
 
         self._require_fit_arrays("wildboottest", arrays="the fitted arrays")
         self._require_estimation_data("wildboottest")
@@ -1770,6 +1773,11 @@ class Feols(ResultAccessorMixin):
             only_coef=only_coef,
         )
 
+        if not self._support_decomposition:
+            raise NotImplementedError(
+                "Decomposition is currently only supported for OLS models."
+            )
+
         self._require_fit_arrays("decompose", arrays="the fitted arrays")
         # A cluster variable or an absorbed fixed effect is read back from the
         # estimation sample; the plain covariate case works on arrays alone.
@@ -2215,6 +2223,10 @@ class Feols(ResultAccessorMixin):
         if self._is_iv:
             raise NotImplementedError(
                 "Randomization Inference is not supported for IV models."
+            )
+        if self._method not in {"feols", "fepois"}:
+            raise NotImplementedError(
+                "Randomization Inference is only supported for OLS and Poisson models."
             )
 
         # check that resampvar in _coefnames

--- a/pyfixest/estimation/models/fepois_.py
+++ b/pyfixest/estimation/models/fepois_.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from importlib import import_module
 from typing import Any
 
 import numpy as np
@@ -203,6 +204,34 @@ class Fepois(Feglm):
 
         self.deviance = self._family.deviance(
             y_orig, self._Y_hat_response, user_weights
+        )
+
+    def _estimation_refit_kwargs(self) -> dict[str, Any]:
+        """Return the full Poisson estimation contract for data-changing refits."""
+        kwargs = super()._estimation_refit_kwargs()
+        kwargs.update(
+            {
+                "offset": self._offset_name,
+                "iwls_tol": self.tol,
+                "iwls_maxiter": self.maxiter,
+                "separation_check": (
+                    None
+                    if self.separation_check is None
+                    else list(self.separation_check)
+                ),
+            }
+        )
+        return kwargs
+
+    def _crv3_refit(self, data: pd.DataFrame) -> Fepois:
+        """Replay Poisson estimation for one leave-one-cluster-out sample."""
+        # lazy loading to avoid circular import
+        fixest_module = import_module("pyfixest.estimation")
+        return fixest_module.fepois(
+            fml=self._fml,
+            data=data,
+            vcov="iid",
+            **self._estimation_refit_kwargs(),
         )
 
     def _clear_attributes(self) -> None:

--- a/pyfixest/estimation/models/fepois_.py
+++ b/pyfixest/estimation/models/fepois_.py
@@ -152,6 +152,9 @@ class Fepois(Feglm):
         # Poisson-specific overrides on top of the Feglm-set defaults.
         self._method = "fepois"
         self._offset_name = offset
+        # The inherited jackknife refit dispatch is valid for Poisson and is a
+        # longstanding public capability. Other GLM families keep this disabled.
+        self._support_crv3_inference = True
         self._supports_cluster_causal_variance = False
         self._support_decomposition = False
 

--- a/pyfixest/estimation/post_estimation/ritest.py
+++ b/pyfixest/estimation/post_estimation/ritest.py
@@ -36,6 +36,7 @@ def _get_ritest_stats_slow(
     model: str,
     rng: np.random.Generator,
     vcov: str | dict[str, str],
+    refit_kwargs: dict | None = None,
     clustervar_arr: np.ndarray | None = None,
 ) -> np.ndarray:
     """
@@ -62,6 +63,9 @@ def _get_ritest_stats_slow(
         The random number generator.
     vcov : str or dict[str, str]
         The type of covarianc estimator. See `feols` or `fepois` for details.
+    refit_kwargs : dict, optional
+        Estimator options from the original fit that must be replayed on each
+        resampled data set. Defaults to no additional options.
     clustervar_arr : np.ndarray, optional
         Array containing the cluster variable. Defaults to None.
 
@@ -77,6 +81,7 @@ def _get_ritest_stats_slow(
 
     fixest_module = import_module("pyfixest.estimation")
     fit_ = getattr(fixest_module, model)
+    fit_kwargs = {} if refit_kwargs is None else refit_kwargs
 
     resampvar_arr = data_resampled[resampvar].to_numpy()
 
@@ -92,7 +97,12 @@ def _get_ritest_stats_slow(
 
         data_resampled[f"{resampvar}_resampled"] = D_treat
 
-        fixest_fit = fit_(fml_update, data=data_resampled, vcov=vcov)
+        fixest_fit = fit_(
+            fml_update,
+            data=data_resampled,
+            vcov=vcov,
+            **fit_kwargs,
+        )
         if type == "randomization-c":
             ri_stats[i] = fixest_fit.coef().xs(f"{resampvar}_resampled")
         else:

--- a/pyfixest/estimation/quantreg/QuantregMulti.py
+++ b/pyfixest/estimation/quantreg/QuantregMulti.py
@@ -209,8 +209,17 @@ class QuantregMulti:
         data: DataFrameType | None = None,
     ) -> dict[float, Quantreg]:
         "Compute variance-covariance matrices for all models in the quantile regression process."
-        for quantreg in self.all_quantregs.values():
-            quantreg.vcov(vcov=vcov, vcov_kwargs=vcov_kwargs, data=data)
+        quantregs = list(self.all_quantregs.values())
+        candidates = [
+            quantreg._prepare_vcov_update(
+                vcov=vcov,
+                vcov_kwargs=vcov_kwargs,
+                data=data,
+            )
+            for quantreg in quantregs
+        ]
+        for quantreg, candidate in zip(quantregs, candidates, strict=True):
+            quantreg._publish_vcov_update(candidate)
 
         return self.all_quantregs
 

--- a/pyfixest/estimation/quantreg/QuantregMulti.py
+++ b/pyfixest/estimation/quantreg/QuantregMulti.py
@@ -11,6 +11,7 @@ from scipy.stats import norm
 
 from pyfixest.demeaners import AnyDemeaner
 from pyfixest.estimation.formula.parse import Formula as FixestFormula
+from pyfixest.estimation.internals.demean_ import DemeanedData
 from pyfixest.estimation.internals.literals import (
     QuantregMethodOptions,
     QuantregMultiOptions,
@@ -35,7 +36,7 @@ class QuantregMulti:
         weights: str | None,
         weights_type: str | None,
         collin_tol: float,
-        lookup_demeaned_data: dict[frozenset[int], pd.DataFrame],
+        lookup_demeaned_data: dict[frozenset[int], DemeanedData],
         solver: SolverOptions = "np.linalg.solve",
         demeaner: AnyDemeaner | None = None,
         store_data: bool = True,

--- a/pyfixest/estimation/quantreg/QuantregMulti.py
+++ b/pyfixest/estimation/quantreg/QuantregMulti.py
@@ -111,11 +111,11 @@ class QuantregMulti:
             fit_kwargs["rng"] = rng
         beta_hat = self.all_quantregs[q[q_median_idx]]._fit(**fit_kwargs)[0]
 
-        self.all_quantregs[q[q_median_idx]]._beta_hat = beta_hat
-        self.all_quantregs[q[q_median_idx]]._u_hat = (
-            Y.flatten() - (X @ beta_hat).flatten()
+        self._publish_fit_state(
+            quantreg=self.all_quantregs[q[q_median_idx]],
+            beta_hat=beta_hat,
+            hessian=hessian,
         )
-        self.all_quantregs[q[q_median_idx]]._hessian = hessian
 
         def _direction_helper(i, direction):
             if direction == "left":
@@ -138,9 +138,11 @@ class QuantregMulti:
                 beta_hat = self.all_quantregs[q[i]].fit_qreg_pfn(
                     X=X, Y=Y, q=q[i], beta_init=beta_hat_prev, eta=0.5
                 )[0]
-                self.all_quantregs[q[i]]._beta_hat = beta_hat
-                self.all_quantregs[q[i]]._u_hat = Y.flatten() - (X @ beta_hat).flatten()
-                self.all_quantregs[q[i]]._hessian = hessian
+                self._publish_fit_state(
+                    quantreg=self.all_quantregs[q[i]],
+                    beta_hat=beta_hat,
+                    hessian=hessian,
+                )
 
             for i in range(q_median_idx - 1, -1, -1):
                 _cfm1_fun(i, "left")
@@ -164,12 +166,11 @@ class QuantregMulti:
                 M = X.T @ (q[i] - (u_hat_prev < 0))[:, None]
                 beta_new = beta_hat_prev + np.linalg.solve(J, M).flatten()
 
-                self.all_quantregs[q[i]]._beta_hat = beta_new
-                self.all_quantregs[q[i]]._u_hat = (
-                    self.all_quantregs[q[i]]._Y.flatten()
-                    - self.all_quantregs[q[i]]._X @ beta_new
+                self._publish_fit_state(
+                    quantreg=self.all_quantregs[q[i]],
+                    beta_hat=beta_new,
+                    hessian=hessian,
                 )
-                self.all_quantregs[q[i]]._hessian = hessian
 
             for i in range(q_median_idx - 1, -1, -1):
                 _cfm2_fun(i, "left")
@@ -187,6 +188,18 @@ class QuantregMulti:
             sorted(self.all_quantregs.items(), key=lambda item: item[0])
         )
         return self.all_quantregs
+
+    @staticmethod
+    def _publish_fit_state(
+        *, quantreg: Quantreg, beta_hat: np.ndarray, hessian: np.ndarray
+    ) -> None:
+        """Publish canonical child state after a multi-quantile solver step."""
+        y_hat = quantreg._X @ beta_hat
+        quantreg._beta_hat = beta_hat
+        quantreg._Y_hat_link = y_hat
+        quantreg._Y_hat_response = y_hat
+        quantreg._u_hat = quantreg._Y.flatten() - y_hat
+        quantreg._hessian = hessian
 
     def vcov(
         self,
@@ -221,9 +234,4 @@ class QuantregMulti:
         "Clear all large non-necessary attributes to free memory."
         for quantreg in self.all_quantregs.values():
             quantreg._clear_attributes()
-
-        # `_X` and `_Y` are read-only views, so their backing state is dropped.
-        for quantreg in self.all_quantregs.values():
-            if hasattr(quantreg, "_within_data"):
-                del quantreg._within_data
         gc.collect()

--- a/pyfixest/estimation/quantreg/quantreg_.py
+++ b/pyfixest/estimation/quantreg/quantreg_.py
@@ -117,6 +117,7 @@ class Quantreg(Feols):
         self._support_crv3_inference = False
         self._supports_cluster_causal_variance = False
         self._support_hac_inference = False
+        self._support_decomposition = False
 
         self._quantile = quantile
         self._method = f"quantreg_{method}"

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -586,6 +586,46 @@ def test_ritest_error(data):
         fit.plot_ritest()
 
 
+@pytest.mark.parametrize("estimator", ["feglm", "quantreg"])
+def test_ritest_rejects_non_ols_working_domains(estimator):
+    """RI must not interpret GLM or quantile arrays as OLS solver inputs."""
+    data = pd.DataFrame(
+        {
+            "y": [0, 1, 0, 1, 1, 0, 1, 0],
+            "x": np.linspace(-1.0, 1.0, 8),
+        }
+    )
+    if estimator == "feglm":
+        fit = pf.feglm("y ~ x", data=data, family="logit")
+    else:
+        with pytest.warns(FutureWarning, match="experimental"):
+            fit = pf.quantreg("y ~ x", data=data, maxiter=100)
+
+    with pytest.raises(
+        NotImplementedError, match=r"only supported for OLS and Poisson"
+    ):
+        fit.ritest(resampvar="x", reps=1)
+
+
+@pytest.mark.parametrize("estimator", ["feglm", "quantreg"])
+def test_wildboottest_rejects_non_ols_working_domains(estimator):
+    """Wild bootstrap must reject estimator-specific non-OLS array domains."""
+    data = pd.DataFrame(
+        {
+            "y": [0, 1, 0, 1, 1, 0, 1, 0],
+            "x": np.linspace(-1.0, 1.0, 8),
+        }
+    )
+    if estimator == "feglm":
+        fit = pf.feglm("y ~ x", data=data, family="logit")
+    else:
+        with pytest.warns(FutureWarning, match="experimental"):
+            fit = pf.quantreg("y ~ x", data=data, maxiter=100)
+
+    with pytest.raises(NotImplementedError, match=r"only supported for unweighted OLS"):
+        fit.wildboottest(param="x", reps=1)
+
+
 def test_wald_test_invalid_distribution():
     data = pd.read_csv("pyfixest/did/data/df_het.csv")
     data = data.iloc[1:3000]
@@ -906,6 +946,23 @@ def test_gelbach_errors():
         fit.decompose(
             decomp_var="x1", combine_covariates={"g1": ["x21"]}, only_coef=False
         )
+
+
+@pytest.mark.parametrize("model_type", ["feglm", "quantreg"])
+def test_decomposition_rejects_unsupported_models(model_type):
+    data = gelbach_data(nobs=100)
+
+    if model_type == "feglm":
+        data["binary_y"] = (data["y"] > data["y"].median()).astype(int)
+        fit = pf.feglm("binary_y ~ x1 + x21", data=data, family="logit")
+    else:
+        fit = pf.quantreg("y ~ x1 + x21", data=data, quantile=0.5)
+
+    with pytest.raises(
+        NotImplementedError,
+        match=r"Decomposition is currently only supported for OLS models\.",
+    ):
+        fit.decompose(decomp_var="x1", only_coef=True)
 
 
 def test_glm_errors():

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -964,6 +964,39 @@ def test_prediction_errors_glm():
             model.predict(se_fit=True)
 
 
+@pytest.mark.parametrize("family", ["gaussian", "logit", "probit"])
+def test_glm_crv3_is_explicitly_unsupported(family):
+    """Do not silently run Poisson jackknife refits for other GLM families."""
+    data = pf.get_data(model="Fepois").dropna().copy()
+    if family in ("logit", "probit"):
+        data["Y"] = (data["Y"] > data["Y"].median()).astype(int)
+
+    with pytest.raises(VcovTypeNotSupportedError, match="CRV3 inference"):
+        pf.feglm(
+            "Y ~ X1",
+            data=data,
+            family=family,
+            vcov={"CRV3": "f1"},
+        )
+
+
+def test_poisson_crv3_remains_supported():
+    """Keep the longstanding Poisson jackknife path across both public APIs."""
+    data = pf.get_data(model="Fepois").dropna().iloc[:120].copy()
+    data["cluster"] = np.arange(len(data)) % 6
+
+    direct_fit = pf.fepois("Y ~ X1", data=data, vcov={"CRV3": "cluster"})
+    glm_fit = pf.feglm(
+        "Y ~ X1",
+        data=data,
+        family="poisson",
+        vcov={"CRV3": "cluster"},
+    )
+
+    np.testing.assert_allclose(direct_fit.coef(), glm_fit.coef())
+    np.testing.assert_allclose(direct_fit._vcov, glm_fit._vcov)
+
+
 def test_empty_vcov_error():
     data = pf.get_data()
     fit = pf.feols("Y ~ 1 | f1", data=data)

--- a/tests/test_estimator_state_lifecycle.py
+++ b/tests/test_estimator_state_lifecycle.py
@@ -478,6 +478,26 @@ def test_lean_iv_rejects_first_stage_diagnostics(
         getattr(fit, method)()
 
 
+@pytest.mark.parametrize("fit_kwargs", [{"store_data": False}, {"lean": True}])
+def test_multiple_estimation_respects_storage_options(
+    lifecycle_data: pd.DataFrame,
+    fit_kwargs: dict[str, bool],
+) -> None:
+    """The result container must not retain data cleared from all child fits."""
+    fit = pf.feols(
+        "y ~ sw(x, x2) | fe",
+        data=lifecycle_data,
+        vcov="iid",
+        **fit_kwargs,
+    )
+
+    assert isinstance(fit, FixestMulti)
+    assert not hasattr(fit, "_data")
+    assert not hasattr(fit, "_config")
+    assert not hasattr(fit, "_context")
+    assert all(not hasattr(model, "_data") for model in fit.to_list())
+
+
 def test_lean_results_predict_new_data_without_fixed_effects(
     lifecycle_data: pd.DataFrame,
 ) -> None:
@@ -554,6 +574,117 @@ def test_store_data_false_vcov_uses_explicit_estimation_sample(
 
     np.testing.assert_allclose(stripped._vcov, expected._vcov)
     assert not hasattr(stripped, "_data")
+
+
+def test_fixest_multi_forwards_explicit_vcov_data(
+    lifecycle_data: pd.DataFrame,
+) -> None:
+    """Multiple-estimation covariance updates forward an explicit sample."""
+    stripped = pf.feols(
+        "y ~ sw(x, x2) | fe",
+        data=lifecycle_data,
+        vcov="iid",
+        store_data=False,
+    )
+    expected = pf.feols(
+        "y ~ sw(x, x2) | fe",
+        data=lifecycle_data,
+        vcov={"CRV1": "fe"},
+    )
+
+    stripped.vcov({"CRV1": "fe"}, data=lifecycle_data)
+
+    for stripped_model, expected_model in zip(
+        stripped.to_list(), expected.to_list(), strict=True
+    ):
+        np.testing.assert_allclose(stripped_model._vcov, expected_model._vcov)
+        assert not hasattr(stripped_model, "_data")
+
+
+def test_fixest_multi_vcov_preflights_different_estimation_samples(
+    lifecycle_data: pd.DataFrame,
+) -> None:
+    """A common-sample mismatch leaves every child model unchanged."""
+    data = lifecycle_data.copy()
+    data.loc[data.index[:3], "x2"] = np.nan
+    fit = pf.feols(
+        "y ~ sw(x, x2) | fe",
+        data=data,
+        vcov="iid",
+        store_data=False,
+    )
+    children = fit.to_list()
+    inference_before = [
+        (child._vcov_type_detail, child._vcov.copy()) for child in children
+    ]
+
+    with pytest.raises(
+        ValueError,
+        match=r"common, already-filtered estimation sample.*\[21, 24\], received 24",
+    ):
+        fit.vcov({"CRV1": "fe"}, data=data)
+
+    for child, (vcov_type_detail, vcov) in zip(children, inference_before, strict=True):
+        assert child._vcov_type_detail == vcov_type_detail
+        np.testing.assert_array_equal(child._vcov, vcov)
+
+
+def test_fixest_multi_vcov_rejects_equal_size_split_samples(
+    lifecycle_data: pd.DataFrame,
+) -> None:
+    """Equal row counts do not make distinct split samples interchangeable."""
+    data = lifecycle_data.assign(sample=np.tile(["left", "right"], 12))
+    fit = pf.feols(
+        "y ~ x | fe",
+        data=data,
+        split="sample",
+        vcov="iid",
+        store_data=False,
+    )
+    children = fit.to_list()
+    inference_before = [
+        (child._vcov_type_detail, child._vcov.copy()) for child in children
+    ]
+    left_sample = data.loc[data["sample"] == "left"]
+
+    with pytest.raises(
+        ValueError,
+        match=r"child models use different estimation samples.*Fetch each child",
+    ):
+        fit.vcov({"CRV1": "fe"}, data=left_sample)
+
+    for child, (vcov_type_detail, vcov) in zip(children, inference_before, strict=True):
+        assert child._vcov_type_detail == vcov_type_detail
+        np.testing.assert_array_equal(child._vcov, vcov)
+
+
+def test_fixest_multi_vcov_rejects_equal_size_distinct_na_masks(
+    lifecycle_data: pd.DataFrame,
+) -> None:
+    """Equal-sized formula expansions must retain the same source rows."""
+    data = lifecycle_data.copy()
+    data.loc[data.index[0], "x"] = np.nan
+    data.loc[data.index[1], "x2"] = np.nan
+    fit = pf.feols(
+        "y ~ sw(x, x2) | fe",
+        data=data,
+        vcov="iid",
+        store_data=False,
+    )
+    children = fit.to_list()
+    inference_before = [
+        (child._vcov_type_detail, child._vcov.copy()) for child in children
+    ]
+
+    with pytest.raises(
+        ValueError,
+        match=r"child models use different estimation samples.*Fetch each child",
+    ):
+        fit.vcov({"CRV1": "fe"}, data=data.drop(index=0))
+
+    for child, (vcov_type_detail, vcov) in zip(children, inference_before, strict=True):
+        assert child._vcov_type_detail == vcov_type_detail
+        np.testing.assert_array_equal(child._vcov, vcov)
 
 
 def test_vcov_rejects_unfiltered_explicit_data(
@@ -758,3 +889,23 @@ def test_quantreg_lean_discards_solver_arrays() -> None:
     solver_arrays = ("_x_final", "_s_final", "_z_final", "_w_final", "_y_final")
     assert all(not hasattr(fit, attr) for attr in solver_arrays)
     assert np.isfinite(fit.coef()).all()
+
+
+def test_quantreg_multi_retains_default_post_estimation_state() -> None:
+    """Default multi-quantile results support prediction and vcov updates."""
+    rng = np.random.default_rng(20260901)
+    x = rng.normal(size=200)
+    data = pd.DataFrame({"y": 1 + 2 * x + rng.normal(size=200), "x": x})
+    with pytest.warns(FutureWarning, match="experimental"):
+        multi = pf.quantreg("y ~ x", data=data, quantile=[0.25, 0.75], vcov="iid")
+        single = pf.quantreg("y ~ x", data=data, quantile=0.25, vcov="hetero")
+
+    multi.vcov("hetero")
+
+    for model in multi.to_list():
+        assert np.isfinite(model.predict()).all()
+        assert np.isfinite(model.se()).all()
+
+    first_quantile = multi.fetch_model(0, print_fml=False)
+    np.testing.assert_allclose(first_quantile.predict(), single.predict())
+    np.testing.assert_allclose(first_quantile.se(), single.se())

--- a/tests/test_estimator_state_lifecycle.py
+++ b/tests/test_estimator_state_lifecycle.py
@@ -24,6 +24,60 @@ from pyfixest.estimation.internals.model_state import (
     ObservationWeights,
     WithinLinearData,
 )
+from pyfixest.estimation.quantreg.QuantregMulti import QuantregMulti
+
+INFERENCE_STATE_ATTRIBUTES = (
+    "_vcov_type",
+    "_vcov_type_detail",
+    "_is_clustered",
+    "_clustervar",
+    "_bread",
+    "_ssc",
+    "_df_k",
+    "_df_t",
+    "_vcov",
+    "_lag",
+    "_time_id",
+    "_panel_id",
+    "_cluster_df",
+    "_G",
+    "_se",
+    "_tstat",
+    "_pvalue",
+    "_conf_int",
+)
+
+
+def _inference_snapshot(model) -> dict[str, tuple[bool, object | None]]:
+    return {
+        attribute: (
+            hasattr(model, attribute),
+            deepcopy(getattr(model, attribute)) if hasattr(model, attribute) else None,
+        )
+        for attribute in INFERENCE_STATE_ATTRIBUTES
+    }
+
+
+def _assert_inference_unchanged(
+    model, expected: dict[str, tuple[bool, object | None]]
+) -> None:
+    for attribute, (was_present, value) in expected.items():
+        assert hasattr(model, attribute) is was_present, (
+            f"failed covariance update changed presence of {attribute}"
+        )
+        if not was_present:
+            continue
+        observed = getattr(model, attribute)
+        if isinstance(value, np.ndarray):
+            np.testing.assert_array_equal(
+                observed,
+                value,
+                err_msg=f"failed covariance update changed {attribute}",
+            )
+        elif isinstance(value, pd.DataFrame):
+            pd.testing.assert_frame_equal(observed, value)
+        else:
+            assert observed == value, f"failed covariance update changed {attribute}"
 
 
 @pytest.fixture
@@ -576,6 +630,37 @@ def test_store_data_false_vcov_uses_explicit_estimation_sample(
     assert not hasattr(stripped, "_data")
 
 
+def test_failed_vcov_update_preserves_complete_inference_state(
+    lifecycle_data: pd.DataFrame,
+) -> None:
+    """A failure during covariance computation publishes no partial state."""
+    fit = pf.feols("y ~ x | fe", data=lifecycle_data, vcov="iid")
+    inference_before = _inference_snapshot(fit)
+
+    with pytest.raises(KeyError, match="fe"):
+        fit.vcov({"CRV1": "fe"}, data=lifecycle_data.drop(columns="fe"))
+
+    _assert_inference_unchanged(fit, inference_before)
+
+
+def test_failed_inference_finalization_preserves_complete_inference_state(
+    lifecycle_data: pd.DataFrame,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Derived inference is prepared before covariance state is published."""
+    fit = pf.feols("y ~ x | fe", data=lifecycle_data, vcov="iid")
+    inference_before = _inference_snapshot(fit)
+
+    def fail_inference(_self) -> None:
+        raise RuntimeError("inference finalization failed")
+
+    monkeypatch.setattr(type(fit), "get_inference", fail_inference)
+    with pytest.raises(RuntimeError, match="inference finalization failed"):
+        fit.vcov("hetero")
+
+    _assert_inference_unchanged(fit, inference_before)
+
+
 def test_fixest_multi_forwards_explicit_vcov_data(
     lifecycle_data: pd.DataFrame,
 ) -> None:
@@ -591,14 +676,141 @@ def test_fixest_multi_forwards_explicit_vcov_data(
         data=lifecycle_data,
         vcov={"CRV1": "fe"},
     )
+    child_ids = [id(child) for child in stripped.to_list()]
 
     stripped.vcov({"CRV1": "fe"}, data=lifecycle_data)
 
+    assert [id(child) for child in stripped.to_list()] == child_ids
     for stripped_model, expected_model in zip(
         stripped.to_list(), expected.to_list(), strict=True
     ):
         np.testing.assert_allclose(stripped_model._vcov, expected_model._vcov)
         assert not hasattr(stripped_model, "_data")
+
+
+def test_fixest_multi_vcov_is_atomic_after_later_child_failure(
+    lifecycle_data: pd.DataFrame,
+) -> None:
+    """Every child covariance is prepared before any child is updated."""
+    data = lifecycle_data.assign(time=np.arange(len(lifecycle_data)))
+    fit = pf.feols("y ~ sw(x, x2)", data=data, vcov="iid")
+    children = fit.to_list()
+    child_ids = [id(child) for child in children]
+    inference_before = [_inference_snapshot(child) for child in children]
+    children[1]._support_hac_inference = False
+
+    with pytest.raises(NotImplementedError, match="HAC inference is not supported"):
+        fit.vcov("NW", vcov_kwargs={"time_id": "time", "lag": 1})
+
+    assert [id(child) for child in fit.to_list()] == child_ids
+    for child, expected in zip(children, inference_before, strict=True):
+        _assert_inference_unchanged(child, expected)
+
+
+def test_quantreg_multi_vcov_is_atomic_after_later_child_failure(
+    lifecycle_data: pd.DataFrame,
+) -> None:
+    """Quantile-process inference also commits only after all children succeed."""
+    fit = pf.quantreg(
+        "y ~ x",
+        data=lifecycle_data,
+        quantile=[0.25, 0.75],
+        vcov="iid",
+        seed=1324,
+    )
+    children = fit.to_list()
+    quantreg_multi = QuantregMulti.__new__(QuantregMulti)
+    quantreg_multi.all_quantregs = dict(zip((0.25, 0.75), children, strict=True))
+    child_ids = [id(child) for child in children]
+    inference_before = [_inference_snapshot(child) for child in children]
+    children[1]._lean = True
+    children[1]._fit_state_discarded = True
+
+    with pytest.raises(RuntimeError, match=r"vcov\(\).*lean=True"):
+        quantreg_multi.vcov("hetero")
+
+    assert [id(child) for child in quantreg_multi.all_quantregs.values()] == child_ids
+    for child, expected in zip(children, inference_before, strict=True):
+        _assert_inference_unchanged(child, expected)
+
+
+@pytest.mark.parametrize(
+    ("fml", "weights", "weights_type"),
+    [
+        ("y ~ x", None, "aweights"),
+        ("y ~ x | fe", "weight", "aweights"),
+        ("y ~ x | fe", "weight", "fweights"),
+    ],
+)
+def test_gaussian_glm_performance_uses_explicit_response_domains(
+    lifecycle_data: pd.DataFrame,
+    fml: str,
+    weights: str | None,
+    weights_type: str,
+) -> None:
+    """Gaussian performance uses raw totals and unpremultiplied within arrays."""
+    fit = pf.feglm(
+        fml,
+        data=lifecycle_data,
+        family="gaussian",
+        weights=weights,
+        weights_type=weights_type,
+        vcov="iid",
+        iwls_tol=1e-10,
+    )
+
+    fit.get_performance()
+
+    observation_weights = fit._observation_weights.values
+    if observation_weights is None:
+        ssu = np.sum(fit._u_hat**2)
+        response_center = np.mean(fit._response)
+        ssy = np.sum((fit._response - response_center) ** 2)
+    else:
+        ssu = np.sum(observation_weights * fit._u_hat**2)
+        response_center = np.average(fit._response, weights=observation_weights)
+        ssy = np.sum(observation_weights * (fit._response - response_center) ** 2)
+
+    np.testing.assert_allclose(
+        fit._rmse,
+        np.sqrt(ssu / fit._N),
+        err_msg="Gaussian GLM RMSE used the wrong residual domain",
+    )
+    np.testing.assert_allclose(
+        fit._r2,
+        1 - ssu / ssy,
+        err_msg="Gaussian GLM R-squared used the wrong response domain",
+    )
+    if fit._has_fixef:
+        data = lifecycle_data
+        assert observation_weights is not None
+        weighted_response = data["weight"] * data["y"]
+        weighted_group_mean = weighted_response.groupby(data["fe"], observed=True).sum()
+        weighted_group_mean /= data["weight"].groupby(data["fe"], observed=True).sum()
+        response_within = (
+            data["y"].to_numpy() - data["fe"].map(weighted_group_mean).to_numpy()
+        )
+        ssy_within = np.sum(observation_weights * response_within**2)
+        np.testing.assert_allclose(
+            fit._r2_within,
+            1 - ssu / ssy_within,
+            err_msg="Gaussian GLM within R-squared used the wrong within response",
+        )
+
+
+def test_lean_gaussian_glm_rejects_performance_update(
+    lifecycle_data: pd.DataFrame,
+) -> None:
+    fit = pf.feglm(
+        "y ~ x | fe",
+        data=lifecycle_data,
+        family="gaussian",
+        vcov="iid",
+        lean=True,
+    )
+
+    with pytest.raises(RuntimeError, match=r"get_performance\(\).*lean=True"):
+        fit.get_performance()
 
 
 def test_fixest_multi_vcov_preflights_different_estimation_samples(

--- a/tests/test_iv.py
+++ b/tests/test_iv.py
@@ -266,3 +266,43 @@ def test_1st_stage_iv(seed, sd, has_weight, adj_vcov):
         atol=1e-8,
         err_msg="F-Stats p-value mismatch in first stage between IV and OLS",
     )
+
+
+def test_iv_diag_does_not_relabel_vcov_type():
+    # The effective F stat refits the first stage with "hetero" errors, but the
+    # outer model must keep the covariance type it was estimated with.
+    data = get_data()
+
+    fit_iid = feols("Y ~ X2 + [X1 ~ Z1 + Z2]", data=data, weights="weights", vcov="iid")
+    vcov_type_detail_before = fit_iid._vcov_type_detail
+    se_before = fit_iid.se().copy()
+
+    fit_iid.IV_Diag()
+
+    assert vcov_type_detail_before == "iid"
+    assert fit_iid._vcov_type_detail == "iid", (
+        "IV_Diag() relabelled the main model's covariance type"
+    )
+    np.testing.assert_allclose(
+        fit_iid.se(),
+        se_before,
+        rtol=1e-12,
+        atol=1e-12,
+        err_msg="IV_Diag() changed the main model's standard errors",
+    )
+    assert np.isfinite(fit_iid._eff_F)
+
+    # The effective F is computed from the heteroskedasticity-robust first
+    # stage, so it does not depend on the outer model's covariance type.
+    fit_hetero = feols(
+        "Y ~ X2 + [X1 ~ Z1 + Z2]", data=data, weights="weights", vcov="hetero"
+    )
+    fit_hetero.IV_Diag()
+
+    np.testing.assert_allclose(
+        fit_iid._eff_F,
+        fit_hetero._eff_F,
+        rtol=1e-10,
+        atol=1e-10,
+        err_msg="Effective F differs between iid and hetero specifications",
+    )

--- a/tests/test_predict_resid_fixef.py
+++ b/tests/test_predict_resid_fixef.py
@@ -247,6 +247,81 @@ def test_feglm_resid_vs_fixest(data, family, fml):
 
 
 @pytest.mark.against_r_core
+@pytest.mark.parametrize(
+    ("weights_name", "weights_type"),
+    [("weights", "aweights"), ("fweights", "fweights")],
+)
+def test_weighted_fixef_is_on_response_scale(data, weights_name, weights_type):
+    """Weighted fixed effects and predictions stay in response units."""
+    group_size = data.groupby("f1")["f1"].transform("size")
+    weighted_data = data.loc[group_size > 1].copy().reset_index(drop=True)
+    weighted_data["fweights"] = np.arange(len(weighted_data)) % 4 + 1
+
+    fit = pf.feols(
+        "Y ~ X1 | f1",
+        data=weighted_data,
+        weights=weights_name,
+        weights_type=weights_type,
+    )
+    fixed_effects = fit.fixef(atol=1e-12, btol=1e-12)
+
+    fit_r = fixest.feols(
+        ro.Formula("Y ~ X1 | f1"),
+        data=weighted_data,
+        weights=ro.Formula(f"~{weights_name}"),
+    )
+    ro.globalenv[".pyfixest_weighted_fixef_fit"] = fit_r
+    fixed_effects_r = ro.r["fixef"](fit_r).rx2("f1")
+    fixed_effect_levels_r = np.asarray(
+        ro.r("names(fixef(.pyfixest_weighted_fixef_fit)$f1)"), dtype=float
+    )
+
+    response_scale_fixed_effect = fit.predict() - weighted_data[
+        "X1"
+    ].to_numpy() * fit.coef().xs("X1")
+    np.testing.assert_allclose(
+        fit._sumFE,
+        response_scale_fixed_effect,
+        rtol=1e-8,
+        atol=1e-8,
+    )
+    np.testing.assert_allclose(
+        fit._sumFE,
+        np.asarray(fit_r.rx2("sumFE")),
+        rtol=1e-8,
+        atol=1e-8,
+    )
+
+    fixed_effects_by_level = fixed_effects.set_index(
+        fixed_effects["level"].astype(float)
+    )["coefficient"].sort_index()
+    fixed_effects_r_by_level = pd.Series(
+        np.asarray(fixed_effects_r),
+        index=fixed_effect_levels_r,
+    ).sort_index()
+    np.testing.assert_allclose(
+        fixed_effects_by_level,
+        fixed_effects_r_by_level,
+        rtol=1e-8,
+        atol=1e-8,
+    )
+
+    np.testing.assert_allclose(
+        fit.predict(),
+        np.asarray(fit_r.rx2("fitted.values")),
+        rtol=1e-8,
+        atol=1e-8,
+    )
+    newdata = weighted_data.iloc[:100]
+    np.testing.assert_allclose(
+        fit.predict(newdata=newdata),
+        np.asarray(stats.predict(fit_r, newdata=newdata)),
+        rtol=1e-8,
+        atol=1e-8,
+    )
+
+
+@pytest.mark.against_r_core
 def test_predict_nas():
     # tests to fix #246: https://github.com/py-econometrics/pyfixest/issues/246
 

--- a/tests/test_ritest.py
+++ b/tests/test_ritest.py
@@ -172,6 +172,69 @@ def test_fepois_ritest():
     assert np.allclose(fit.pvalue().xs("f3"), fit._ritest_pvalue, rtol=0.01, atol=0.01)
 
 
+def test_fepois_slow_ritest_replays_estimation_contract(monkeypatch):
+    """Poisson RI refits must retain offsets, formula context, and fit options."""
+    import pyfixest.estimation as estimation
+
+    data = pf.get_data(model="Fepois").dropna().iloc[:96].copy()
+    data["treatment"] = (data["X2"] > data["X2"].median()).astype(int)
+    data["exposure"] = np.random.default_rng(20260901).uniform(0.5, 3.0, len(data))
+
+    def shift(values):
+        return values + 0.125
+
+    demeaner = pf.MapDemeaner(fixef_tol=1e-8, fixef_maxiter=20_000)
+    ssc_config = pf.ssc(k_adj=False, G_adj=False)
+    real_fepois = estimation.fepois
+    fit = real_fepois(
+        "Y ~ treatment + shift(X1) | f1",
+        data=data,
+        offset="log(exposure)",
+        ssc=ssc_config,
+        fixef_rm="none",
+        iwls_tol=1e-10,
+        iwls_maxiter=100,
+        collin_tol=1e-8,
+        separation_check=[],
+        solver="np.linalg.lstsq",
+        demeaner=demeaner,
+        drop_intercept=True,
+        context={"shift": shift},
+    )
+
+    refit_calls = []
+
+    def recording_fepois(fml, *, data, vcov, **kwargs):
+        refit_calls.append((fml, vcov, kwargs))
+        return real_fepois(fml=fml, data=data, vcov=vcov, **kwargs)
+
+    monkeypatch.setattr(estimation, "fepois", recording_fepois)
+    fit.ritest(
+        resampvar="treatment",
+        reps=3,
+        choose_algorithm="slow",
+        rng=np.random.default_rng(1234),
+    )
+
+    assert len(refit_calls) == 3
+    for fml, vcov, kwargs in refit_calls:
+        assert fml == "Y ~ treatment_resampled + shift(X1) | f1"
+        assert vcov == "iid"
+        assert kwargs["weights"] is None
+        assert kwargs["weights_type"] == "aweights"
+        assert kwargs["ssc"] == ssc_config
+        assert kwargs["fixef_rm"] == "none"
+        assert kwargs["iwls_tol"] == 1e-10
+        assert kwargs["iwls_maxiter"] == 100
+        assert kwargs["collin_tol"] == 1e-8
+        assert kwargs["separation_check"] == []
+        assert kwargs["solver"] == "np.linalg.lstsq"
+        assert kwargs["demeaner"] is demeaner
+        assert kwargs["drop_intercept"] is True
+        assert kwargs["offset"] == "log(exposure)"
+        assert kwargs["context"]["shift"] is shift
+
+
 @pytest.fixture
 def data_r_vs_t():
     return pf.get_data(N=5000, seed=2999)

--- a/tests/test_ses.py
+++ b/tests/test_ses.py
@@ -1,6 +1,9 @@
 import numpy as np
+import pandas as pd
 import pytest
 
+import pyfixest.estimation as estimation
+from pyfixest.demeaners import LsmrDemeaner, MapDemeaner
 from pyfixest.estimation import feols, fepois
 from pyfixest.utils.utils import get_data, ssc
 
@@ -218,6 +221,128 @@ def run_crv3_poisson():
         vcov={"CRV3": "f1"},
         ssc=ssc(k_adj=False, G_adj=False),
     )
+
+
+def test_fepois_crv3_replays_estimation_contract(monkeypatch):
+    """Poisson jackknife refits must preserve every coefficient-affecting option."""
+    rng = np.random.default_rng(20260901)
+    n_clusters = 6
+    rows_per_cluster = 12
+    n = n_clusters * rows_per_cluster
+    cluster = np.repeat(np.arange(n_clusters), rows_per_cluster)
+    fixed_effect = np.tile(np.arange(6), n // 6)
+    x = rng.normal(size=n)
+    exposure = rng.uniform(0.5, 3.0, size=n)
+    weight = rng.uniform(0.75, 1.5, size=n)
+    fixed_effect_value = np.linspace(-0.25, 0.25, 6)[fixed_effect]
+
+    def shift(values):
+        return values + 0.125
+
+    eta = 0.35 * shift(x) + fixed_effect_value + np.log(exposure)
+    data = pd.DataFrame(
+        {
+            "y": rng.poisson(np.exp(eta)),
+            "x": x,
+            "exposure": exposure,
+            "weight": weight,
+            "fixed_effect": fixed_effect,
+            "cluster": cluster,
+        }
+    )
+
+    demeaner = MapDemeaner(fixef_tol=1e-8, fixef_maxiter=20_000)
+    ssc_config = ssc(k_adj=False, G_adj=False)
+    real_fepois = estimation.fepois
+    refit_calls = []
+    beta_jack = []
+
+    def recording_fepois(*, data, **kwargs):
+        refit_calls.append((data, kwargs))
+        refit = real_fepois(data=data, **kwargs)
+        beta_jack.append(refit.coef().to_numpy())
+        return refit
+
+    monkeypatch.setattr(estimation, "fepois", recording_fepois)
+    fit = real_fepois(
+        "y ~ shift(x) | fixed_effect",
+        data=data,
+        vcov={"CRV3": "cluster"},
+        weights="weight",
+        weights_type="aweights",
+        offset="log(exposure)",
+        ssc=ssc_config,
+        fixef_rm="none",
+        iwls_tol=1e-10,
+        iwls_maxiter=100,
+        collin_tol=1e-8,
+        separation_check=[],
+        solver="np.linalg.lstsq",
+        demeaner=demeaner,
+        drop_intercept=True,
+        context={"shift": shift},
+    )
+
+    assert len(refit_calls) == n_clusters
+    for refit_data, kwargs in refit_calls:
+        assert refit_data["cluster"].nunique() == n_clusters - 1
+        assert kwargs["fml"] == "y ~ shift(x) | fixed_effect"
+        assert kwargs["vcov"] == "iid"
+        assert kwargs["weights"] == "weight"
+        assert kwargs["weights_type"] == "aweights"
+        assert kwargs["ssc"] == ssc_config
+        assert kwargs["fixef_rm"] == "none"
+        assert kwargs["iwls_tol"] == 1e-10
+        assert kwargs["iwls_maxiter"] == 100
+        assert kwargs["collin_tol"] == 1e-8
+        assert kwargs["separation_check"] == []
+        assert kwargs["solver"] == "np.linalg.lstsq"
+        assert kwargs["demeaner"] is demeaner
+        assert kwargs["drop_intercept"] is True
+        assert kwargs["offset"] == "log(exposure)"
+        assert kwargs["context"]["shift"] is shift
+
+    expected_vcov = np.zeros_like(fit._vcov)
+    for beta in beta_jack:
+        centered = beta - fit.coef().to_numpy()
+        expected_vcov += np.outer(centered, centered)
+    np.testing.assert_allclose(fit._vcov, expected_vcov, rtol=1e-12, atol=1e-12)
+
+
+def test_crv3_rebuilds_preconditioner_for_each_changed_design():
+    """Leave-cluster-out refits must not reuse a full-sample factorization."""
+    rng = np.random.default_rng(20260902)
+    n_groups = 6
+    rows_per_group = 6
+    n = n_groups * rows_per_group
+    data = pd.DataFrame(
+        {
+            "y": rng.normal(size=n),
+            "x": rng.normal(size=n),
+            "group": np.repeat(np.arange(n_groups), rows_per_group),
+            "time": np.tile(np.arange(rows_per_group), n_groups),
+        }
+    )
+    base = feols(
+        "y ~ x | group + time",
+        data=data,
+        vcov="iid",
+        demeaner=LsmrDemeaner(backend="within"),
+    )
+    assert base.preconditioner is not None
+    reused = LsmrDemeaner(
+        backend="within",
+        preconditioner=base.preconditioner,
+    )
+
+    fit = feols(
+        "y ~ x | group + time",
+        data=data,
+        vcov={"CRV3": "group"},
+        demeaner=reused,
+    )
+
+    assert np.isfinite(fit._vcov).all()
 
 
 @pytest.mark.parametrize("vcov", ["NW", "DK"])

--- a/tests/test_vs_fixest.py
+++ b/tests/test_vs_fixest.py
@@ -680,6 +680,33 @@ def test_feglm_gaussian_reference_behavior():
         atol=1e-10,
         err_msg="pyfixest Gaussian GLM and OLS covariance matrices differ",
     )
+    py_glm.get_performance()
+    py_ols.get_performance()
+    for attribute in ("_rmse", "_r2", "_adj_r2"):
+        np.testing.assert_allclose(
+            getattr(py_glm, attribute),
+            getattr(py_ols, attribute),
+            rtol=0,
+            atol=1e-10,
+            err_msg=f"Gaussian GLM and OLS {attribute} differ",
+        )
+    r_lm_residuals = np.asarray(stats.residuals(r_lm))
+    np.testing.assert_allclose(
+        py_glm._rmse,
+        np.sqrt(np.mean(r_lm_residuals**2)),
+        rtol=0,
+        atol=1e-10,
+        err_msg="Gaussian GLM RMSE differs from base R lm residuals",
+    )
+    np.testing.assert_allclose(
+        py_glm._r2,
+        1
+        - np.sum(r_lm_residuals**2)
+        / np.sum((data["Y"].to_numpy() - data["Y"].mean()) ** 2),
+        rtol=0,
+        atol=1e-10,
+        err_msg="Gaussian GLM R-squared differs from base R lm",
+    )
 
     for r_fit, label in (
         (r_lm, "base R lm"),


### PR DESCRIPTION
Completes the shared estimator-state lifecycle: covariance updates are computed on detached candidates and published only after covariance and inference succeed. Single models and both multi-model containers retain their existing identities and previous results on failure. Gaussian `get_performance()` now uses the appropriate shared within-response accessor rather than assuming linear-only state.

Preserves the existing raw-scale weighted FE reconstruction, storage cleanup, unsupported-path guards, and faithful CRV3/randomization refits. `update(inplace=True)` remains explicitly rejected. Gaussian offsets remain unsupported; explicit covariance data must already match the filtered sample and order.

Integrates reviewed #1500 through an additive merge. No reviewed history was rewritten, and #1504 or its descendants were not adjusted.

Local verification: release contract 1,355 passed; lifecycle 65 passed; focused checks 9 passed; Gaussian/R-reference plus offset rejection 2 passed; covariance/HAC primitives 16 passed; live-R HAC 353 passed with 184 non-applicable combinations skipped; Ruff, mypy, and whitespace checks passed. Fresh exact-head CI supplies remaining Python/R/docs evidence. #1500's Ubuntu R preflight hit an unchanged auxiliary quantile-solver convergence failure; same-runtime old/new comparisons pass locally, but that failed CI check remains unresolved. Not merge-ready pending reference/platform evidence and human review.
