### PR TITLE
refactor(estimation): declare post-estimation support per estimator

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -87,6 +87,8 @@ website:
           file: how-to/marginaleffects.qmd
         - text: "When to Use Anytime-Valid Inference"
           file: how-to/anytime-valid-inference.qmd
+        - text: "Which Methods Does Each Estimator Support?"
+          file: how-to/supported-methods.qmd
         - text: "Regression Decomposition"
           file: how-to/regression_decomposition.qmd
         - text: "Compare Stata & PyFixest"
@@ -204,6 +206,7 @@ quartodoc:
         - estimation.models.feols_.Feols.vcov
         - estimation.models.feols_.Feols.predict
         - estimation.models.feols_.Feols.fixef
+        - estimation.models.feols_.Feols.capabilities
         - estimation.models.feols_.Feols.get_performance
         - estimation.models.feols_.Feols.wald_test
         - estimation.models.feols_.Feols.wildboottest
@@ -213,6 +216,12 @@ quartodoc:
         - estimation.models.feols_.Feols.update
         - estimation.models.feols_.Feols.evalue
         - estimation.models.feols_.Feols.pvalue_savi
+    - title: Estimator Support
+      desc: |
+        Which post-estimation and inference methods each estimator supports. See
+        [Which Methods Does Each Estimator Support?](/how-to/supported-methods.qmd).
+      contents:
+        - estimation.capabilities.support_matrix
     - title: Summarize and Visualize
       desc: |
         Summary tables and coefficient plots for fitted models.

--- a/docs/_sidebar.yml
+++ b/docs/_sidebar.yml
@@ -39,6 +39,7 @@ website:
       - reference/estimation.models.feols_.Feols.vcov.qmd
       - reference/estimation.models.feols_.Feols.predict.qmd
       - reference/estimation.models.feols_.Feols.fixef.qmd
+      - reference/estimation.models.feols_.Feols.capabilities.qmd
       - reference/estimation.models.feols_.Feols.get_performance.qmd
       - reference/estimation.models.feols_.Feols.wald_test.qmd
       - reference/estimation.models.feols_.Feols.wildboottest.qmd
@@ -49,6 +50,9 @@ website:
       - reference/estimation.models.feols_.Feols.evalue.qmd
       - reference/estimation.models.feols_.Feols.pvalue_savi.qmd
       section: Post-Estimation Methods
+    - contents:
+      - reference/estimation.capabilities.support_matrix.qmd
+      section: Estimator Support
     - contents:
       - reference/report.summary.qmd
       - reference/report.etable.qmd

--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -78,6 +78,32 @@ fit3 = pf.feols("Y ~ X1 + X2 | f1", data = df)
   fit.confint(inference_type="simult")   # replaces fit.confint(joint=True)
   ```
 
+### Post-Estimation
+
+- Which post-estimation and inference methods a fit supports is now declared
+  once per estimator instead of being re-derived inside each method.
+  `pf.estimation.support_matrix()` shows the estimator-by-feature table, and
+  `fit.capabilities()` reports the support of one fitted model together with
+  the reason behind every unsupported entry. See
+  [Which Methods Does Each Estimator Support?](/how-to/supported-methods.qmd).
+
+  ```python
+  import pyfixest as pf
+
+  pf.estimation.support_matrix()
+  pf.feols("Y ~ X1", pf.get_data(), weights="weights").capabilities()
+  ```
+
+- Rejected combinations now share one message, `"<feature> is not supported for
+  <reason>."`. The exception types are unchanged: `CRV3` raises
+  `VcovTypeNotSupportedError` and every other feature raises
+  `NotImplementedError`.
+- `quantreg()` results now reject `predict(se_fit=True)` and
+  `predict(interval="prediction")`. They previously returned prediction
+  standard errors from the OLS residual-variance formula, which does not
+  describe a conditional quantile; R `quantreg` inverts ranks or bootstraps
+  instead.
+
 ### Safe Anytime-Valid Inference (SAVI)
 
 PyFixest now supports safe anytime-valid inference (SAVI) for linear

--- a/docs/how-to/index.qmd
+++ b/docs/how-to/index.qmd
@@ -8,6 +8,7 @@ listing:
   contents:
     - marginaleffects.qmd
     - anytime-valid-inference.qmd
+    - supported-methods.qmd
     - regression_decomposition.qmd
     - demeaner-backends.qmd
     - pyfixest_gpu.qmd

--- a/docs/how-to/supported-methods.qmd
+++ b/docs/how-to/supported-methods.qmd
@@ -1,0 +1,74 @@
+---
+title: "Which Methods Does Each Estimator Support?"
+description: "Look up whether a fitted model can run a post-estimation or inference method, and why not when it cannot."
+categories: [post-estimation, inference]
+jupyter: python3
+---
+
+Not every post-estimation method applies to every fit. Cluster-jackknife
+covariance needs refits that reproduce the original estimator; the wild cluster
+bootstrap resamples residuals of a single linear equation; the Gelbach
+decomposition compares nested linear projections. PyFixest declares those
+limits once per estimator instead of discovering them halfway through a
+computation, so an unsupported combination raises an error naming the reason
+rather than returning a plausible-looking number.
+
+## The estimator matrix
+
+`support_matrix()` shows what each estimator supports for a plain fit, i.e.
+without weights and without absorbed fixed effects.
+
+```{python}
+import pyfixest as pf
+
+pf.estimation.support_matrix()
+```
+
+Read the rows as follows.
+
+| Feature | Method |
+|---|---|
+| `crv3` | `vcov({"CRV3": ...})`, the cluster jackknife |
+| `hac` | `vcov("NW")` and `vcov("DK")` |
+| `nid` | `vcov("nid")`, the quantile sandwich with an estimated conditional density |
+| `wildboottest` | [`wildboottest()`](/reference/estimation.models.feols_.Feols.wildboottest.qmd) |
+| `ccv` | [`ccv()`](/reference/estimation.models.feols_.Feols.ccv.qmd) |
+| `decompose` | [`decompose()`](/reference/estimation.models.feols_.Feols.decompose.qmd) |
+| `ritest` | [`ritest()`](/reference/estimation.models.feols_.Feols.ritest.qmd) |
+| `fixef` | [`fixef()`](/reference/estimation.models.feols_.Feols.fixef.qmd) |
+| `predict` | [`predict()`](/reference/estimation.models.feols_.Feols.predict.qmd) |
+| `prediction_errors` | `predict(se_fit=True)` and `predict(interval="prediction")` |
+| `update` | [`update()`](/reference/estimation.models.feols_.Feols.update.qmd) |
+| `savi` | [`evalue()`](/reference/estimation.models.feols_.Feols.evalue.qmd), [`pvalue_savi()`](/reference/estimation.models.feols_.Feols.pvalue_savi.qmd), and `confint(inference_type="savi")` |
+
+## The support of one fit
+
+Weights, fixed effects, and instruments can withdraw a feature the estimator
+supports in general. `capabilities()` reports the support of the fit in hand
+together with the reason for every unsupported entry.
+
+```{python}
+data = pf.get_data()
+weighted = pf.feols("Y ~ X1 + X2", data=data, weights="weights")
+
+weighted.capabilities()
+```
+
+Analytic weights leave point predictions and cluster-robust covariance
+available but rule out the wild bootstrap, randomization inference, the causal
+cluster variance, and safe anytime-valid inference, each of which assumes an
+unweighted estimating equation.
+
+Calling one of those methods raises the same reason as an error.
+
+```{python}
+try:
+    weighted.ccv(treatment="X1")
+except NotImplementedError as error:
+    print(error)
+```
+
+Restrictions that depend on the arguments rather than on the fit -- the vcov
+types `evalue()` accepts, `update(inplace=True)`, or multiway clustering in the
+wild bootstrap -- are not part of this table and are documented with the
+individual methods.

--- a/pyfixest/estimation/__init__.py
+++ b/pyfixest/estimation/__init__.py
@@ -16,6 +16,7 @@ from pyfixest.estimation.api import (
     fepois,
     quantreg,
 )
+from pyfixest.estimation.capabilities import support_matrix
 from pyfixest.estimation.deprecated.model_matrix_fixest_ import (
     model_matrix_fixest,
 )
@@ -67,5 +68,6 @@ __all__ = [
     "optimal_mixture_precision",
     "quantreg",
     "rwolf",
+    "support_matrix",
     "wyoung",
 ]

--- a/pyfixest/estimation/capabilities.py
+++ b/pyfixest/estimation/capabilities.py
@@ -1,0 +1,313 @@
+"""Declarative support contract for post-estimation and inference features.
+
+One table per model class answers a single question: can this fitted result run
+this feature? Each gated method asks the table instead of re-deriving support
+from `_is_iv`, `_has_weights`, `_has_fixef`, or the mutable `_method` label, so
+an unsupported combination fails with a specific error rather than
+reinterpreting one estimator's arrays as another's.
+
+A class declares a `Capabilities` table of `Rule` callables, one per `Feature`.
+A rule receives the `FitFeatures` of one fitted result and returns either
+`None`, meaning supported, or the reason the fit is unsupported.
+Argument-level restrictions -- `update(inplace=True)`,
+`decompose(only_coef=...)`, multiway-cluster limits, or the covariance types
+SAVI accepts -- stay with their methods; only fit-level support lives here.
+
+See [Which Methods Does Each Estimator Support?](/how-to/supported-methods.qmd)
+for the rendered table.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Final, Literal, TypeAlias, get_args
+
+from pyfixest.errors import VcovTypeNotSupportedError
+from pyfixest.estimation.internals.literals import (
+    EstimatorKind,
+    FamilyOptions,
+    WeightsTypeOptions,
+)
+
+Feature: TypeAlias = Literal[
+    "crv3",
+    "hac",
+    "nid",
+    "wildboottest",
+    "ccv",
+    "decompose",
+    "ritest",
+    "fixef",
+    "predict",
+    "prediction_errors",
+    "update",
+    "savi",
+]
+
+FEATURES: Final[tuple[Feature, ...]] = get_args(Feature)
+
+# `_method` labels that the difference-in-differences entry points write onto an
+# otherwise ordinary `Feols` result. Their coefficients and covariance come from
+# a two-step or event-study estimator, so features that refit the retained OLS
+# design would silently report inference for a different model.
+DID_METHOD_LABELS: Final[frozenset[str]] = frozenset({"did2s", "twfe", "saturated"})
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class FitFeatures:
+    """Fit-level properties that decide post-estimation support.
+
+    Attributes
+    ----------
+    estimator : EstimatorKind
+        Estimator that produced the fit, taken from the model class rather than
+        from the mutable `_method` label.
+    family : FamilyOptions or None
+        GLM family of the fit, and None outside GLMs.
+    is_iv : bool
+        Whether the fit instruments an endogenous regressor.
+    has_fixef : bool
+        Whether fixed effects were absorbed.
+    has_weights : bool
+        Whether the user supplied observation weights.
+    weights_kind : WeightsTypeOptions or None
+        Interpretation of the observation weights, and None when the fit is
+        unweighted. An unweighted fit reports None even though the estimation
+        API still carries its default `weights_type`.
+    is_did : bool
+        Whether a difference-in-differences entry point relabelled this result.
+        Such results reuse `Feols` as their result class but carry two-step or
+        event-study estimates and covariance.
+    """
+
+    estimator: EstimatorKind
+    family: FamilyOptions | None = None
+    is_iv: bool = False
+    has_fixef: bool = False
+    has_weights: bool = False
+    weights_kind: WeightsTypeOptions | None = None
+    is_did: bool = False
+
+
+Rule: TypeAlias = Callable[[FitFeatures], "str | None"]
+"""Return the reason a fit is unsupported, or None when it is supported."""
+
+Condition: TypeAlias = tuple[Callable[[FitFeatures], bool], str]
+"""A predicate on a fit paired with the reason it makes a feature unavailable."""
+
+
+def unsupported_estimator(features: FitFeatures) -> str:
+    """Reject every fit, naming the estimator that produced it.
+
+    This is the default rule of every `Capabilities` field: a feature a class
+    does not declare is unsupported for that estimator.
+
+    Parameters
+    ----------
+    features : FitFeatures
+        Properties of the fitted result under test.
+
+    Returns
+    -------
+    str
+        The reason, naming the estimator.
+    """
+    return f"models of type '{features.estimator}'"
+
+
+def supported() -> Rule:
+    """Build a rule that accepts every fit of the declaring estimator.
+
+    Returns
+    -------
+    Rule
+        A rule that always returns None.
+    """
+
+    def rule(features: FitFeatures) -> str | None:
+        return None
+
+    return rule
+
+
+def unsupported(reason: str) -> Rule:
+    """Build a rule that rejects every fit of the declaring estimator.
+
+    Parameters
+    ----------
+    reason : str
+        The reason, phrased as the object of "is not supported for", such as
+        `"IV models"`.
+
+    Returns
+    -------
+    Rule
+        A rule that always returns `reason`.
+    """
+
+    def rule(features: FitFeatures) -> str | None:
+        return reason
+
+    return rule
+
+
+def unless(*conditions: Condition) -> Rule:
+    """Build a rule that accepts a fit unless one of `conditions` holds.
+
+    Parameters
+    ----------
+    *conditions : Condition
+        Predicate and reason pairs, tested in order. The first predicate that
+        holds decides the message, so list the most specific condition first.
+
+    Returns
+    -------
+    Rule
+        A rule returning the reason of the first matching condition, else None.
+    """
+
+    def rule(features: FitFeatures) -> str | None:
+        for holds, reason in conditions:
+            if holds(features):
+                return reason
+        return None
+
+    return rule
+
+
+IV: Final[Condition] = (lambda features: features.is_iv, "IV models")
+WEIGHTED: Final[Condition] = (
+    lambda features: features.has_weights,
+    "models with weights",
+)
+FIXED_EFFECTS: Final[Condition] = (
+    lambda features: features.has_fixef,
+    "models with fixed effects",
+)
+FREQUENCY_WEIGHTS: Final[Condition] = (
+    lambda features: features.weights_kind == "fweights",
+    "models with frequency weights",
+)
+NON_FREQUENCY_WEIGHTS: Final[Condition] = (
+    lambda features: features.has_weights and features.weights_kind != "fweights",
+    "models with non-frequency weights",
+)
+DIFFERENCE_IN_DIFFERENCES: Final[Condition] = (
+    lambda features: features.is_did,
+    "difference-in-differences results",
+)
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class Capabilities:
+    """The post-estimation features one model class supports.
+
+    Every field is a `Rule` evaluated against the `FitFeatures` of a fitted
+    result. Fields left out default to `unsupported_estimator`, so a class
+    declares only what it supports and any feature added later starts out
+    unsupported everywhere.
+
+    Attributes
+    ----------
+    crv3 : Rule
+        `vcov={"CRV3": ...}` cluster-jackknife covariance.
+    hac : Rule
+        Newey-West and Driscoll-Kraay covariance.
+    nid : Rule
+        `vcov="nid"`, the quantile-regression sandwich with an estimated
+        conditional density.
+    wildboottest : Rule
+        Wild cluster bootstrap.
+    ccv : Rule
+        Causal cluster variance of Abadie et al. (2023).
+    decompose : Rule
+        Gelbach (2016) decomposition.
+    ritest : Rule
+        Randomization inference.
+    fixef : Rule
+        Recovery of the absorbed fixed-effect coefficients.
+    predict : Rule
+        Point predictions, in sample and on new data.
+    prediction_errors : Rule
+        Prediction standard errors and prediction intervals.
+    update : Rule
+        Sherman-Morrison coefficient updates.
+    savi : Rule
+        Safe anytime-valid e-values, sequential p-values, and confidence
+        sequences.
+    """
+
+    crv3: Rule = unsupported_estimator
+    hac: Rule = unsupported_estimator
+    nid: Rule = unsupported_estimator
+    wildboottest: Rule = unsupported_estimator
+    ccv: Rule = unsupported_estimator
+    decompose: Rule = unsupported_estimator
+    ritest: Rule = unsupported_estimator
+    fixef: Rule = unsupported_estimator
+    predict: Rule = unsupported_estimator
+    prediction_errors: Rule = unsupported_estimator
+    update: Rule = unsupported_estimator
+    savi: Rule = unsupported_estimator
+
+    def evaluate(self, features: FitFeatures) -> dict[Feature, str | None]:
+        """Evaluate every rule against one fitted result.
+
+        Parameters
+        ----------
+        features : FitFeatures
+            Properties of the fitted result under test.
+
+        Returns
+        -------
+        dict
+            Maps each feature to None when it is supported, and otherwise to
+            the reason it is not.
+        """
+        return {feature: getattr(self, feature)(features) for feature in FEATURES}
+
+
+FEATURE_ERRORS: Final[Mapping[Feature, type[Exception]]] = MappingProxyType(
+    {
+        **dict.fromkeys(FEATURES, NotImplementedError),
+        # A rejected covariance type is a covariance error, not a missing
+        # method, and callers have caught it as such since CRV3 was added.
+        "crv3": VcovTypeNotSupportedError,
+    }
+)
+
+
+def require_support(
+    *,
+    capabilities: Capabilities,
+    feature: Feature,
+    features: FitFeatures,
+    subject: str,
+) -> None:
+    """Raise unless `capabilities` support `feature` for this fit.
+
+    Parameters
+    ----------
+    capabilities : Capabilities
+        The declaration of the model class that produced the fit.
+    feature : Feature
+        The feature the caller is about to run.
+    features : FitFeatures
+        Properties of the fitted result under test.
+    subject : str
+        How the message names the feature, such as `"CRV3 inference"`. It
+        becomes the subject of "... is not supported for ...".
+
+    Raises
+    ------
+    Exception
+        The type registered for `feature` in `FEATURE_ERRORS`:
+        `VcovTypeNotSupportedError` for `"crv3"` and `NotImplementedError`
+        otherwise.
+    """
+    reason = getattr(capabilities, feature)(features)
+    if reason is None:
+        return
+    raise FEATURE_ERRORS[feature](f"{subject} is not supported for {reason}.")

--- a/pyfixest/estimation/capabilities.py
+++ b/pyfixest/estimation/capabilities.py
@@ -93,11 +93,11 @@ class FitFeatures:
     is_did: bool = False
 
 
+# A rule returns the reason a fit is unsupported, or None when it is supported.
 Rule: TypeAlias = Callable[[FitFeatures], str | None]
-"""Return the reason a fit is unsupported, or None when it is supported."""
 
+# A predicate on a fit paired with the reason it makes a feature unavailable.
 Condition: TypeAlias = tuple[Callable[[FitFeatures], bool], str]
-"""A predicate on a fit paired with the reason it makes a feature unavailable."""
 
 
 def unsupported_estimator(features: FitFeatures) -> str:

--- a/pyfixest/estimation/capabilities.py
+++ b/pyfixest/estimation/capabilities.py
@@ -24,6 +24,8 @@ from dataclasses import dataclass
 from types import MappingProxyType
 from typing import Final, Literal, TypeAlias, get_args
 
+import pandas as pd
+
 from pyfixest.errors import VcovTypeNotSupportedError
 from pyfixest.estimation.internals.literals import (
     EstimatorKind,
@@ -91,7 +93,7 @@ class FitFeatures:
     is_did: bool = False
 
 
-Rule: TypeAlias = Callable[[FitFeatures], "str | None"]
+Rule: TypeAlias = Callable[[FitFeatures], str | None]
 """Return the reason a fit is unsupported, or None when it is supported."""
 
 Condition: TypeAlias = tuple[Callable[[FitFeatures], bool], str]
@@ -311,3 +313,53 @@ def require_support(
     if reason is None:
         return
     raise FEATURE_ERRORS[feature](f"{subject} is not supported for {reason}.")
+
+
+def support_matrix() -> pd.DataFrame:
+    """Return the feature support of every estimator at a plain fit.
+
+    The table evaluates each model class's declaration for an unweighted fit
+    without fixed effects, so it shows what an estimator supports in principle.
+    Weights, fixed effects, and instruments can withdraw a feature from an
+    individual fit; call
+    [`capabilities()`](/reference/estimation.models.feols_.Feols.capabilities.qmd)
+    on a fitted result for the support of that fit.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Boolean support, indexed by feature, with one column per estimator:
+        `feols`, `feiv`, `fepois`, `feglm`, and `quantreg`.
+
+    Examples
+    --------
+    ```{python}
+    import pyfixest as pf
+
+    pf.estimation.support_matrix()
+    ```
+    """
+    from pyfixest.estimation.models.feglm_ import Feglm
+    from pyfixest.estimation.models.feiv_ import Feiv
+    from pyfixest.estimation.models.feols_ import Feols
+    from pyfixest.estimation.models.fepois_ import Fepois
+    from pyfixest.estimation.quantreg.quantreg_ import Quantreg
+
+    plain_fits: dict[str, tuple[type[Feols], FitFeatures]] = {
+        "feols": (Feols, FitFeatures(estimator="feols")),
+        "feiv": (Feiv, FitFeatures(estimator="feols", is_iv=True)),
+        "fepois": (Fepois, FitFeatures(estimator="fepois", family="poisson")),
+        "feglm": (Feglm, FitFeatures(estimator="feglm", family="logit")),
+        "quantreg": (Quantreg, FitFeatures(estimator="quantreg")),
+    }
+
+    return pd.DataFrame(
+        {
+            name: [
+                reason is None
+                for reason in model._capabilities.evaluate(features).values()
+            ]
+            for name, (model, features) in plain_fits.items()
+        },
+        index=pd.Index(FEATURES, name="feature"),
+    )

--- a/pyfixest/estimation/internals/literals.py
+++ b/pyfixest/estimation/internals/literals.py
@@ -5,6 +5,10 @@ VcovTypeOptions = Literal["iid", "hetero", "HC1", "HC2", "HC3", "nid"]
 WeightsTypeOptions = Literal["aweights", "fweights"]
 FixedRmOptions = Literal["singleton", "none"]
 FamilyOptions = Literal["logit", "probit", "gaussian", "poisson"]
+# The estimator that produced a fitted result. Unlike the mutable `_method`
+# label, this identifies the model class and never carries a family, solver, or
+# difference-in-differences suffix.
+EstimatorKind = Literal["feols", "fepois", "feglm", "quantreg"]
 SolverOptions = Literal[
     "np.linalg.lstsq",
     "np.linalg.solve",

--- a/pyfixest/estimation/models/_result_accessor_mixin.py
+++ b/pyfixest/estimation/models/_result_accessor_mixin.py
@@ -9,6 +9,7 @@ import pandas as pd
 from pyfixest.errors import EmptyVcovError
 
 if TYPE_CHECKING:
+    from pyfixest.estimation.capabilities import Feature
     from pyfixest.estimation.internals.families import InferenceDist
     from pyfixest.estimation.internals.model_state import (
         ObservationWeights,
@@ -162,6 +163,15 @@ class ResultAccessorMixin(TidyColumnAccessors):
         remedy: str = "Refit with lean=False.",
     ) -> None:
         """Reject a call whose input arrays `lean=True` discarded.
+
+        Implemented by the host class.
+        """
+        raise NotImplementedError
+
+    def _require_support(
+        self, feature: "Feature", *, subject: str | None = None
+    ) -> None:
+        """Reject a feature this fit does not support.
 
         Implemented by the host class.
         """

--- a/pyfixest/estimation/models/feglm_.py
+++ b/pyfixest/estimation/models/feglm_.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, Literal
+from typing import Any, ClassVar, Literal
 
 import numpy as np
 import pandas as pd
@@ -9,11 +9,18 @@ from numpy.typing import NDArray
 
 from pyfixest.core.demean import Preconditioner
 from pyfixest.demeaners import AnyDemeaner
+from pyfixest.estimation.capabilities import (
+    FREQUENCY_WEIGHTS,
+    Capabilities,
+    supported,
+    unless,
+)
 from pyfixest.estimation.formula.model_matrix import ModelMatrix
 from pyfixest.estimation.formula.parse import Formula as FixestFormula
 from pyfixest.estimation.internals.demean_ import DemeanedData
 from pyfixest.estimation.internals.families import GlmFamily
 from pyfixest.estimation.internals.fit_glm_ import fit_glm_irls
+from pyfixest.estimation.internals.literals import EstimatorKind
 from pyfixest.estimation.internals.separation import check_for_separation
 from pyfixest.estimation.internals.vcov_ import vcov_iid_glm
 from pyfixest.estimation.models.feols_ import (
@@ -48,6 +55,17 @@ class Feglm(Feols):
     fit.tidy()
     ```
     """
+
+    _estimator: ClassVar[EstimatorKind] = "feglm"
+    # IRLS leaves a working response, a working design, and working weights
+    # behind. Features that read those arrays as an OLS fit would resample or
+    # refit the wrong quantities, so a GLM keeps only the covariance and
+    # post-estimation paths written against its working state.
+    _capabilities: ClassVar[Capabilities] = Capabilities(
+        hac=unless(FREQUENCY_WEIGHTS),
+        fixef=supported(),
+        predict=supported(),
+    )
 
     def __init__(
         self,
@@ -112,15 +130,6 @@ class Feglm(Feols):
         self.convergence = False
         self.separation_check = separation_check
         self._accelerate = accelerate
-
-        # The inherited slow jackknife refits with the linear/Poisson APIs and
-        # cannot yet preserve a generic GLM family's estimation contract.
-        self._support_crv3_inference = False
-        self._support_iid_inference = True
-        self._support_hac_inference = True
-        self._supports_wildboottest = False
-        self._supports_cluster_causal_variance = False
-        self._support_decomposition = False
 
         self._Y_hat_response = np.empty(0)
         self.deviance = None
@@ -402,8 +411,8 @@ class Feglm(Feols):
             standard errors if argument "se_fit=True".
         """
         if se_fit:
-            raise NotImplementedError(
-                "Prediction with standard errors is not implemented for GLMs."
+            self._require_support(
+                "prediction_errors", subject="Prediction with standard errors"
             )
 
         yhat = super().predict(newdata=newdata, type="link", atol=atol, btol=btol)

--- a/pyfixest/estimation/models/feiv_.py
+++ b/pyfixest/estimation/models/feiv_.py
@@ -4,7 +4,7 @@ import warnings
 from collections.abc import Mapping
 from dataclasses import replace
 from importlib import import_module
-from typing import Any, Literal
+from typing import Any, ClassVar, Literal
 
 import numpy as np
 import pandas as pd
@@ -12,6 +12,12 @@ from numpy.typing import NDArray
 
 from pyfixest.core.demean import Preconditioner
 from pyfixest.demeaners import AnyDemeaner, LsmrDemeaner
+from pyfixest.estimation.capabilities import (
+    FREQUENCY_WEIGHTS,
+    Capabilities,
+    unless,
+    unsupported,
+)
 from pyfixest.estimation.formula.parse import Formula as FixestFormula
 from pyfixest.estimation.internals.collinearity import drop_multicollinear_variables
 from pyfixest.estimation.internals.demean_ import DemeanedData
@@ -74,10 +80,6 @@ class Feiv(Feols):
         Indices of collinear variables in Z.
     _is_iv : bool
         Indicator if instrumental variables are used.
-    _support_crv3_inference : bool
-        Indicator for supporting CRV3 inference.
-    _support_iid_inference : bool
-        Indicator for supporting IID inference.
     _tZX : np.ndarray
         Transpose of Z times X.
     _tXZ : np.ndarray
@@ -160,6 +162,25 @@ class Feiv(Feols):
     details.
     """
 
+    # 2SLS keeps the estimator kind of the linear path it extends. Every
+    # feature that reads the retained design as a single-equation OLS fit --
+    # jackknife refits, bootstrap resampling, mediation, prediction, and
+    # coefficient updates -- would ignore the first stage, so 2SLS supports
+    # only the covariance estimators written for it.
+    _capabilities: ClassVar[Capabilities] = Capabilities(
+        crv3=unsupported("IV models"),
+        hac=unless(FREQUENCY_WEIGHTS),
+        wildboottest=unsupported("IV models"),
+        ccv=unsupported("IV models"),
+        decompose=unsupported("IV models"),
+        ritest=unsupported("IV models"),
+        fixef=unsupported("IV models"),
+        predict=unsupported("IV models"),
+        prediction_errors=unsupported("IV models"),
+        update=unsupported("IV models"),
+        savi=unsupported("IV models"),
+    )
+
     # Constructor and methods implementation...
     def __init__(
         self,
@@ -209,10 +230,6 @@ class Feiv(Feols):
         )
 
         self._is_iv = True
-        self._support_crv3_inference = False
-        self._support_iid_inference = True
-        self._supports_cluster_causal_variance = False
-        self._support_decomposition = False
 
     def _prepare_within_data(self) -> WithinLinearData:
         """Return second-stage and instrument arrays on within scale."""

--- a/pyfixest/estimation/models/feols_.py
+++ b/pyfixest/estimation/models/feols_.py
@@ -1137,6 +1137,53 @@ class Feols(ResultAccessorMixin):
         if self._lean:
             self._fit_state_discarded = True
 
+    def capabilities(self) -> pd.DataFrame:
+        """
+        Report which post-estimation methods this fitted model supports.
+
+        Support depends on the estimator and on the fit: weights, absorbed
+        fixed effects, and instruments each withdraw methods whose derivation
+        does not cover them. Calling an unsupported method raises an error
+        carrying the same reason.
+
+        Returns
+        -------
+        pandas.DataFrame
+            Indexed by feature, with a boolean `supported` column and a
+            `reason` column that is None wherever the feature is available.
+            See [Which Methods Does Each Estimator Support?](/how-to/supported-methods.qmd)
+            for what each feature name refers to.
+
+        Notes
+        -----
+        Restrictions that depend on the arguments rather than on the fit, such
+        as the covariance types `evalue()` accepts or `update(inplace=True)`,
+        are documented with the individual methods.
+        [`pf.estimation.support_matrix()`](/reference/estimation.capabilities.support_matrix.qmd)
+        gives the same table across all estimators.
+
+        Examples
+        --------
+        ```{python}
+        import pyfixest as pf
+
+        fit = pf.feols("Y ~ X1 + X2", pf.get_data(), weights="weights")
+        fit.capabilities()
+        ```
+        """
+        reasons = self._capabilities.evaluate(self._fit_features)
+        index = pd.Index(list(reasons), name="feature")
+        return pd.DataFrame(
+            {
+                "supported": pd.Series(
+                    [reason is None for reason in reasons.values()], index=index
+                ),
+                # object dtype so a supported feature keeps its None reason
+                # instead of being coerced to a missing string value.
+                "reason": pd.Series(list(reasons.values()), index=index, dtype=object),
+            }
+        )
+
     def wald_test(self, R=None, q=None, distribution="F"):
         """
         Conduct Wald test.

--- a/pyfixest/estimation/models/feols_.py
+++ b/pyfixest/estimation/models/feols_.py
@@ -6,7 +6,7 @@ from collections.abc import Mapping
 from dataclasses import replace
 from functools import partial
 from importlib import import_module
-from typing import Any, Literal, cast
+from typing import Any, ClassVar, Literal, cast
 
 import formulaic
 import numpy as np
@@ -20,6 +20,20 @@ from pyfixest.core.demean import Preconditioner, WithinPreconditionerName
 from pyfixest.demeaners import AnyDemeaner, LsmrDemeaner, MapDemeaner
 from pyfixest.errors import VcovTypeNotSupportedError
 from pyfixest.estimation.api.utils import _ALL_SAMPLE, _AllSampleSentinel
+from pyfixest.estimation.capabilities import (
+    DID_METHOD_LABELS,
+    DIFFERENCE_IN_DIFFERENCES,
+    FIXED_EFFECTS,
+    FREQUENCY_WEIGHTS,
+    NON_FREQUENCY_WEIGHTS,
+    WEIGHTED,
+    Capabilities,
+    Feature,
+    FitFeatures,
+    require_support,
+    supported,
+    unless,
+)
 from pyfixest.estimation.formula import FORMULAIC_TRANSFORMS
 from pyfixest.estimation.formula import model_matrix as model_matrix_fixest
 from pyfixest.estimation.formula.formulaic_compat import (
@@ -32,6 +46,7 @@ from pyfixest.estimation.internals.demean_ import DemeanCache, DemeanedData
 from pyfixest.estimation.internals.families import T_DIST, InferenceDist
 from pyfixest.estimation.internals.fit_ import fit_ols
 from pyfixest.estimation.internals.literals import (
+    EstimatorKind,
     PredictionErrorOptions,
     PredictionType,
     SolverOptions,
@@ -151,8 +166,6 @@ class Feols(ResultAccessorMixin):
         Number of observations.
     _k : int
         Number of independent variables (or features).
-    _support_crv3_inference : bool
-        Indicates support for CRV3 inference.
     _data : Any
         Data used in the regression, to be enriched outside of the class.
     _fml : Any
@@ -257,6 +270,24 @@ class Feols(ResultAccessorMixin):
 
     """
 
+    _estimator: ClassVar[EstimatorKind] = "feols"
+    # Which post-estimation features an OLS fit supports; see
+    # `pyfixest.estimation.capabilities`. Argument-level restrictions stay with
+    # their methods, so only fit-level support is declared here.
+    _capabilities: ClassVar[Capabilities] = Capabilities(
+        crv3=supported(),
+        hac=unless(FREQUENCY_WEIGHTS),
+        wildboottest=unless(WEIGHTED),
+        ccv=unless(FIXED_EFFECTS, WEIGHTED),
+        decompose=unless(NON_FREQUENCY_WEIGHTS),
+        ritest=unless(DIFFERENCE_IN_DIFFERENCES, WEIGHTED),
+        fixef=supported(),
+        predict=supported(),
+        prediction_errors=unless(FIXED_EFFECTS, WEIGHTED),
+        update=unless(DIFFERENCE_IN_DIFFERENCES, FIXED_EFFECTS, WEIGHTED),
+        savi=unless(DIFFERENCE_IN_DIFFERENCES, FIXED_EFFECTS, WEIGHTED),
+    )
+
     def __init__(
         self,
         FixestFormula: FixestFormula,
@@ -328,14 +359,6 @@ class Feols(ResultAccessorMixin):
         # through the same guarded methods.
         self._fit_state_discarded = False
         self._context = capture_context(context)
-
-        self._support_crv3_inference = True
-        self._support_hac_inference = True
-        self._supports_wildboottest = True
-        self._supports_cluster_causal_variance = True
-        if self._has_weights or self._is_iv:
-            self._supports_wildboottest = False
-        self._support_decomposition = True
 
         # attributes that have to be enriched outside of the class -
         # not really optimal code change later
@@ -644,6 +667,47 @@ class Feols(ResultAccessorMixin):
         """Yield this fitted result to the result container."""
         return (self,)
 
+    @property
+    def _fit_features(self) -> FitFeatures:
+        """Fit-level properties the capability rules read.
+
+        Rebuilt on every access: `vcov()` and the storage options mutate a
+        fitted result in place, so a cached snapshot could outlive the state it
+        describes.
+        """
+        family = getattr(self, "_family", None)
+        return FitFeatures(
+            estimator=self._estimator,
+            family=None if family is None else family.name,
+            is_iv=self._is_iv,
+            has_fixef=self._has_fixef,
+            has_weights=self._has_weights,
+            weights_kind=(
+                cast(WeightsTypeOptions, self._weights_type)
+                if self._has_weights
+                else None
+            ),
+            is_did=self._method in DID_METHOD_LABELS,
+        )
+
+    def _require_support(self, feature: Feature, *, subject: str | None = None) -> None:
+        """Reject a feature this fit does not support.
+
+        Parameters
+        ----------
+        feature : Feature
+            The feature the caller is about to run.
+        subject : str, optional
+            How the error message names the feature. Defaults to
+            `"<feature>()"`.
+        """
+        require_support(
+            capabilities=self._capabilities,
+            feature=feature,
+            features=self._fit_features,
+            subject=f"{feature}()" if subject is None else subject,
+        )
+
     def _require_fit_arrays(
         self,
         method: str,
@@ -863,10 +927,7 @@ class Feols(ResultAccessorMixin):
         if self._vcov_type_detail == "CRV1":
             return self._vcov_crv1(clustid=clustid, cluster_col=cluster_col)
 
-        if not self._support_crv3_inference:
-            raise VcovTypeNotSupportedError(
-                f"CRV3 inference is not for models of type '{self._method}'."
-            )
+        self._require_support("crv3", subject="CRV3 inference")
         use_fast = not self._has_fixef and self._method == "feols" and not self._is_iv
         if use_fast:
             return self._vcov_crv3_fast(clustid=clustid, cluster_col=cluster_col)
@@ -917,16 +978,7 @@ class Feols(ResultAccessorMixin):
         _time_id = self._time_id
         _panel_id = self._panel_id
 
-        if not self._support_hac_inference:
-            raise NotImplementedError(
-                "HAC inference is not supported for this model type."
-            )
-
-        # fweights not supported
-        if self._has_weights and self._weights_type == "fweights":
-            raise NotImplementedError(
-                "HAC inference (NW, DK) is not supported with `weights_type='fweights'`."
-            )
+        self._require_support("hac", subject="HAC inference (NW, DK)")
 
         # some data checks on input pandas df
         # time needs to be numeric or date else we cannot sort by time
@@ -954,8 +1006,11 @@ class Feols(ResultAccessorMixin):
         )
 
     def _vcov_nid(self):
+        "Reject 'nid' covariance for estimators without a conditional density."
+        self._require_support("nid", subject="'nid' inference")
         raise NotImplementedError(
-            "Only models of type Quantreg support a variance-covariance matrix of type 'nid'."
+            f"'nid' inference is declared supported for models of type "
+            f"'{self._estimator}', but the class provides no implementation."
         )
 
     def _vcov_crv1(self, clustid: np.ndarray, cluster_col: np.ndarray):
@@ -1284,18 +1339,7 @@ class Feols(ResultAccessorMixin):
                 f"Parameter {param} not found in the model's coefficients."
             )
 
-        if not self._supports_wildboottest:
-            if self._is_iv:
-                raise NotImplementedError(
-                    "Wild cluster bootstrap is not supported for IV estimation."
-                )
-            if self._has_weights:
-                raise NotImplementedError(
-                    "Wild cluster bootstrap is not supported for WLS estimation."
-                )
-            raise NotImplementedError(
-                "Wild cluster bootstrap is only supported for unweighted OLS models."
-            )
+        self._require_support("wildboottest", subject="Wild cluster bootstrap")
 
         self._require_fit_arrays("wildboottest", arrays="the fitted arrays")
         self._require_estimation_data("wildboottest")
@@ -1330,16 +1374,6 @@ class Feols(ResultAccessorMixin):
         except ImportError:
             print(
                 "Module 'wildboottest' not found. Please install 'wildboottest', e.g. via `PyPi`."
-            )
-
-        if self._is_iv:
-            raise NotImplementedError(
-                "Wild cluster bootstrap is not supported with IV estimation."
-            )
-
-        if self._method == "fepois":
-            raise NotImplementedError(
-                "Wild cluster bootstrap is not supported for Poisson regression."
             )
 
         _Y, _X, _xnames = self._model_matrix_one_hot()
@@ -1466,11 +1500,7 @@ class Feols(ResultAccessorMixin):
         fit.ccv(treatment="D", pk=0.05, qk=0.5, n_splits=8, seed=123).head()
         ```
         """
-        if not self._supports_cluster_causal_variance:
-            raise NotImplementedError(
-                "The causal cluster variance estimator is not supported for models "
-                f"of type '{self._method}'."
-            )
+        self._require_support("ccv", subject="The causal cluster variance estimator")
         assert isinstance(treatment, str), "treatment must be a string."
         assert isinstance(cluster, str) or cluster is None, (
             "cluster must be a string or None."
@@ -1479,15 +1509,6 @@ class Feols(ResultAccessorMixin):
         assert isinstance(n_splits, int), "n_splits must be an integer."
         assert isinstance(pk, (int, float)) and 0 <= pk <= 1
         assert isinstance(qk, (int, float)) and 0 <= qk <= 1
-
-        if self._has_fixef:
-            raise NotImplementedError(
-                "The causal cluster variance estimator is currently not supported for models with fixed effects."
-            )
-        if self._has_weights:
-            raise NotImplementedError(
-                "The causal cluster variance estimator is currently not supported for models with weights."
-            )
 
         if treatment not in self._coefnames:
             raise ValueError(
@@ -1764,19 +1785,12 @@ class Feols(ResultAccessorMixin):
             else:
                 x1_vars = list(x1_vars)
 
+        self._require_support("decompose", subject="Decomposition")
         _decompose_arg_check(
             type=type,
             has_weights=self._has_weights,
-            weights_type=self._weights_type,
-            is_iv=self._is_iv,
-            method=self._method,
             only_coef=only_coef,
         )
-
-        if not self._support_decomposition:
-            raise NotImplementedError(
-                "Decomposition is currently only supported for OLS models."
-            )
 
         self._require_fit_arrays("decompose", arrays="the fitted arrays")
         # A cluster variable or an absorbed fixed effect is read back from the
@@ -1878,10 +1892,7 @@ class Feols(ResultAccessorMixin):
         if not self._has_fixef:
             raise ValueError("The regression model does not have fixed effects.")
 
-        if self._is_iv:
-            raise NotImplementedError(
-                "The fixef() method is currently not supported for IV models."
-            )
+        self._require_support("fixef", subject="The fixef() method")
 
         self._require_fit_arrays("fixef", arrays="the fitted arrays")
         self._require_estimation_data("fixef")
@@ -2018,21 +2029,12 @@ class Feols(ResultAccessorMixin):
         fit.predict(newdata=data.head())
         ```
         """
-        if self._is_iv:
-            raise NotImplementedError(
-                "The predict() method is currently not supported for IV models."
-            )
+        self._require_support("predict", subject="The predict() method")
 
         if interval == "prediction" or se_fit:
-            if self._has_fixef:
-                raise NotImplementedError(
-                    "Prediction errors are currently not supported for models with fixed effects."
-                )
-
-            if self._has_weights:
-                raise NotImplementedError(
-                    "Prediction errors are currently not supported for models with weights."
-                )
+            self._require_support(
+                "prediction_errors", subject="Prediction with standard errors"
+            )
 
         _validate_literal_argument(type, PredictionType)
         if interval is not None:
@@ -2220,14 +2222,7 @@ class Feols(ResultAccessorMixin):
         resampvar = resampvar.replace(" ", "")
         resampvar_, h0_value, hypothesis, test_type = _decode_resampvar(resampvar)
 
-        if self._is_iv:
-            raise NotImplementedError(
-                "Randomization Inference is not supported for IV models."
-            )
-        if self._method not in {"feols", "fepois"}:
-            raise NotImplementedError(
-                "Randomization Inference is only supported for OLS and Poisson models."
-            )
+        self._require_support("ritest", subject="Randomization inference")
 
         # check that resampvar in _coefnames
         if resampvar_ not in self._coefnames:
@@ -2274,13 +2269,6 @@ class Feols(ResultAccessorMixin):
             choose_algorithm = "fast" if _HAS_NUMBA else "slow"
 
         assert isinstance(reps, int) and reps > 0, "reps must be a positive integer."
-
-        if self._has_weights:
-            raise NotImplementedError(
-                """
-                Regression Weights are not supported with Randomization Inference.
-                """
-            )
 
         if choose_algorithm == "slow" or self._method == "fepois":
             vcov_input: str | dict[str, str]
@@ -2454,22 +2442,7 @@ class Feols(ResultAccessorMixin):
         fit.update(X_new, y_new)
         ```
         """
-        if self._has_fixef:
-            raise NotImplementedError(
-                "The update() method is currently not supported for models with fixed effects."
-            )
-        if self._method != "feols":
-            raise NotImplementedError(
-                "The update() method is currently only supported for OLS models."
-            )
-        if self._is_iv:
-            raise NotImplementedError(
-                "The update() method is currently not supported for IV models."
-            )
-        if self._has_weights:
-            raise NotImplementedError(
-                "The update() method is currently not supported for models with weights."
-            )
+        self._require_support("update", subject="The update() method")
         if inplace:
             raise NotImplementedError(
                 "update(..., inplace=True) is not supported because appending design "

--- a/pyfixest/estimation/models/fepois_.py
+++ b/pyfixest/estimation/models/fepois_.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from importlib import import_module
-from typing import Any
+from typing import Any, ClassVar
 
 import numpy as np
 import pandas as pd
@@ -10,10 +10,18 @@ from scipy.special import gammaln
 
 from pyfixest.core.demean import Preconditioner
 from pyfixest.demeaners import AnyDemeaner
+from pyfixest.estimation.capabilities import (
+    FREQUENCY_WEIGHTS,
+    WEIGHTED,
+    Capabilities,
+    supported,
+    unless,
+)
 from pyfixest.estimation.formula.parse import Formula as FixestFormula
 from pyfixest.estimation.internals.demean_ import DemeanedData
 from pyfixest.estimation.internals.families import POISSON
 from pyfixest.estimation.internals.literals import (
+    EstimatorKind,
     SolverOptions,
 )
 from pyfixest.estimation.models.feglm_ import Feglm
@@ -100,6 +108,19 @@ class Fepois(Feglm):
     ```
     """
 
+    _estimator: ClassVar[EstimatorKind] = "fepois"
+    # Poisson adds the two paths whose refits the class can replay: the
+    # longstanding CRV3 jackknife and randomization inference, which both
+    # re-estimate through the public Poisson API rather than reusing the IRLS
+    # working arrays.
+    _capabilities: ClassVar[Capabilities] = Capabilities(
+        crv3=supported(),
+        hac=unless(FREQUENCY_WEIGHTS),
+        ritest=unless(WEIGHTED),
+        fixef=supported(),
+        predict=supported(),
+    )
+
     def __init__(
         self,
         FixestFormula: FixestFormula,
@@ -153,11 +174,6 @@ class Fepois(Feglm):
         # Poisson-specific overrides on top of the Feglm-set defaults.
         self._method = "fepois"
         self._offset_name = offset
-        # The inherited jackknife refit dispatch is valid for Poisson and is a
-        # longstanding public capability. Other GLM families keep this disabled.
-        self._support_crv3_inference = True
-        self._supports_cluster_causal_variance = False
-        self._support_decomposition = False
 
     def get_fit(self) -> None:
         "Fit via Feglm IRLS, then add Poisson-specific post-fit summary stats."
@@ -301,8 +317,8 @@ class Fepois(Feglm):
             standard errors if argument "se_fit=True".
         """
         if se_fit:
-            raise NotImplementedError(
-                "Prediction with standard errors is not implemented for Poisson regression."
+            self._require_support(
+                "prediction_errors", subject="Prediction with standard errors"
             )
 
         return super().predict(newdata=newdata, type=type, atol=atol, btol=btol)

--- a/pyfixest/estimation/post_estimation/decomposition.py
+++ b/pyfixest/estimation/post_estimation/decomposition.py
@@ -1024,12 +1024,14 @@ class GelbachDecomposition:
 def _decompose_arg_check(
     type: str,
     has_weights: bool,
-    weights_type: str | None,
-    is_iv: bool,
-    method: str,
     only_coef: bool,
 ) -> None:
-    "Check arguments for decomposition."
+    """Check the decomposition arguments against the fit that requests them.
+
+    Fit-level support -- IV, non-OLS estimators, and non-frequency weights --
+    is declared in `pyfixest.estimation.capabilities` and rejected before this
+    call. What remains depends on the arguments.
+    """
     supported_decomposition_types = ["gelbach"]
 
     if type not in supported_decomposition_types:
@@ -1037,23 +1039,9 @@ def _decompose_arg_check(
             f"'type' {type} is not in supported types {supported_decomposition_types}."
         )
 
-    if has_weights and weights_type != "fweights":
-        raise NotImplementedError(
-            "Decomposition is currently only supported for models with frequency weights."
-        )
     if has_weights and not only_coef:
         raise NotImplementedError(
             "Decomposition is currently only supported for models with frequency weights when only_coef is False."
-        )
-
-    if is_iv:
-        raise NotImplementedError(
-            "Decomposition is currently not supported for IV models."
-        )
-
-    if method == "fepois":
-        raise NotImplementedError(
-            "Decomposition is currently not supported for Poisson regression."
         )
 
     return None

--- a/pyfixest/estimation/post_estimation/savi.py
+++ b/pyfixest/estimation/post_estimation/savi.py
@@ -157,18 +157,7 @@ def optimal_mixture_precision(
 
 def _validate_savi_model(model: ResultAccessorMixin) -> None:
     """Reject fitted-model configurations not supported by SAVI."""
-    if model._method != "feols" or model._is_iv:
-        raise NotImplementedError(
-            "SAVI inference is currently supported only for feols models."
-        )
-    if model._has_weights:
-        raise NotImplementedError(
-            "SAVI inference does not currently support weighted feols models."
-        )
-    if model._has_fixef:
-        raise NotImplementedError(
-            "SAVI inference does not currently support feols models with fixed effects."
-        )
+    model._require_support("savi", subject="SAVI inference")
     if model._vcov_type not in _SAVI_SUPPORTED_VCOV_TYPES:
         raise NotImplementedError(
             f"SAVI inference does not support vcov type {model._vcov_type!r}. "

--- a/pyfixest/estimation/quantreg/quantreg_.py
+++ b/pyfixest/estimation/quantreg/quantreg_.py
@@ -1,16 +1,18 @@
 import warnings
 from collections.abc import Callable, Mapping
 from functools import partial
-from typing import Any, cast
+from typing import Any, ClassVar, cast
 
 import numpy as np
 import pandas as pd
 from scipy.linalg import cho_factor, solve_triangular
 
 from pyfixest.demeaners import AnyDemeaner
+from pyfixest.estimation.capabilities import Capabilities, supported
 from pyfixest.estimation.formula.parse import Formula as FixestFormula
 from pyfixest.estimation.internals.demean_ import DemeanedData
 from pyfixest.estimation.internals.literals import (
+    EstimatorKind,
     QuantregMethodOptions,
     SolverOptions,
 )
@@ -59,6 +61,17 @@ class Quantreg(Feols):
     See the [quantile regression tutorial](/tutorials/quantile-regression.qmd)
     for details.
     """
+
+    _estimator: ClassVar[EstimatorKind] = "quantreg"
+    # The quantile sandwich replaces the OLS residual variance, so `nid` is the
+    # estimator-specific covariance and the OLS residual-variance formulas
+    # behind prediction errors do not describe a conditional quantile. Their
+    # standard errors would be a validated-looking number for a method R
+    # `quantreg` estimates by rank inversion or the bootstrap instead.
+    _capabilities: ClassVar[Capabilities] = Capabilities(
+        nid=supported(),
+        predict=supported(),
+    )
 
     def __init__(
         self,
@@ -112,12 +125,6 @@ class Quantreg(Feols):
            """,
             FutureWarning,
         )
-
-        self._supports_wildboottest = False
-        self._support_crv3_inference = False
-        self._supports_cluster_causal_variance = False
-        self._support_hac_inference = False
-        self._support_decomposition = False
 
         self._quantile = quantile
         self._method = f"quantreg_{method}"

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -19,6 +19,7 @@ from pyfixest.estimation.capabilities import (
     Capabilities,
     FitFeatures,
     require_support,
+    support_matrix,
     supported,
     unless,
     unsupported,
@@ -124,6 +125,24 @@ def test_feature_errors_cover_every_feature():
     assert {FEATURE_ERRORS[feature] for feature in FEATURES if feature != "crv3"} == {
         NotImplementedError
     }
+
+
+def test_support_matrix_shape_and_selected_entries():
+    matrix = support_matrix()
+
+    assert list(matrix.index) == list(FEATURES)
+    assert matrix.index.name == "feature"
+    assert list(matrix.columns) == ["feols", "feiv", "fepois", "feglm", "quantreg"]
+    assert matrix.to_numpy().dtype == np.dtype(bool)
+
+    assert matrix.loc["crv3", "feols"]
+    assert not matrix.loc["crv3", "feiv"]
+    assert matrix.loc["crv3", "fepois"]
+    assert not matrix.loc["crv3", "feglm"]
+    assert matrix.loc["nid", "quantreg"]
+    assert not matrix.loc["nid", "feols"]
+    assert matrix.loc["predict", "quantreg"]
+    assert not matrix.loc["prediction_errors", "quantreg"]
 
 
 # ---------------------------------------------------------------------------
@@ -318,6 +337,27 @@ def test_declared_support_matches_the_public_methods(
         FEATURE_ERRORS[feature], match=rf"is not supported for {reason}\.$"
     ):
         _call(fit, feature)
+
+
+def test_capabilities_accessor_reports_supported_and_reason(
+    capability_data: pd.DataFrame,
+):
+    """The accessor reports the support of the fit in hand, not of its class."""
+    fit = _fit("ols_aweights", capability_data)
+    table = fit.capabilities()
+
+    assert list(table.index) == list(FEATURES)
+    assert table.index.name == "feature"
+    assert list(table.columns) == ["supported", "reason"]
+
+    assert table.loc["predict", "supported"]
+    assert table.loc["predict", "reason"] is None
+    assert not table.loc["ccv", "supported"]
+    assert table.loc["ccv", "reason"] == "models with weights"
+
+    plain = _fit("ols", capability_data).capabilities()
+    assert plain.loc["ccv", "supported"]
+    assert plain.loc["ccv", "reason"] is None
 
 
 def test_quantreg_rejects_ols_prediction_errors(capability_data: pd.DataFrame):

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -1,7 +1,12 @@
 """Tests for the declarative post-estimation capability contract."""
 
+import warnings
+
+import numpy as np
+import pandas as pd
 import pytest
 
+import pyfixest as pf
 from pyfixest.errors import VcovTypeNotSupportedError
 from pyfixest.estimation.capabilities import (
     FEATURE_ERRORS,
@@ -119,3 +124,242 @@ def test_feature_errors_cover_every_feature():
     assert {FEATURE_ERRORS[feature] for feature in FEATURES if feature != "crv3"} == {
         NotImplementedError
     }
+
+
+# ---------------------------------------------------------------------------
+# The declared table, enforced through the public methods that consult it.
+# ---------------------------------------------------------------------------
+
+_N = 60
+
+
+@pytest.fixture(scope="module")
+def capability_data() -> pd.DataFrame:
+    """Build a tiny deterministic sample every estimator in the matrix can fit."""
+    rng = np.random.default_rng(2718)
+    treatment = rng.binomial(1, 0.5, size=_N).astype(float)
+    instrument = rng.normal(size=_N)
+    endogenous = 0.8 * instrument + rng.normal(scale=0.5, size=_N)
+    return pd.DataFrame(
+        {
+            "Y": 1.0 + 0.5 * treatment + 0.4 * endogenous + rng.normal(size=_N),
+            "Y_count": rng.poisson(2.0, size=_N),
+            "Y_bin": rng.binomial(1, 0.5, size=_N),
+            "D": treatment,
+            "X2": rng.normal(size=_N),
+            "Z1": instrument,
+            "endog": endogenous,
+            "t": np.arange(_N, dtype=float),
+            "f1": np.tile(np.arange(6), _N // 6),
+            "cluster": np.tile(np.arange(5), _N // 5),
+            "aw": np.linspace(0.5, 1.5, _N),
+            "fw": np.tile([1.0, 2.0], _N // 2),
+        }
+    )
+
+
+def _fit(kind: str, data: pd.DataFrame):
+    if kind == "ols":
+        return pf.feols("Y ~ D + X2", data=data)
+    if kind == "ols_aweights":
+        return pf.feols("Y ~ D + X2", data=data, weights="aw", weights_type="aweights")
+    if kind == "ols_fweights":
+        return pf.feols("Y ~ D + X2", data=data, weights="fw", weights_type="fweights")
+    if kind == "ols_fixef":
+        return pf.feols("Y ~ D + X2 | f1", data=data)
+    if kind == "iv":
+        return pf.feols("Y ~ X2 + [endog ~ Z1]", data=data)
+    if kind == "iv_fixef":
+        return pf.feols("Y ~ X2 + [endog ~ Z1] | f1", data=data)
+    if kind == "poisson":
+        return pf.fepois("Y_count ~ D + X2", data=data)
+    if kind == "logit":
+        return pf.feglm("Y_bin ~ D + X2", data=data, family="logit")
+    if kind == "quantreg":
+        with pytest.warns(FutureWarning, match="experimental"):
+            return pf.quantreg("Y ~ D + X2", data=data, quantile=0.5)
+    raise AssertionError(f"unknown fit kind {kind}")
+
+
+def _call(fit, feature: str):
+    """Invoke `feature` with the smallest arguments that reach its support gate."""
+    if feature == "crv3":
+        return fit.vcov({"CRV3": "cluster"})
+    if feature == "hac":
+        return fit.vcov("NW", vcov_kwargs={"time_id": "t", "lag": 1})
+    if feature == "nid":
+        return fit.vcov("nid")
+    if feature == "wildboottest":
+        return fit.wildboottest(param=fit._coefnames[1], reps=11, seed=45)
+    if feature == "ccv":
+        return fit.ccv(treatment="D", cluster="cluster", n_splits=2, seed=45)
+    if feature == "decompose":
+        return fit.decompose(decomp_var="D", only_coef=True)
+    if feature == "ritest":
+        return fit.ritest(resampvar="D", reps=2)
+    if feature == "fixef":
+        return fit.fixef()
+    if feature == "predict":
+        return fit.predict()
+    if feature == "prediction_errors":
+        return fit.predict(se_fit=True)
+    if feature == "update":
+        return fit.update(np.ones((1, fit._k)), np.zeros(1))
+    if feature == "savi":
+        return fit.evalue()
+    raise AssertionError(f"unknown feature {feature}")
+
+
+# (fit, feature, declared reason or None when the feature must be available).
+# `fixef` appears only for fits that absorb fixed effects, because the missing
+# fixed-effect ValueError is raised before the support gate.
+SUPPORT_CASES = [
+    ("ols", "crv3", None),
+    ("ols", "hac", None),
+    ("ols", "nid", "models of type 'feols'"),
+    ("ols", "wildboottest", None),
+    ("ols", "ccv", None),
+    ("ols", "decompose", None),
+    ("ols", "ritest", None),
+    ("ols", "predict", None),
+    ("ols", "prediction_errors", None),
+    ("ols", "update", None),
+    ("ols", "savi", None),
+    ("ols_aweights", "crv3", None),
+    ("ols_aweights", "hac", None),
+    ("ols_aweights", "wildboottest", "models with weights"),
+    ("ols_aweights", "ccv", "models with weights"),
+    ("ols_aweights", "decompose", "models with non-frequency weights"),
+    ("ols_aweights", "ritest", "models with weights"),
+    ("ols_aweights", "predict", None),
+    ("ols_aweights", "prediction_errors", "models with weights"),
+    ("ols_aweights", "update", "models with weights"),
+    ("ols_aweights", "savi", "models with weights"),
+    ("ols_fweights", "hac", "models with frequency weights"),
+    ("ols_fweights", "decompose", None),
+    ("ols_fweights", "savi", "models with weights"),
+    ("ols_fixef", "crv3", None),
+    ("ols_fixef", "hac", None),
+    ("ols_fixef", "wildboottest", None),
+    ("ols_fixef", "ccv", "models with fixed effects"),
+    ("ols_fixef", "ritest", None),
+    ("ols_fixef", "fixef", None),
+    ("ols_fixef", "predict", None),
+    ("ols_fixef", "prediction_errors", "models with fixed effects"),
+    ("ols_fixef", "update", "models with fixed effects"),
+    ("ols_fixef", "savi", "models with fixed effects"),
+    ("iv", "crv3", "IV models"),
+    ("iv", "hac", None),
+    ("iv", "wildboottest", "IV models"),
+    ("iv", "ccv", "IV models"),
+    ("iv", "decompose", "IV models"),
+    ("iv", "ritest", "IV models"),
+    ("iv", "predict", "IV models"),
+    ("iv", "prediction_errors", "IV models"),
+    ("iv", "update", "IV models"),
+    ("iv", "savi", "IV models"),
+    ("iv_fixef", "fixef", "IV models"),
+    ("poisson", "crv3", None),
+    ("poisson", "hac", None),
+    ("poisson", "nid", "models of type 'fepois'"),
+    ("poisson", "wildboottest", "models of type 'fepois'"),
+    ("poisson", "ccv", "models of type 'fepois'"),
+    ("poisson", "decompose", "models of type 'fepois'"),
+    ("poisson", "ritest", None),
+    ("poisson", "predict", None),
+    ("poisson", "prediction_errors", "models of type 'fepois'"),
+    ("poisson", "update", "models of type 'fepois'"),
+    ("poisson", "savi", "models of type 'fepois'"),
+    ("logit", "crv3", "models of type 'feglm'"),
+    ("logit", "hac", None),
+    ("logit", "nid", "models of type 'feglm'"),
+    ("logit", "wildboottest", "models of type 'feglm'"),
+    ("logit", "ccv", "models of type 'feglm'"),
+    ("logit", "decompose", "models of type 'feglm'"),
+    ("logit", "ritest", "models of type 'feglm'"),
+    ("logit", "predict", None),
+    ("logit", "prediction_errors", "models of type 'feglm'"),
+    ("logit", "update", "models of type 'feglm'"),
+    ("logit", "savi", "models of type 'feglm'"),
+    ("quantreg", "crv3", "models of type 'quantreg'"),
+    ("quantreg", "hac", "models of type 'quantreg'"),
+    ("quantreg", "nid", None),
+    ("quantreg", "wildboottest", "models of type 'quantreg'"),
+    ("quantreg", "ccv", "models of type 'quantreg'"),
+    ("quantreg", "decompose", "models of type 'quantreg'"),
+    ("quantreg", "ritest", "models of type 'quantreg'"),
+    ("quantreg", "predict", None),
+    ("quantreg", "prediction_errors", "models of type 'quantreg'"),
+    ("quantreg", "update", "models of type 'quantreg'"),
+    ("quantreg", "savi", "models of type 'quantreg'"),
+]
+
+
+@pytest.mark.parametrize(
+    ("kind", "feature", "reason"),
+    SUPPORT_CASES,
+    ids=[f"{kind}-{feature}" for kind, feature, _ in SUPPORT_CASES],
+)
+def test_declared_support_matches_the_public_methods(
+    capability_data: pd.DataFrame, kind: str, feature: str, reason: "str | None"
+):
+    """Every declared cell is what the corresponding public method enforces."""
+    fit = _fit(kind, capability_data)
+    assert fit._capabilities.evaluate(fit._fit_features)[feature] == reason
+
+    if reason is None:
+        # A supported cell must not raise the errors the contract owns.
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            _call(fit, feature)
+        return
+
+    with pytest.raises(
+        FEATURE_ERRORS[feature], match=rf"is not supported for {reason}\.$"
+    ):
+        _call(fit, feature)
+
+
+def test_quantreg_rejects_ols_prediction_errors(capability_data: pd.DataFrame):
+    """OLS residual-variance prediction errors do not describe a quantile."""
+    fit = _fit("quantreg", capability_data)
+
+    for kwargs in ({"se_fit": True}, {"interval": "prediction"}):
+        with pytest.raises(
+            NotImplementedError,
+            match=(
+                r"Prediction with standard errors is not supported for models of "
+                r"type 'quantreg'\."
+            ),
+        ):
+            fit.predict(**kwargs)
+
+
+def test_unweighted_fits_report_no_weights_kind():
+    """The estimation API keeps a default `weights_type` on unweighted fits."""
+    fit = pf.feols("Y ~ X1", data=pf.get_data(), weights_type="fweights")
+    assert fit._fit_features.weights_kind is None
+    assert not FREQUENCY_WEIGHTS[0](fit._fit_features)
+
+
+def test_difference_in_differences_results_keep_their_refit_gates():
+    """A relabelled `Feols` result must not be refit as if it were plain OLS."""
+    data = pd.read_csv("pyfixest/did/data/df_het.csv").iloc[:2000]
+    fit = pf.did2s(
+        data,
+        yname="dep_var",
+        first_stage="~ 0 | state + year",
+        second_stage="~ i(rel_year, ref=-1.0)",
+        treatment="treat",
+        cluster="state",
+    )
+
+    assert fit._fit_features.is_did
+    reasons = fit._capabilities.evaluate(fit._fit_features)
+    for feature in ("ritest", "update", "savi"):
+        assert reasons[feature] == "difference-in-differences results"
+
+    with pytest.raises(NotImplementedError, match="difference-in-differences results"):
+        fit.update(np.ones((1, fit._k)), np.zeros(1))
+    with pytest.raises(NotImplementedError, match="difference-in-differences results"):
+        fit.evalue()

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -1,0 +1,121 @@
+"""Tests for the declarative post-estimation capability contract."""
+
+import pytest
+
+from pyfixest.errors import VcovTypeNotSupportedError
+from pyfixest.estimation.capabilities import (
+    FEATURE_ERRORS,
+    FEATURES,
+    FIXED_EFFECTS,
+    FREQUENCY_WEIGHTS,
+    IV,
+    NON_FREQUENCY_WEIGHTS,
+    WEIGHTED,
+    Capabilities,
+    FitFeatures,
+    require_support,
+    supported,
+    unless,
+    unsupported,
+    unsupported_estimator,
+)
+
+PLAIN = FitFeatures(estimator="feols")
+WITH_FIXEF = FitFeatures(estimator="feols", has_fixef=True)
+AWEIGHTED = FitFeatures(estimator="feols", has_weights=True, weights_kind="aweights")
+FWEIGHTED = FitFeatures(estimator="feols", has_weights=True, weights_kind="fweights")
+IV_FIT = FitFeatures(estimator="feols", is_iv=True)
+
+
+def test_rule_helpers_report_the_expected_reasons():
+    assert supported()(PLAIN) is None
+    assert unsupported("IV models")(PLAIN) == "IV models"
+    assert (
+        unsupported_estimator(FitFeatures(estimator="quantreg"))
+        == "models of type 'quantreg'"
+    )
+
+
+@pytest.mark.parametrize(
+    ("condition", "holds_for", "not_for"),
+    [
+        (IV, IV_FIT, PLAIN),
+        (WEIGHTED, AWEIGHTED, PLAIN),
+        (FIXED_EFFECTS, WITH_FIXEF, PLAIN),
+        (FREQUENCY_WEIGHTS, FWEIGHTED, AWEIGHTED),
+        (NON_FREQUENCY_WEIGHTS, AWEIGHTED, FWEIGHTED),
+    ],
+)
+def test_named_conditions_separate_the_fits_they_describe(
+    condition, holds_for, not_for
+):
+    predicate, reason = condition
+    assert predicate(holds_for)
+    assert not predicate(not_for)
+    assert unless(condition)(holds_for) == reason
+    assert unless(condition)(not_for) is None
+
+
+def test_unless_reports_the_first_matching_condition():
+    rule = unless(FIXED_EFFECTS, WEIGHTED)
+    both = FitFeatures(
+        estimator="feols", has_fixef=True, has_weights=True, weights_kind="aweights"
+    )
+    assert rule(both) == "models with fixed effects"
+    assert rule(AWEIGHTED) == "models with weights"
+
+
+def test_capabilities_default_every_feature_to_unsupported():
+    """A feature a class does not declare is unsupported for that estimator."""
+    reasons = Capabilities().evaluate(FitFeatures(estimator="fepois"))
+    assert list(reasons) == list(FEATURES)
+    assert set(reasons.values()) == {"models of type 'fepois'"}
+
+
+def test_capabilities_evaluate_mixes_declared_and_default_rules():
+    declaration = Capabilities(predict=supported(), hac=unless(FREQUENCY_WEIGHTS))
+    reasons = declaration.evaluate(FWEIGHTED)
+    assert reasons["predict"] is None
+    assert reasons["hac"] == "models with frequency weights"
+    assert reasons["ccv"] == "models of type 'feols'"
+
+
+def test_require_support_passes_silently_when_supported():
+    require_support(
+        capabilities=Capabilities(predict=supported()),
+        feature="predict",
+        features=PLAIN,
+        subject="predict()",
+    )
+
+
+def test_require_support_raises_the_registered_type_and_message():
+    with pytest.raises(
+        NotImplementedError,
+        match=r"^Randomization inference is not supported for models with weights\.$",
+    ):
+        require_support(
+            capabilities=Capabilities(ritest=unless(WEIGHTED)),
+            feature="ritest",
+            features=AWEIGHTED,
+            subject="Randomization inference",
+        )
+
+    with pytest.raises(
+        VcovTypeNotSupportedError,
+        match=r"^CRV3 inference is not supported for IV models\.$",
+    ):
+        require_support(
+            capabilities=Capabilities(crv3=unsupported("IV models")),
+            feature="crv3",
+            features=IV_FIT,
+            subject="CRV3 inference",
+        )
+
+
+def test_feature_errors_cover_every_feature():
+    assert set(FEATURE_ERRORS) == set(FEATURES)
+    assert FEATURE_ERRORS["crv3"] is VcovTypeNotSupportedError
+    assert {FEATURE_ERRORS[feature] for feature in FEATURES if feature != "crv3"} == {
+        NotImplementedError
+    }

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -472,9 +472,7 @@ def test_errors_ccv():
 
     # same for IV
     fit = feols("Y ~ 1 | D ~ Z1", data=data)
-    with pytest.raises(
-        NotImplementedError, match=r"not supported for models of type 'feols'"
-    ):
+    with pytest.raises(NotImplementedError, match=r"not supported for IV models"):
         fit.ccv(treatment="D", pk=0.05, qk=0.5, n_splits=10, seed=929)
 
 
@@ -506,7 +504,9 @@ def test_non_ols_update_is_explicitly_unsupported():
     )
 
     for fit in models:
-        with pytest.raises(NotImplementedError, match=r"update.*only supported.*OLS"):
+        with pytest.raises(
+            NotImplementedError, match=r"update.*not supported for models of type"
+        ):
             fit.update(X_new=np.ones((1, fit._k)), y_new=np.ones(1))
 
 
@@ -602,7 +602,8 @@ def test_ritest_rejects_non_ols_working_domains(estimator):
             fit = pf.quantreg("y ~ x", data=data, maxiter=100)
 
     with pytest.raises(
-        NotImplementedError, match=r"only supported for OLS and Poisson"
+        NotImplementedError,
+        match=r"Randomization inference is not supported for models of type",
     ):
         fit.ritest(resampvar="x", reps=1)
 
@@ -622,7 +623,10 @@ def test_wildboottest_rejects_non_ols_working_domains(estimator):
         with pytest.warns(FutureWarning, match="experimental"):
             fit = pf.quantreg("y ~ x", data=data, maxiter=100)
 
-    with pytest.raises(NotImplementedError, match=r"only supported for unweighted OLS"):
+    with pytest.raises(
+        NotImplementedError,
+        match=r"Wild cluster bootstrap is not supported for models of type",
+    ):
         fit.wildboottest(param="x", reps=1)
 
 
@@ -928,7 +932,7 @@ def test_gelbach_errors():
     # error for WLS and aweights
     with pytest.raises(
         NotImplementedError,
-        match=r"Decomposition is currently only supported for models with frequency weights.",
+        match=r"Decomposition is not supported for models with non-frequency weights\.",
     ):
         fit = pf.feols(
             "y ~ x1 + x21", data=data, weights="weights", weights_type="aweights"
@@ -960,7 +964,7 @@ def test_decomposition_rejects_unsupported_models(model_type):
 
     with pytest.raises(
         NotImplementedError,
-        match=r"Decomposition is currently only supported for OLS models\.",
+        match=r"Decomposition is not supported for models of type '(feglm|quantreg)'\.",
     ):
         fit.decompose(decomp_var="x1", only_coef=True)
 
@@ -1346,7 +1350,7 @@ def unsupported_savi_design(request):
         weights="savi_weights",
         weights_type=request.param,
     )
-    return fit, "weighted feols"
+    return fit, "models with weights"
 
 
 @pytest.fixture(scope="module", params=["hac", "crv", "multiway_crv"])
@@ -1375,7 +1379,9 @@ def unsupported_savi_vcov(request):
 
 
 def test_savi_rejects_unsupported_models(unsupported_savi_model):
-    with pytest.raises(NotImplementedError, match="supported only for feols"):
+    with pytest.raises(
+        NotImplementedError, match="SAVI inference is not supported for"
+    ):
         unsupported_savi_model.evalue()
 
 

--- a/tests/test_ses.py
+++ b/tests/test_ses.py
@@ -355,7 +355,10 @@ def test_hac_rejects_fweights(vcov):
     if vcov == "DK":
         kwargs["panel_id"] = "unit"
 
-    with pytest.raises(NotImplementedError, match="fweights"):
+    with pytest.raises(
+        NotImplementedError,
+        match=r"HAC inference \(NW, DK\) is not supported for models with frequency weights",
+    ):
         feols(
             "Y ~ X1",
             data=data,


### PR DESCRIPTION
Layer 4 of the estimation-state stack, based on `fix/estimation-state-contracts` (#1501).

Every post-estimation and inference feature now asks one declarative capability table whether the fitted result supports it, instead of six boolean flags and per-method checks on `_is_iv`, `_has_weights`, `_has_fixef`, and the `_method` label. Each model class declares a `Capabilities` table in `pyfixest/estimation/capabilities.py`; `fit.capabilities()` reports the support of one fit with reasons, `pf.estimation.support_matrix()` renders the estimator-by-feature table, and a new how-to page documents it. Exception types are unchanged.

- Numerical results are invariant. One behavior change: `quantreg()` results now reject `predict(se_fit=True)` and `interval="prediction"`, which returned OLS residual-variance prediction errors that do not describe a conditional quantile.
- DiD-relabelled `Feols` results keep their existing refit gates (`ritest`, `update`, SAVI) through an explicit `is_did` fit feature.
- Follow-ups for the next layer: the GLM `predict` override still ignores `interval="prediction"`; the `_method` comparisons left in `_finalize_fit`, the CRV3 fast path, `fixef`, and `predict` become hooks.

## Verification

Passed locally at the head: release contract 1355/1355 against pyfixest 0.60.0, `tests/test_vs_fixest.py` 5104 passed, fast live-R 22/22, targeted suites, broad Python-only suite (pre-existing `torch_mps` failures excluded), ruff, mypy. Deferred to CI: HAC, docs render.
