### PR TITLE
build: add ty type checking alongside mypy

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -13,6 +13,23 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  type-check:
+    name: "Type Check"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: prefix-dev/setup-pixi@v0.10.2
+        with:
+          pixi-version: v0.76.2
+          cache: true
+          cache-write: ${{ github.event_name == 'push' && github.ref_name == 'master' }}
+          frozen: true
+          environments: py312
+
+      - name: Type-check with ty
+        run: pixi run -e py312 type-check
+
   test-python:
     name: "Tests Python (${{ matrix.environment }}, ${{ matrix.os }})"
     runs-on: ${{ matrix.os }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,6 +160,7 @@ pixi run -e py312 test-release-contract                             # refactor i
 pixi run -e py312-r test-r-fixest-fast                              # fast live-R
 pixi run test-py                                                    # Python baseline
 pixi run -e lint prek run ruff-check --files <changed files>        # changed-file lint
+pixi run -e py312 type-check                                        # ty, whole package
 pixi task list                                                      # everything else
 ```
 

--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -40,6 +40,12 @@ fit3 = pf.feols("Y ~ X1 + X2 | f1", data = df)
   platform, because pixi has deprecated the `[system-requirements]` table. We
   also refresh `pixi.lock` in the newer v7 format. Both ask for pixi 0.71.0 or
   newer.
+- We add [ty](https://github.com/astral-sh/ty) as a blocking CI check,
+  `pixi run -e py312 type-check`, alongside the existing mypy pre-commit hook.
+  Fixing its diagnostics tightened annotations across the DiD, formula,
+  decomposition, and reporting code; `panelview` now declares the
+  `matplotlib.pyplot.Axes` its docstring already documented. The files the
+  open estimation-state work rewrites are excluded for now and follow later.
 
 ### Inference Types
 

--- a/docs/contributing.qmd
+++ b/docs/contributing.qmd
@@ -122,6 +122,19 @@ This installs prek as a git hook so checks run automatically on each commit.
 pixi run lint
 ```
 
+### Type checking
+
+The prek hooks run [mypy](https://mypy-lang.org/). CI additionally runs
+[ty](https://github.com/astral-sh/ty), which resolves imports from the
+environment it runs in and therefore lives with the runtime dependencies
+instead of the lint environment:
+
+```{.bash .code-copy}
+pixi run -e py312 type-check
+```
+
+Both checks must pass. ty is configured under `[tool.ty]` in `pyproject.toml`.
+
 ### Building the documentation
 
 ```{.bash .code-copy}

--- a/docs/developer/testing.md
+++ b/docs/developer/testing.md
@@ -12,7 +12,7 @@ selection affect wall time.
 
 | Stage | Purpose | Typical scale | Examples |
 |---|---|---|---|
-| Edit feedback | Exercise the changed seam repeatedly | Seconds to a few minutes | targeted pytest, release contract, targeted or fast live-R checks, changed-file Ruff/mypy |
+| Edit feedback | Exercise the changed seam repeatedly | Seconds to a few minutes | targeted pytest, release contract, targeted or fast live-R checks, changed-file Ruff/mypy, ty |
 | Stabilized implementation | Broaden local confidence once | Minutes | selected subsystem checks, `pixi run test-py` when required |
 | Merge evidence | Validate the exact PR head in affected environments | May take tens of minutes | canonical R, HAC, no-JIT, docs, plots, Rust, platform CI |
 | Exhaustive or release | Exercise everything available | Potentially substantially longer | `test-all`, CRAN-only dependencies, platform CI, benchmarks |
@@ -70,6 +70,9 @@ pixi run -e lint prek run ruff-format --files <changed files>
 pixi run -e lint prek run ruff-check --files <changed files>
 pixi run -e lint prek run mypy --files <changed files>
 
+# Whole-package type check; ty resolves imports from the estimation environment
+pixi run -e py312 type-check
+
 # Documentation (costly; run only when the selection matrix calls for it)
 pixi run docs-build
 pixi run docs-render
@@ -81,6 +84,13 @@ conda-forge R comparisons. CI partitions that population into
 `tests/test_vs_fixest.py` is not executed twice. The fast suite runs once as a
 preflight in the canonical `fixest` job.
 
+Two type checkers run side by side while pyfixest migrates from mypy to ty
+(issue #1104). mypy stays a prek hook and keeps owning the `# type: ignore`
+comments; ty checks the whole package in one pass and blocks CI. ty is
+configured under `[tool.ty]` in `pyproject.toml`, including a temporary
+exclude list; do not silence a diagnostic by extending it. Suppress a single
+line only with `# ty: ignore[rule]` and a reason naming the third-party gap.
+
 ## Selection matrix
 
 This matrix is authoritative for which checks a change requires.
@@ -90,8 +100,8 @@ This matrix is authoritative for which checks a change requires.
 | Public docstrings or API-reference configuration | `git diff --check`; execute changed examples; `docs-build` | affected reference-page render when applicable |
 | Content under `docs/` | `git diff --check`; execute changed examples; render the affected page when practical | `docs-render` only for site-wide configuration, navigation, templates, or cross-page changes |
 | Repository guidance or workflow metadata outside `docs/` | `git diff --check`; targeted skill, template, or configuration validation | affected CI workflow only; no docs build by default |
-| Python API or internals | targeted public tests; changed-file lint/type checks | Python baseline |
-| Internal or backend refactor with unchanged results | release contract green (passed, not skipped); targeted tests; changed-file lint/type checks | Python baseline; applicable external suite for every estimator the refactor touches |
+| Python API or internals | targeted public tests; changed-file lint/mypy; `type-check` | Python baseline |
+| Internal or backend refactor with unchanged results | release contract green (passed, not skipped); targeted tests; changed-file lint/mypy; `type-check` | Python baseline; applicable external suite for every estimator the refactor touches |
 | Estimation or inference numerics | targeted integration and edge tests; release contract with every intended difference declared by `reason` | applicable live external-reference suite |
 | New estimator | complete support matrix and permanent external comparison | Python baseline, external suite, full platform CI |
 | HAC | targeted HAC/meat tests | single-threaded `test-r-hac` |

--- a/pixi.lock
+++ b/pixi.lock
@@ -6197,6 +6197,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2022.3.0-hb700be7_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.3-py311h49ec1c0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ty-0.0.78-heeb25aa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-17.0.1-py311h49ec1c0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_1.conda
@@ -6526,6 +6527,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/statsmodels-0.14.6-py311h09efe57_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.5.4-py311h9408147_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ty-0.0.78-h98cbc1d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/unicodedata2-17.0.1-py311hc949640_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.12-hc919400_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.5-hc919400_1.conda
@@ -6701,6 +6703,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2022.3.0-hb700be7_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.3-py311h49ec1c0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ty-0.0.78-heeb25aa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-17.0.1-py311h49ec1c0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_1.conda
@@ -7013,6 +7016,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2022.3.0-h3155e25_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h6ed50ae_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/tornado-6.5.4-py311h3485c13_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ty-0.0.78-h0cebda5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/unicodedata2-17.0.1-py311h3485c13_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h41ae7f8_34.conda
@@ -8470,6 +8474,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2022.3.0-hb700be7_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.3-py312h4c3975b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ty-0.0.78-heeb25aa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-17.0.1-py312h4c3975b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_1.conda
@@ -8799,6 +8804,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/statsmodels-0.14.6-py312ha11c99a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.5.4-py312h4409184_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ty-0.0.78-h98cbc1d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/unicodedata2-17.0.1-py312h2bbb03f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.12-hc919400_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.5-hc919400_1.conda
@@ -8974,6 +8980,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2022.3.0-hb700be7_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.3-py312h4c3975b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ty-0.0.78-heeb25aa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-17.0.1-py312h4c3975b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_1.conda
@@ -9286,6 +9293,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2022.3.0-h3155e25_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h6ed50ae_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/tornado-6.5.4-py312he06e257_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ty-0.0.78-h0cebda5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/unicodedata2-17.0.1-py312he06e257_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h41ae7f8_34.conda
@@ -10742,6 +10750,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2022.3.0-hb700be7_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.3-py313h07c4f96_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ty-0.0.78-heeb25aa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h280c20c_3.conda
@@ -11069,6 +11078,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/statsmodels-0.14.6-py313hc577518_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.5.4-py313h6535dbc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ty-0.0.78-h98cbc1d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.12-hc919400_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.5-hc919400_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h925e9cb_3.conda
@@ -11242,6 +11252,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2022.3.0-hb700be7_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.3-py313h07c4f96_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ty-0.0.78-heeb25aa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h280c20c_3.conda
@@ -11552,6 +11563,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2022.3.0-h3155e25_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h6ed50ae_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/tornado-6.5.4-py313h5ea7bf4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ty-0.0.78-h0cebda5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h41ae7f8_34.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.44.35208-h818238b_34.conda
@@ -11734,6 +11746,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2022.3.0-hb700be7_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.3-py314h5bd0f2a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ty-0.0.78-heeb25aa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-17.0.1-py314h5bd0f2a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_1.conda
@@ -12063,6 +12076,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/statsmodels-0.14.6-py314hdcf55e8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.5.4-py314h0612a62_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ty-0.0.78-h98cbc1d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/unicodedata2-17.0.1-py314h6c2aa35_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.12-hc919400_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.5-hc919400_1.conda
@@ -12236,6 +12250,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2022.3.0-hb700be7_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.3-py314h5bd0f2a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ty-0.0.78-heeb25aa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-17.0.1-py314h5bd0f2a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_1.conda
@@ -12548,6 +12563,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2022.3.0-h3155e25_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h6ed50ae_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/tornado-6.5.4-py314h5a2d7ad_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ty-0.0.78-h0cebda5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/unicodedata2-17.0.1-py314h5a2d7ad_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h41ae7f8_34.conda
@@ -19348,6 +19364,25 @@ packages:
   - pkg:pypi/tornado?source=hash-mapping
   size: 905436
   timestamp: 1765458949518
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ty-0.0.78-heeb25aa_0.conda
+  noarch: python
+  sha256: 4f70dc81e89bbc4fa983705929888a0dbaaccb1ae8eae3f1588e2f8eaf10f3a9
+  md5: 410fa01adb1bc626f2b6276c51c4b9eb
+  depends:
+  - python
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=15
+  - _python_abi3_support 1.*
+  - cpython >=3.11
+  constrains:
+  - __glibc >=2.17
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/ty?source=compressed-mapping
+  run_exports: {}
+  size: 11520379
+  timestamp: 1788398096040
 - conda: https://conda.anaconda.org/conda-forge/linux-64/typst-0.14.2-h4c46f8d_0.conda
   sha256: 2051dee6a67d43a0ff0fd2ff9dacd8ef533e89d0b30feedf87613fc84b00c247
   md5: 6733bfb9b4338039e182ca3a41253ab5
@@ -31500,6 +31535,24 @@ packages:
   - pkg:pypi/tornado?source=hash-mapping
   size: 909298
   timestamp: 1765836779269
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ty-0.0.78-h98cbc1d_0.conda
+  noarch: python
+  sha256: 6a50ebbabcbeb52f470d0ff175f55602fa4d59ed3081349a0bc3087943ad91b1
+  md5: 9e6fd3196325f0bce23418905f5d22c4
+  depends:
+  - python
+  - __osx >=11.0
+  - _python_abi3_support 1.*
+  - cpython >=3.11
+  constrains:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/ty?source=compressed-mapping
+  run_exports: {}
+  size: 10409035
+  timestamp: 1788398090213
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/typst-0.14.2-hd1458d2_0.conda
   sha256: 201e08fc74e3dc8161d583bb50d23ae07b4537c5efa41c8a7e1ba46a30261ea6
   md5: 750223ac708cb65d0d32fa61d84e35e4
@@ -39125,6 +39178,24 @@ packages:
   - pkg:pypi/tornado?source=hash-mapping
   size: 859726
   timestamp: 1774358173994
+- conda: https://conda.anaconda.org/conda-forge/win-64/ty-0.0.78-h0cebda5_0.conda
+  noarch: python
+  sha256: 4565f8f510348a2c01bd25891b0508d62feabc1e395f66fbd5cfb280a7b75c19
+  md5: cca528455b779886ab5e67cfc42c6cbf
+  depends:
+  - python
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - _python_abi3_support 1.*
+  - cpython >=3.11
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/ty?source=compressed-mapping
+  run_exports: {}
+  size: 11699326
+  timestamp: 1788398092117
 - conda: https://conda.anaconda.org/conda-forge/win-64/typst-0.14.2-h77a83cd_0.conda
   sha256: 6e6f4dfb5d3e43d627e248723ccc963c7889fc59e7039c67b4d6ca2aea20ea99
   md5: c7d150437cdf4a2facdb156fe1dbe9b7

--- a/pyfixest/did/did2s.py
+++ b/pyfixest/did/did2s.py
@@ -121,7 +121,8 @@ class DID2S(DID):
             treatment="is_treated",
             first_u=self._first_u,
             second_u=self._second_u,
-            cluster=self._cluster,
+            # DID2S always clusters; only the DID base class allows `None`.
+            cluster=cast(str, self._cluster),
             weights=self._weights_name,
         )
 
@@ -302,7 +303,10 @@ def _did2s_vcov(
         A variance covariance matrix.
     """
     cluster_col = data[cluster]
-    _, clustid = pd.factorize(cluster_col)
+    # `pd.factorize` returns the distinct levels as an ndarray or an Index
+    # depending on the input; the cluster loop and count below need an Index.
+    _, clustid_levels = pd.factorize(cluster_col)
+    clustid = pd.Index(clustid_levels)
 
     _G = clustid.nunique()  # actually not used here, neither in did2s
 

--- a/pyfixest/did/estimation.py
+++ b/pyfixest/did/estimation.py
@@ -164,7 +164,10 @@ def event_study(
         fit._att = saturated._att
 
         fit._method = "saturated"
-        fit.iplot = saturated.iplot.__get__(fit, type(fit))
+        # Rebinding the saturated event-study methods onto a plain `Feols`
+        # replaces `Feols.iplot`, which is a `functools.partial` attribute.
+        # Follow-up: give the saturated estimator its own result class.
+        fit.iplot = saturated.iplot.__get__(fit, type(fit))  # ty: ignore[invalid-assignment]
         fit.test_treatment_heterogeneity = (
             saturated.test_treatment_heterogeneity.__get__(fit, type(fit))
         )
@@ -321,7 +324,7 @@ def lpdid(
     post_window: int | None = None,
     never_treated: int = 0,
     att: bool = True,
-    xfml=None,
+    xfml: str | None = None,
 ) -> LPDID:
     """
     Local projections approach to estimation.

--- a/pyfixest/did/lpdid.py
+++ b/pyfixest/did/lpdid.py
@@ -26,7 +26,7 @@ class LPDID(DID):
         The name of the time variable.
     gname : str
         The name of the group variable.
-    xfml : str
+    xfml : str, optional
         The transformation to apply to the data.
     att : str
         The attribute to consider in the model.
@@ -49,7 +49,7 @@ class LPDID(DID):
         idname: str,
         tname: str,
         gname: str,
-        xfml: str,
+        xfml: str | None,
         att: bool,
         cluster: str,
         vcov: VcovTypeOptions | dict[str, str] | None = None,

--- a/pyfixest/did/visualize.py
+++ b/pyfixest/did/visualize.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import pandas as pd
 
@@ -27,7 +27,7 @@ def panelview(
     ax: plt.Axes | None = None,
     xlim: tuple | None = None,
     ylim: tuple | None = None,
-) -> None:
+) -> plt.Axes:
     """
     Generate a panel view of the treatment variable over time for each unit.
 
@@ -210,11 +210,11 @@ def _prepare_panelview_df_for_outcome_plot(
         def get_treatment_start(x: pd.DataFrame) -> pd.Timestamp:
             return x[x[treat]][time].min()
 
-        treatment_starts = (
-            data.groupby(unit)
-            .apply(get_treatment_start)
-            .reset_index(name="treatment_start")
-        )
+        # A scalar-valued `apply` reduces each group to one row, so the result
+        # is a Series and `reset_index` can name its value column.
+        treatment_starts = cast(
+            "pd.Series", data.groupby(unit).apply(get_treatment_start)
+        ).reset_index(name="treatment_start")
 
         data = data.merge(treatment_starts, on=unit, how="left")
         data_agg = (

--- a/pyfixest/estimation/formula/formulaic_compat.py
+++ b/pyfixest/estimation/formula/formulaic_compat.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable, Iterator, Mapping
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypeAlias, cast
 
 import formulaic
 import formulaic.formula
@@ -20,19 +20,55 @@ from pyfixest.estimation.formula.transforms.factor_interaction import (
 if TYPE_CHECKING:
     from formulaic.model_spec import ModelSpec
 
+# One side of a parsed formula: a flat list of terms, or, for an IV
+# specification, formulaic's nested `[endogenous ~ instruments]` container.
+FormulaSide: TypeAlias = (
+    formulaic.formula.SimpleFormula | formulaic.formula.StructuredFormula
+)
+
 
 class FormulaicCompatibilityError(RuntimeError):
     """Raised when formulaic internals no longer match pyfixest expectations."""
 
 
-def terms_without_intercept(formula: formulaic.formula.Formula) -> Iterator[Any]:
+def formula_lhs(
+    formula: formulaic.formula.Formula,
+) -> formulaic.formula.SimpleFormula:
+    """Return the dependent-variable side of a parsed formulaic formula."""
+    # formulaic internal: `StructuredFormula` serves `lhs`, `rhs` and `root`
+    # from `Structured.__getattr__`, so they are invisible to a type checker
+    # on the `Formula` base class the parser is declared to return.
+    return formula.lhs  # ty: ignore[unresolved-attribute]
+
+
+def formula_rhs(
+    formula: formulaic.formula.Formula,
+) -> FormulaSide | tuple[FormulaSide, ...]:
+    """
+    Return the covariate side of a parsed formulaic formula.
+
+    A `|`-separated (MULTIPART) formula returns one entry per part.
+    """
+    # formulaic internal: see `formula_lhs`.
+    return formula.rhs  # ty: ignore[unresolved-attribute]
+
+
+def simple_formula(terms: Iterable[Any]) -> formulaic.formula.SimpleFormula:
+    """Build a flat formulaic formula from an iterable of terms."""
+    # formulaic internal: the `Formula` metaclass annotates `__call__` as
+    # returning the `Formula` base class, also for `SimpleFormula(...)`, and
+    # only accepts a materialized sequence of terms.
+    return cast(
+        "formulaic.formula.SimpleFormula",
+        formulaic.formula.SimpleFormula(list(terms)),
+    )
+
+
+def terms_without_intercept(
+    formula: formulaic.formula.SimpleFormula,
+) -> Iterator[Any]:
     """Yield formula terms excluding Formulaic's intercept term."""
     return (term for term in formula if term != "1")
-
-
-def is_structured_formula(rhs: formulaic.formula.Formula) -> bool:
-    """Return whether formulaic parsed an IV RHS as a StructuredFormula."""
-    return isinstance(rhs, formulaic.formula.StructuredFormula)
 
 
 def count_multistage_blocks(rhs: formulaic.formula.Formula) -> int:
@@ -45,14 +81,14 @@ def count_multistage_blocks(rhs: formulaic.formula.Formula) -> int:
 
 def get_first_multistage_lhs(
     rhs: formulaic.formula.Formula,
-) -> formulaic.formula.Formula:
+) -> formulaic.formula.SimpleFormula:
     """Return the endogenous formula from a formulaic MULTISTAGE RHS."""
     return _get_single_multistage_block(rhs).lhs
 
 
 def get_first_multistage_rhs(
     rhs: formulaic.formula.Formula,
-) -> formulaic.formula.Formula:
+) -> formulaic.formula.SimpleFormula:
     """Return the instrument formula from a formulaic MULTISTAGE RHS."""
     return _get_single_multistage_block(rhs).rhs
 
@@ -75,7 +111,7 @@ def _get_single_multistage_block(rhs: formulaic.formula.Formula) -> Any:
 
 
 def filter_multistage_endogenous_terms(
-    exogenous: formulaic.formula.Formula,
+    exogenous: formulaic.formula.StructuredFormula,
     endogenous_terms: Iterable[Any],
 ) -> formulaic.formula.SimpleFormula:
     """Drop formulaic's generated ``<endogenous term>_hat`` second-stage terms."""
@@ -90,8 +126,8 @@ def filter_multistage_endogenous_terms(
             "formulaic MULTISTAGE endogenous suffix changed: expected generated "
             f"second-stage terms {sorted(missing)} to be present before filtering."
         )
-    return formulaic.formula.SimpleFormula(
-        [term for term in terms if str(term) not in generated_endogenous]
+    return simple_formula(
+        term for term in terms if str(term) not in generated_endogenous
     )
 
 
@@ -109,7 +145,11 @@ def materialize_model_spec_with_unseen_mask(
 ) -> tuple[formulaic.ModelMatrix, np.ndarray]:
     """Materialize a prediction matrix and flag unseen categorical levels."""
     materializer = rhs_spec.get_materializer(newdata, context=context)
-    model_matrix = materializer.get_model_matrix(rhs_spec)
+    # formulaic returns its structured `ModelMatrices` container only for a
+    # structured spec; a single `ModelSpec` always materializes one matrix.
+    model_matrix = cast(
+        "formulaic.ModelMatrix", materializer.get_model_matrix(rhs_spec)
+    )
     unseen = rows_with_unseen_contrast_levels(
         rhs_spec, newdata, materializer.factor_cache
     )

--- a/pyfixest/estimation/formula/parse.py
+++ b/pyfixest/estimation/formula/parse.py
@@ -1,7 +1,7 @@
 import itertools
 from collections.abc import Iterator
 from dataclasses import dataclass
-from typing import Final
+from typing import Final, cast
 
 import formulaic
 import formulaic.formula
@@ -16,11 +16,14 @@ from pyfixest.errors import (
 )
 from pyfixest.estimation.formula import FORMULAIC_FEATURE_FLAG
 from pyfixest.estimation.formula.formulaic_compat import (
+    FormulaSide,
     count_multistage_blocks,
     filter_multistage_endogenous_terms,
+    formula_lhs,
+    formula_rhs,
     get_first_multistage_lhs,
     get_first_multistage_rhs,
-    is_structured_formula,
+    simple_formula,
     terms_without_intercept,
 )
 from pyfixest.estimation.formula.utils import (
@@ -149,54 +152,60 @@ class Formula:
     @property
     def _left_hand_side(self) -> formulaic.formula.SimpleFormula:
         """The left hand side of the formula."""
-        return self._formula.lhs
+        return formula_lhs(self._formula)
 
     @property
-    def _right_hand_side(self) -> formulaic.formula.SimpleFormula:
+    def _right_hand_side(self) -> FormulaSide:
         """The right hand side of the formula excluding fixed effects."""
+        right_hand_side = formula_rhs(self._formula)
         return (
-            self._formula.rhs[0]
-            if isinstance(self._formula.rhs, tuple)
-            else self._formula.rhs
+            right_hand_side[0]
+            if isinstance(right_hand_side, tuple)
+            else right_hand_side
         )
 
     @property
     def is_instrumental_variable(self) -> bool:
         """Boolean indicating whether the formula is an instrumental variable specification."""
-        return is_structured_formula(self._right_hand_side)
+        # formulaic parses an IV right hand side into a nested StructuredFormula
+        return isinstance(self._right_hand_side, formulaic.formula.StructuredFormula)
 
     @property
     def is_fixed_effects(self) -> bool:
         """Boolean indicating whether the formula is a fixed effects specification."""
         # A MULTIPART formula is a tuple of formulas on the right hand side
+        right_hand_side = formula_rhs(self._formula)
         return (
-            isinstance(self._formula.rhs, tuple)
-            and str(self._formula.rhs[-1]) not in ["", "0", "1"]  # ignore intercept
+            isinstance(right_hand_side, tuple)
+            and str(right_hand_side[-1]) not in ["", "0", "1"]  # ignore intercept
         )
 
     @property
-    def dependent(self) -> formulaic.formula.Formula:
+    def dependent(self) -> formulaic.formula.SimpleFormula:
         """The dependent variable."""
         return self._left_hand_side
 
     @property
-    def exogenous(self) -> formulaic.formula.Formula:
+    def exogenous(self) -> formulaic.formula.SimpleFormula:
         """Exogenous aka covariates aka independent variables."""
-        exogenous = self._right_hand_side
-        if self.is_instrumental_variable:
-            exogenous = filter_multistage_endogenous_terms(exogenous, self.endogenous)
+        right_hand_side = self._right_hand_side
+        exogenous = (
+            filter_multistage_endogenous_terms(right_hand_side, self.endogenous)
+            if isinstance(right_hand_side, formulaic.formula.StructuredFormula)
+            else right_hand_side
+        )
 
         exogenous_terms = tuple(terms_without_intercept(exogenous))
         if self.is_fixed_effects and exogenous_terms:
             # Drop the intercept for fixed effects regressions, except for
             # intercept-only specifications such as `Y ~ 1 | f1`; these can be
             # used to demean dependent variables.
-            exogenous = formulaic.formula.SimpleFormula(exogenous_terms)
+            exogenous = simple_formula(exogenous_terms)
 
         return exogenous
 
     @property
-    def endogenous(self) -> formulaic.formula.Formula:
+    def endogenous(self) -> formulaic.formula.SimpleFormula:
         """Endogenous variables of an instrumental variable specification."""
         if not self.is_instrumental_variable:
             raise AttributeError(
@@ -205,7 +214,7 @@ class Formula:
         return get_first_multistage_lhs(self._right_hand_side)
 
     @property
-    def instruments(self) -> formulaic.formula.Formula:
+    def instruments(self) -> formulaic.formula.SimpleFormula:
         """Instruments of an instrumental variable specification."""
         if not self.is_instrumental_variable:
             raise AttributeError(
@@ -214,13 +223,18 @@ class Formula:
         return get_first_multistage_rhs(self._right_hand_side)
 
     @property
-    def fixed_effects(self) -> formulaic.formula.Formula:
+    def fixed_effects(self) -> formulaic.formula.SimpleFormula:
         """The fixed effects of a formula."""
         if not self.is_fixed_effects:
             raise AttributeError("Not a fixed effects specification")
-        return formulaic.formula.SimpleFormula(
-            terms_without_intercept(self._formula.rhs[1])
+        # `is_fixed_effects` guarantees a MULTIPART right hand side, and
+        # formulaic nests an IV block only in its first part, so the
+        # fixed-effect part is always a flat list of terms.
+        parts = cast(
+            "tuple[FormulaSide, formulaic.formula.SimpleFormula]",
+            formula_rhs(self._formula),
         )
+        return simple_formula(terms_without_intercept(parts[1]))
 
     @property
     def fixed_effects_wrapped(self) -> formulaic.formula.Formula:
@@ -236,14 +250,14 @@ class Formula:
         right_hand_side = list(self.exogenous)
         if self.is_instrumental_variable:
             right_hand_side += list(self.endogenous)
-        return f"{self.dependent} ~ {formulaic.formula.SimpleFormula(right_hand_side)}"
+        return f"{self.dependent} ~ {simple_formula(right_hand_side)}"
 
     @property
     def first_stage(self) -> str:
         """The first stage formula of an instrumental variable specification."""
         if not self.is_instrumental_variable:
             raise TypeError("Not an instrumental variable specification.")
-        return f"{self.endogenous} ~ {formulaic.formula.SimpleFormula([term for term in itertools.chain(self.instruments, self.exogenous)])}"
+        return f"{self.endogenous} ~ {simple_formula(itertools.chain(self.instruments, self.exogenous))}"
 
     @classmethod
     def parse(cls, formula: str) -> list["Formula"]:

--- a/pyfixest/estimation/formula/transforms/fixed_effects_encoding.py
+++ b/pyfixest/estimation/formula/transforms/fixed_effects_encoding.py
@@ -1,4 +1,4 @@
-from typing import Final
+from typing import Any, Final, cast
 
 import pandas as pd
 from formulaic.utils.stateful_transforms import stateful_transform
@@ -9,13 +9,16 @@ FIXED_EFFECT_ENCODING: Final[str] = "__fixed_effect_encoding__"
 @stateful_transform
 def encode_fixed_effects(*args, _state=None, _metadata=None, _spec=None):
     """Encode fixed effect interactions for model matrix construction."""
+    # formulaic's `stateful_transform` always injects the mutable state
+    # dictionary; the `None` default only keeps the plain signature valid.
+    state = cast("dict[str, Any]", _state)
     data = pd.concat(args, axis=1)
-    if FIXED_EFFECT_ENCODING not in _state:
+    if FIXED_EFFECT_ENCODING not in state:
         data[FIXED_EFFECT_ENCODING] = data.groupby(data.columns.tolist()).ngroup()
         encoded_state = data.dropna(subset=[FIXED_EFFECT_ENCODING]).drop_duplicates()
-        _state[FIXED_EFFECT_ENCODING] = encoded_state
+        state[FIXED_EFFECT_ENCODING] = encoded_state
         return data[FIXED_EFFECT_ENCODING]
 
     return data.merge(
-        _state[FIXED_EFFECT_ENCODING], on=data.columns.tolist(), how="left"
+        state[FIXED_EFFECT_ENCODING], on=data.columns.tolist(), how="left"
     )[FIXED_EFFECT_ENCODING]

--- a/pyfixest/estimation/internals/separation.py
+++ b/pyfixest/estimation/internals/separation.py
@@ -4,12 +4,15 @@ import re
 import warnings
 from functools import partial
 from importlib import import_module
-from typing import Protocol
+from typing import TYPE_CHECKING, Protocol, cast
 
 import numpy as np
 import pandas as pd
 
 from pyfixest.demeaners import AnyDemeaner
+
+if TYPE_CHECKING:
+    from pyfixest.estimation.models.feols_ import Feols
 
 
 def check_for_separation(
@@ -238,7 +241,11 @@ def _check_for_separation_ir(
         iteration += 1
         # regress U on X
         # TODO: check acceleration in ppmlhdfe's implementation: https://github.com/sergiocorreia/ppmlhdfe/blob/master/src/ppmlhdfe_separation_relu.mata#L135
-        fitted = feols(fml_separation, data=tmp, weights="omega", demeaner=demeaner)
+        # A single formula without multiple estimation always fits one model.
+        fitted = cast(
+            "Feols",
+            feols(fml_separation, data=tmp, weights="omega", demeaner=demeaner),
+        )
         tmp["Uhat"] = pd.Series(
             data=fitted.predict(), index=fitted._data.index, name="Uhat"
         )

--- a/pyfixest/estimation/internals/vcov_utils.py
+++ b/pyfixest/estimation/internals/vcov_utils.py
@@ -15,7 +15,7 @@ from pyfixest.core.nw import (
     nw_meat_time as _nw_meat_time_rs,
 )
 from pyfixest.errors import NanInClusterVarError
-from pyfixest.utils.dev_utils import DataFrameType, _narwhals_to_pandas
+from pyfixest.utils.dev_utils import _narwhals_to_pandas
 from pyfixest.utils.utils import get_ssc
 
 
@@ -32,7 +32,10 @@ class ClusterPrep:
 
 def prepare_cluster_state(
     *,
-    data: DataFrameType,
+    # `_get_cluster_df` inspects `data.empty` and `_check_cluster_df` its shape,
+    # so the CRV path requires a pandas frame rather than any narwhals-native
+    # frame the public `vcov()` signature accepts.
+    data: pd.DataFrame,
     clustervar: list[str],
     ssc_dict: dict,
     fixef: str | None,

--- a/pyfixest/estimation/numba/demean_nb.py
+++ b/pyfixest/estimation/numba/demean_nb.py
@@ -77,7 +77,9 @@ def demean(
     x_prev = np.empty((n_threads, n_samples), dtype=x.dtype)
 
     not_converged = 0
-    for k in nb.prange(n_features):
+    # numba's `prange` is a marker class whose `__new__` returns a plain
+    # `range` outside nopython mode, which static type checkers cannot see.
+    for k in nb.prange(n_features):  # ty: ignore[not-iterable]
         tid = nb.get_thread_id()
 
         xk_curr = x_curr[tid, :]

--- a/pyfixest/estimation/numba/nested_fixef_nb.py
+++ b/pyfixest/estimation/numba/nested_fixef_nb.py
@@ -35,7 +35,9 @@ def _count_fixef_fully_nested_all(
     k_fe_nested_flag = np.zeros(all_fixef_array.size, dtype=np.bool_)
     n_fe_fully_nested = 0
 
-    for fi in nb.prange(all_fixef_array.size):
+    # numba's `prange` is a marker class whose `__new__` returns a plain
+    # `range` outside nopython mode, which static type checkers cannot see.
+    for fi in nb.prange(all_fixef_array.size):  # ty: ignore[not-iterable]
         this_fe_name = all_fixef_array[fi]
 
         found_in_cluster = False

--- a/pyfixest/estimation/post_estimation/decomposition.py
+++ b/pyfixest/estimation/post_estimation/decomposition.py
@@ -1,15 +1,21 @@
 import itertools
 import warnings
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, TypeAlias, cast
 
 import numpy as np
 import pandas as pd
 from joblib import Parallel, delayed
 from numpy.typing import NDArray
-from scipy.sparse import diags, hstack, spmatrix, vstack
+from pandas.api.extensions import ExtensionArray
+from scipy.sparse import csc_matrix, csr_matrix, diags, hstack, spmatrix, vstack
 from scipy.sparse.linalg import lsqr
 from tqdm import tqdm
+
+# scipy's `spmatrix` only carries the matrix-semantics mixin: indexing,
+# `.multiply()` and the format converters live on the concrete classes. The
+# decomposition builds and consumes compressed matrices throughout.
+CompressedMatrix: TypeAlias = csc_matrix | csr_matrix
 
 # Panel name mappings for consistent API
 PANEL_ALIASES = {
@@ -164,7 +170,9 @@ class GelbachDecomposition:
 
     # Define attributes initialized post-creation
     cluster_dict: dict[Any, Any] | None = field(init=False, default=None)
-    unique_clusters: np.ndarray | None = field(init=False, default=None)
+    unique_clusters: np.ndarray | ExtensionArray | None = field(
+        init=False, default=None
+    )
     mask: np.ndarray = field(init=False)
     mediator_names: list[str] = field(init=False)
     X_dict: dict[Any, Any] = field(init=False, default_factory=dict)
@@ -190,10 +198,11 @@ class GelbachDecomposition:
 
         # Handle clustering setup if cluster_df is provided
         if self.cluster_df is not None and not self.only_coef:
-            self.unique_clusters = self.cluster_df.unique()
+            unique_clusters = self.cluster_df.unique()
+            self.unique_clusters = unique_clusters
             self.cluster_dict = {
                 cluster: self.cluster_df[self.cluster_df == cluster].index
-                for cluster in self.unique_clusters
+                for cluster in unique_clusters
             }
         else:
             self.unique_clusters = None
@@ -268,7 +277,7 @@ class GelbachDecomposition:
 
     def fit(
         self,
-        X: spmatrix,
+        X: CompressedMatrix,
         Y: np.ndarray,
         weights: np.ndarray | None = None,
         store: bool = True,
@@ -437,8 +446,11 @@ class GelbachDecomposition:
     def _bootstrap(self, rng: np.random.Generator):
         "Run a single bootstrap iteration."
         if self.unique_clusters is not None:
+            # A pandas ExtensionArray is an array-like the generator samples
+            # from, but numpy does not type its overloads for it.
+            unique_clusters = cast("np.ndarray", self.unique_clusters)
             idx_clusters = rng.choice(
-                self.unique_clusters, len(self.unique_clusters), replace=True
+                unique_clusters, len(unique_clusters), replace=True
             ).tolist()
 
             X = vstack([self.X_dict[g].tocsr() for g in idx_clusters])
@@ -454,7 +466,7 @@ class GelbachDecomposition:
     def compute_gelbach(
         self,
         X1: spmatrix,
-        X2: spmatrix,
+        X2: CompressedMatrix,
         Y: np.ndarray,
         X: spmatrix,
         agg_first: bool | None,

--- a/pyfixest/estimation/post_estimation/fixed_effects.py
+++ b/pyfixest/estimation/post_estimation/fixed_effects.py
@@ -313,12 +313,15 @@ def contrast_code_fixed_effects(
         context=context,
         transform_state=transform_state,
     )
+    # An unstructured formula always materializes into a single `ModelMatrix`,
+    # which carries the `ModelSpec` recorded during materialization.
+    model_spec = cast(ModelSpec, matrix.model_spec)
     coefficient_positions: dict[str, FixedEffectCoefficientPositions] = {}
     for fixed_effect_name, term in zip(
-        fixed_effect_names, matrix.model_spec.terms, strict=True
+        fixed_effect_names, model_spec.terms, strict=True
     ):
         coefficient_positions[fixed_effect_name] = (
-            get_fixed_effect_coefficient_positions(term, matrix.model_spec)
+            get_fixed_effect_coefficient_positions(term, model_spec)
         )
 
     return FixedEffectContrastCoding(

--- a/pyfixest/estimation/torch/demean_torch_.py
+++ b/pyfixest/estimation/torch/demean_torch_.py
@@ -75,7 +75,7 @@ def _get_device(dtype: torch.dtype = torch.float64) -> torch.device:
 @torch.no_grad()
 def _demean_torch_on_device_impl(
     x: NDArray[np.float64],
-    flist: NDArray[np.uint64],
+    flist: NDArray[np.uint64] | None,
     weights: NDArray[np.float64] | None,
     tol: float,
     maxiter: int,

--- a/pyfixest/report/visualize.py
+++ b/pyfixest/report/visualize.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import math
 from importlib.util import find_spec
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import numpy as np
 import pandas as pd
@@ -696,13 +696,14 @@ def _coefplot_matplotlib(
     if ax is None:
         f, ax = plt.subplots(figsize=figsize, **fig_kwargs)
     else:
-        f = ax.get_figure()
+        # An Axes drawn by matplotlib always belongs to a figure.
+        f = cast("plt.Figure", ax.get_figure())
 
     # Check if we have multiple models
     models = df["fml"].unique()
     is_multi_model = len(models) > 1
 
-    colors = plt.cm.jet(np.linspace(0, 1, len(models)))
+    colors = plt.get_cmap("jet")(np.linspace(0, 1, len(models)))
     color_dict = dict(zip(models, colors, strict=False))
 
     # Calculate the positions for dodging

--- a/pyfixest/utils/check_r_install.py
+++ b/pyfixest/utils/check_r_install.py
@@ -1,4 +1,6 @@
-from rpy2.robjects.packages import importr
+# rpy2 ships only with the `r` pixi feature, so it is absent from the
+# environment the type checker resolves imports from.
+from rpy2.robjects.packages import importr  # ty: ignore[unresolved-import]
 
 
 def _catch_import_issue(name: str, strict: bool) -> bool | None:

--- a/pyfixest/utils/set_rpy2_path.py
+++ b/pyfixest/utils/set_rpy2_path.py
@@ -1,5 +1,7 @@
-import rpy2.robjects as robjects
-from rpy2.robjects.packages import importr
+# rpy2 ships only with the `r` pixi feature, so it is absent from the
+# environment the type checker resolves imports from.
+import rpy2.robjects as robjects  # ty: ignore[unresolved-import]
+from rpy2.robjects.packages import importr  # ty: ignore[unresolved-import]
 
 
 def update_r_paths():

--- a/pyfixest/utils/utils.py
+++ b/pyfixest/utils/utils.py
@@ -1,6 +1,6 @@
 import warnings
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, cast
 
 import numpy as np
 import pandas as pd
@@ -483,7 +483,11 @@ def capture_context(context: int | Mapping[str, Any]) -> Mapping[str, Any]:
         The context that should be later passed to the Formulaic materialization
         procedure like: `.get_model_matrix(..., context=<this object>)`.
     """
-    return _capture_context(context + 2) if isinstance(context, int) else context
+    if not isinstance(context, int):
+        return context
+    # formulaic returns `None` only on interpreters without `sys._getframe`;
+    # a frame offset always resolves to a mapping on CPython.
+    return cast("Mapping[str, Any]", _capture_context(context + 2))
 
 
 def _check_balanced(panel_arr: np.ndarray, time_arr: np.ndarray) -> bool:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -180,6 +180,31 @@ module = [
 ]
 ignore_missing_imports = true
 
+[tool.ty.src]
+include = ["pyfixest"]
+exclude = [
+    # Superseded formula plumbing kept for backwards compatibility.
+    "pyfixest/estimation/deprecated",
+    # Temporary: these files are rewritten by the open estimation-state stack
+    # (#1499-#1501). They are type-checked by the mypy-to-ty migration layer
+    # that lands on top of that stack, so that the two efforts do not conflict.
+    "pyfixest/estimation/FixestMulti_.py",
+    "pyfixest/estimation/formula/model_matrix.py",
+    "pyfixest/estimation/models/_result_accessor_mixin.py",
+    "pyfixest/estimation/models/feglm_.py",
+    "pyfixest/estimation/models/feiv_.py",
+    "pyfixest/estimation/models/feols_.py",
+    "pyfixest/estimation/post_estimation/ritest.py",
+    "pyfixest/estimation/quantreg/QuantregMulti.py",
+    "pyfixest/estimation/quantreg/frisch_newton_ip.py",
+    "pyfixest/estimation/quantreg/quantreg_.py",
+]
+
+[tool.ty.rules]
+# mypy still runs as a pre-commit hook and owns the `# type: ignore` comments
+# in this repository, so ty must not report them as unused.
+unused-type-ignore-comment = "ignore"
+
 # --------------------------------------------------------------------------------------
 # pixi configuration
 # --------------------------------------------------------------------------------------
@@ -326,6 +351,18 @@ prek = ">=0.3.4"
 [tool.pixi.feature.lint.tasks]
 lint = { cmd = "prek run --all-files", description = "Run all pre-commit hooks via prek" }
 
+# -- type-check feature ------------------------------------------------------------------
+# ty resolves imports from the environment it runs in, so it is paired with the
+# runtime dependencies rather than with the standalone lint environment. It is a
+# feature rather than a default dependency because conda-forge's `ty` requires
+# CPython >= 3.11 and would make the py310 environment unsolvable.
+
+[tool.pixi.feature.typecheck.dependencies]
+ty = ">=0.0.78"
+
+[tool.pixi.feature.typecheck.tasks]
+type-check = { cmd = "ty check", description = "Type-check pyfixest with ty" }
+
 # -- benchmark feature -----------------------------------------------------------------
 
 [tool.pixi.feature.benchmark]
@@ -352,10 +389,10 @@ torch = { version = ">=2.7.0", index = "https://download.pytorch.org/whl/cu128" 
 
 [tool.pixi.environments]
 py310 = ["py310", "torch"]
-py311 = ["py311", "torch"]
-py312 = ["py312", "torch"]
-py313 = ["py313", "torch"]
-py314 = ["py314", "torch"]
+py311 = ["py311", "torch", "typecheck"]
+py312 = ["py312", "torch", "typecheck"]
+py313 = ["py313", "torch", "typecheck"]
+py314 = ["py314", "torch", "typecheck"]
 py310-r = { features = ["py310", "torch", "r"], solve-group = "py310" }
 py311-r = { features = ["py311", "torch", "r"], solve-group = "py311" }
 py312-r = { features = ["py312", "torch", "r"], solve-group = "py312" }


### PR DESCRIPTION
Adds [ty](https://github.com/astral-sh/ty) 0.0.78 as a blocking CI type check alongside the existing mypy pre-commit hook, as the first step of #1104. ty lives in a `typecheck` pixi feature on the py311 to py314 environments (conda-forge's ty needs CPython 3.11+), with a `type-check` task and a `[tool.ty]` configuration; CI runs `pixi run -e py312 type-check`.

Of 169 diagnostics on master, 60 are fixed for real (formulaic formula sides read through typed accessors, honest annotations in the DiD, decomposition, and plotting entries, real narrowing fixes) and 11 unused-ignore warnings are silenced because mypy still owns those comments. The files rewritten by the open estimation-state stack (#1499 to #1501) are excluded temporarily and will be un-excluded, together with removing mypy, in a follow-up layer on top of that stack. Every remaining suppression is a `# ty: ignore[rule]` with a reason naming the third-party gap. No runtime behavior changes.

## Verification

Passed locally at the head: `ty check` clean, mypy, ruff, release contract 1355/1355, targeted formula, DiD, decomposition, and plotting suites, broad Python-only suite (pre-existing `torch_mps` failures excluded), fast live-R 22/22. `pixi.lock` adds only ty. Deferred to CI: the `type-check` job itself, R suites, docs.
