### PR TITLE
build: complete the migration from mypy to ty

### DIFF
--- a/.agents/skills/change-verification/SKILL.md
+++ b/.agents/skills/change-verification/SKILL.md
@@ -23,9 +23,10 @@ only when it reports passed cases: a skip means no baseline, not success. A
 failure ends the refactor classification. Fix it or follow the numerics row.
 Never widen a contract tolerance to get green.
 
-Start with targeted tests and changed-file format/lint/type checks. Once the
-implementation stabilizes, run the selected broader baseline once and assign
-each required long check to a local run or exact-head CI.
+Start with targeted tests, changed-file format and lint checks, and the
+whole-package type check. Once the implementation stabilizes, run the selected
+broader baseline once and assign each required long check to a local run or
+exact-head CI.
 
 Unknown paths require the conservative PR baseline. For a stack, run targeted
 checks for each layer against its immediate parent and the broad suites once on

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -13,6 +13,23 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  type-check:
+    name: "Type Check"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: prefix-dev/setup-pixi@v0.10.2
+        with:
+          pixi-version: v0.76.2
+          cache: true
+          cache-write: ${{ github.event_name == 'push' && github.ref_name == 'master' }}
+          frozen: true
+          environments: py312
+
+      - name: Type-check with ty
+        run: pixi run -e py312 type-check
+
   test-python:
     name: "Tests Python (${{ matrix.environment }}, ${{ matrix.os }})"
     runs-on: ${{ matrix.os }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,11 +42,3 @@ repos:
         types_or: [jupyter, pyi, python]
       - id: ruff-format
         types_or: [jupyter, pyi, python]
-
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v2.3.0
-    hooks:
-      - id: mypy
-        args: [--ignore-missing-imports]
-        files: ^pyfixest/
-        additional_dependencies: [numpy>=1.20, pandas-stubs]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,6 +161,7 @@ pixi run -e py312 test-release-contract                             # refactor i
 pixi run -e py312-r test-r-fixest-fast                              # fast live-R
 pixi run test-py                                                    # Python baseline
 pixi run -e lint prek run ruff-check --files <changed files>        # changed-file lint
+pixi run -e py312 type-check                                        # ty, whole package
 pixi task list                                                      # everything else
 ```
 

--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -61,12 +61,17 @@ fit3 = pf.feols("Y ~ X1 + X2 | f1", data = df)
   container are typed against a `FittedResult` protocol, `FixestMulti` is
   generic in its result class, and `pf.estimation.BaseRegression` is exported
   for `isinstance` checks.
-- We add [ty](https://github.com/astral-sh/ty) as a blocking CI check,
-  `pixi run -e py312 type-check`, alongside the existing mypy pre-commit hook.
-  Fixing its diagnostics tightened annotations across the DiD, formula,
-  decomposition, and reporting code; `panelview` now declares the
-  `matplotlib.pyplot.Axes` its docstring already documented. The files the
-  open estimation-state work rewrites are excluded for now and follow later.
+- pyfixest is now type-checked with [ty](https://github.com/astral-sh/ty)
+  instead of mypy, which completes the migration in issue #1104.
+  `pixi run -e py312 type-check` runs it over the whole package and blocks CI,
+  and the mypy pre-commit hook and its `# type: ignore` comments are gone.
+  Fixing the diagnostics tightened annotations throughout: `panelview` declares
+  the `matplotlib.pyplot.Axes` its docstring already documented, the `vcov`
+  argument accepts the `"NW"` and `"DK"` strings the estimators document and
+  validate, and the reporting entries declare every collection of models they
+  already accepted. Options that never accepted `None` no longer say they do,
+  among them the `wildboottest` bootstrap settings and `weights_type` on the
+  result classes.
 
 ### Inference Types
 

--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -61,6 +61,12 @@ fit3 = pf.feols("Y ~ X1 + X2 | f1", data = df)
   container are typed against a `FittedResult` protocol, `FixestMulti` is
   generic in its result class, and `pf.estimation.BaseRegression` is exported
   for `isinstance` checks.
+- We add [ty](https://github.com/astral-sh/ty) as a blocking CI check,
+  `pixi run -e py312 type-check`, alongside the existing mypy pre-commit hook.
+  Fixing its diagnostics tightened annotations across the DiD, formula,
+  decomposition, and reporting code; `panelview` now declares the
+  `matplotlib.pyplot.Axes` its docstring already documented. The files the
+  open estimation-state work rewrites are excluded for now and follow later.
 
 ### Inference Types
 

--- a/docs/contributing.qmd
+++ b/docs/contributing.qmd
@@ -124,16 +124,17 @@ pixi run lint
 
 ### Type checking
 
-The prek hooks run [mypy](https://mypy-lang.org/). CI additionally runs
-[ty](https://github.com/astral-sh/ty), which resolves imports from the
-environment it runs in and therefore lives with the runtime dependencies
-instead of the lint environment:
+pyfixest is type-checked with [ty](https://github.com/astral-sh/ty), which
+blocks CI. It resolves imports from the environment it runs in and therefore
+lives with the runtime dependencies instead of the lint environment:
 
 ```{.bash .code-copy}
 pixi run -e py312 type-check
 ```
 
-Both checks must pass. ty is configured under `[tool.ty]` in `pyproject.toml`.
+ty is configured under `[tool.ty]` in `pyproject.toml`. Fix a diagnostic at its
+source; suppress a line only with `# ty: ignore[rule]` and a comment naming the
+third-party gap it works around.
 
 ### Building the documentation
 

--- a/docs/contributing.qmd
+++ b/docs/contributing.qmd
@@ -122,6 +122,19 @@ This installs prek as a git hook so checks run automatically on each commit.
 pixi run lint
 ```
 
+### Type checking
+
+The prek hooks run [mypy](https://mypy-lang.org/). CI additionally runs
+[ty](https://github.com/astral-sh/ty), which resolves imports from the
+environment it runs in and therefore lives with the runtime dependencies
+instead of the lint environment:
+
+```{.bash .code-copy}
+pixi run -e py312 type-check
+```
+
+Both checks must pass. ty is configured under `[tool.ty]` in `pyproject.toml`.
+
 ### Building the documentation
 
 ```{.bash .code-copy}

--- a/docs/developer/testing.md
+++ b/docs/developer/testing.md
@@ -12,7 +12,7 @@ selection affect wall time.
 
 | Stage | Purpose | Typical scale | Examples |
 |---|---|---|---|
-| Edit feedback | Exercise the changed seam repeatedly | Seconds to a few minutes | targeted pytest, release contract, targeted or fast live-R checks, changed-file Ruff/mypy |
+| Edit feedback | Exercise the changed seam repeatedly | Seconds to a few minutes | targeted pytest, release contract, targeted or fast live-R checks, changed-file Ruff/mypy, ty |
 | Stabilized implementation | Broaden local confidence once | Minutes | selected subsystem checks, `pixi run test-py` when required |
 | Merge evidence | Validate the exact PR head in affected environments | May take tens of minutes | canonical R, HAC, no-JIT, docs, plots, Rust, platform CI |
 | Exhaustive or release | Exercise everything available | Potentially substantially longer | `test-all`, CRAN-only dependencies, platform CI, benchmarks |
@@ -70,6 +70,9 @@ pixi run -e lint prek run ruff-format --files <changed files>
 pixi run -e lint prek run ruff-check --files <changed files>
 pixi run -e lint prek run mypy --files <changed files>
 
+# Whole-package type check; ty resolves imports from the estimation environment
+pixi run -e py312 type-check
+
 # Documentation (costly; run only when the selection matrix calls for it)
 pixi run docs-build
 pixi run docs-render
@@ -81,6 +84,13 @@ conda-forge R comparisons. CI partitions that population into
 `tests/test_vs_fixest.py` is not executed twice. The fast suite runs once as a
 preflight in the canonical `fixest` job.
 
+Two type checkers run side by side while pyfixest migrates from mypy to ty
+(issue #1104). mypy stays a prek hook and keeps owning the `# type: ignore`
+comments; ty checks the whole package in one pass and blocks CI. ty is
+configured under `[tool.ty]` in `pyproject.toml`, including a temporary
+exclude list; do not silence a diagnostic by extending it. Suppress a single
+line only with `# ty: ignore[rule]` and a reason naming the third-party gap.
+
 ## Selection matrix
 
 This matrix is authoritative for which checks a change requires.
@@ -90,8 +100,8 @@ This matrix is authoritative for which checks a change requires.
 | Public docstrings or API-reference configuration | `git diff --check`; execute changed examples; `docs-build` | affected reference-page render when applicable |
 | Content under `docs/` | `git diff --check`; execute changed examples; render the affected page when practical | `docs-render` only for site-wide configuration, navigation, templates, or cross-page changes |
 | Repository guidance or workflow metadata outside `docs/` | `git diff --check`; targeted skill, template, or configuration validation | affected CI workflow only; no docs build by default |
-| Python API or internals | targeted public tests; changed-file lint/type checks | Python baseline |
-| Internal or backend refactor with unchanged results | release contract green (passed, not skipped); targeted tests; changed-file lint/type checks | Python baseline; applicable external suite for every estimator the refactor touches |
+| Python API or internals | targeted public tests; changed-file lint/mypy; `type-check` | Python baseline |
+| Internal or backend refactor with unchanged results | release contract green (passed, not skipped); targeted tests; changed-file lint/mypy; `type-check` | Python baseline; applicable external suite for every estimator the refactor touches |
 | Estimation or inference numerics | targeted integration and edge tests; release contract with every intended difference declared by `reason` | applicable live external-reference suite |
 | New estimator | complete support matrix and permanent external comparison | Python baseline, external suite, full platform CI |
 | HAC | targeted HAC/meat tests | single-threaded `test-r-hac` |

--- a/docs/developer/testing.md
+++ b/docs/developer/testing.md
@@ -12,7 +12,7 @@ selection affect wall time.
 
 | Stage | Purpose | Typical scale | Examples |
 |---|---|---|---|
-| Edit feedback | Exercise the changed seam repeatedly | Seconds to a few minutes | targeted pytest, release contract, targeted or fast live-R checks, changed-file Ruff/mypy, ty |
+| Edit feedback | Exercise the changed seam repeatedly | Seconds to a few minutes | targeted pytest, release contract, targeted or fast live-R checks, changed-file Ruff, ty |
 | Stabilized implementation | Broaden local confidence once | Minutes | selected subsystem checks, `pixi run test-py` when required |
 | Merge evidence | Validate the exact PR head in affected environments | May take tens of minutes | canonical R, HAC, no-JIT, docs, plots, Rust, platform CI |
 | Exhaustive or release | Exercise everything available | Potentially substantially longer | `test-all`, CRAN-only dependencies, platform CI, benchmarks |
@@ -68,7 +68,6 @@ pixi run -e py312-r test-r-extended
 # Changed-file quality checks
 pixi run -e lint prek run ruff-format --files <changed files>
 pixi run -e lint prek run ruff-check --files <changed files>
-pixi run -e lint prek run mypy --files <changed files>
 
 # Whole-package type check; ty resolves imports from the estimation environment
 pixi run -e py312 type-check
@@ -84,12 +83,15 @@ conda-forge R comparisons. CI partitions that population into
 `tests/test_vs_fixest.py` is not executed twice. The fast suite runs once as a
 preflight in the canonical `fixest` job.
 
-Two type checkers run side by side while pyfixest migrates from mypy to ty
-(issue #1104). mypy stays a prek hook and keeps owning the `# type: ignore`
-comments; ty checks the whole package in one pass and blocks CI. ty is
-configured under `[tool.ty]` in `pyproject.toml`, including a temporary
-exclude list; do not silence a diagnostic by extending it. Suppress a single
-line only with `# ty: ignore[rule]` and a reason naming the third-party gap.
+[ty](https://github.com/astral-sh/ty) is the repository's only type checker
+(issue #1104). It checks the whole package in one pass and blocks CI, and it
+resolves imports from the environment it runs in, so it ships with the
+estimation dependencies rather than with the lint environment. It is configured
+under `[tool.ty]` in `pyproject.toml`, where the exclude list covers only
+superseded code; do not silence a diagnostic by extending it. Fix the
+annotation or the code at its source instead. Suppress a single line only with
+`# ty: ignore[rule]` and a reason naming the third-party gap, and never with a
+blanket `# type: ignore`, which is reported as unused once it stops matching.
 
 ## Selection matrix
 
@@ -100,8 +102,8 @@ This matrix is authoritative for which checks a change requires.
 | Public docstrings or API-reference configuration | `git diff --check`; execute changed examples; `docs-build` | affected reference-page render when applicable |
 | Content under `docs/` | `git diff --check`; execute changed examples; render the affected page when practical | `docs-render` only for site-wide configuration, navigation, templates, or cross-page changes |
 | Repository guidance or workflow metadata outside `docs/` | `git diff --check`; targeted skill, template, or configuration validation | affected CI workflow only; no docs build by default |
-| Python API or internals | targeted public tests; changed-file lint/mypy; `type-check` | Python baseline |
-| Internal or backend refactor with unchanged results | release contract green (passed, not skipped); targeted tests; changed-file lint/mypy; `type-check` | Python baseline; applicable external suite for every estimator the refactor touches |
+| Python API or internals | targeted public tests; changed-file lint; `type-check` | Python baseline |
+| Internal or backend refactor with unchanged results | release contract green (passed, not skipped); targeted tests; changed-file lint; `type-check` | Python baseline; applicable external suite for every estimator the refactor touches |
 | Estimation or inference numerics | targeted integration and edge tests; release contract with every intended difference declared by `reason` | applicable live external-reference suite |
 | New estimator | complete support matrix and permanent external comparison | Python baseline, external suite, full platform CI |
 | HAC | targeted HAC/meat tests | single-threaded `test-r-hac` |

--- a/pixi.lock
+++ b/pixi.lock
@@ -6197,6 +6197,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2022.3.0-hb700be7_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.3-py311h49ec1c0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ty-0.0.78-heeb25aa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-17.0.1-py311h49ec1c0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_1.conda
@@ -6526,6 +6527,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/statsmodels-0.14.6-py311h09efe57_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.5.4-py311h9408147_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ty-0.0.78-h98cbc1d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/unicodedata2-17.0.1-py311hc949640_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.12-hc919400_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.5-hc919400_1.conda
@@ -6701,6 +6703,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2022.3.0-hb700be7_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.3-py311h49ec1c0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ty-0.0.78-heeb25aa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-17.0.1-py311h49ec1c0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_1.conda
@@ -7013,6 +7016,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2022.3.0-h3155e25_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h6ed50ae_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/tornado-6.5.4-py311h3485c13_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ty-0.0.78-h0cebda5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/unicodedata2-17.0.1-py311h3485c13_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h41ae7f8_34.conda
@@ -8470,6 +8474,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2022.3.0-hb700be7_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.3-py312h4c3975b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ty-0.0.78-heeb25aa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-17.0.1-py312h4c3975b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_1.conda
@@ -8799,6 +8804,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/statsmodels-0.14.6-py312ha11c99a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.5.4-py312h4409184_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ty-0.0.78-h98cbc1d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/unicodedata2-17.0.1-py312h2bbb03f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.12-hc919400_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.5-hc919400_1.conda
@@ -8974,6 +8980,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2022.3.0-hb700be7_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.3-py312h4c3975b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ty-0.0.78-heeb25aa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-17.0.1-py312h4c3975b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_1.conda
@@ -9286,6 +9293,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2022.3.0-h3155e25_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h6ed50ae_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/tornado-6.5.4-py312he06e257_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ty-0.0.78-h0cebda5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/unicodedata2-17.0.1-py312he06e257_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h41ae7f8_34.conda
@@ -10742,6 +10750,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2022.3.0-hb700be7_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.3-py313h07c4f96_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ty-0.0.78-heeb25aa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h280c20c_3.conda
@@ -11069,6 +11078,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/statsmodels-0.14.6-py313hc577518_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.5.4-py313h6535dbc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ty-0.0.78-h98cbc1d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.12-hc919400_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.5-hc919400_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h925e9cb_3.conda
@@ -11242,6 +11252,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2022.3.0-hb700be7_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.3-py313h07c4f96_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ty-0.0.78-heeb25aa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h280c20c_3.conda
@@ -11552,6 +11563,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2022.3.0-h3155e25_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h6ed50ae_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/tornado-6.5.4-py313h5ea7bf4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ty-0.0.78-h0cebda5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h41ae7f8_34.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.44.35208-h818238b_34.conda
@@ -11734,6 +11746,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2022.3.0-hb700be7_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.3-py314h5bd0f2a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ty-0.0.78-heeb25aa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-17.0.1-py314h5bd0f2a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_1.conda
@@ -12063,6 +12076,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/statsmodels-0.14.6-py314hdcf55e8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.5.4-py314h0612a62_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ty-0.0.78-h98cbc1d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/unicodedata2-17.0.1-py314h6c2aa35_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.12-hc919400_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.5-hc919400_1.conda
@@ -12236,6 +12250,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2022.3.0-hb700be7_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.3-py314h5bd0f2a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ty-0.0.78-heeb25aa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-17.0.1-py314h5bd0f2a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_1.conda
@@ -12548,6 +12563,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2022.3.0-h3155e25_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h6ed50ae_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/tornado-6.5.4-py314h5a2d7ad_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ty-0.0.78-h0cebda5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/unicodedata2-17.0.1-py314h5a2d7ad_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h41ae7f8_34.conda
@@ -19348,6 +19364,25 @@ packages:
   - pkg:pypi/tornado?source=hash-mapping
   size: 905436
   timestamp: 1765458949518
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ty-0.0.78-heeb25aa_0.conda
+  noarch: python
+  sha256: 4f70dc81e89bbc4fa983705929888a0dbaaccb1ae8eae3f1588e2f8eaf10f3a9
+  md5: 410fa01adb1bc626f2b6276c51c4b9eb
+  depends:
+  - python
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=15
+  - _python_abi3_support 1.*
+  - cpython >=3.11
+  constrains:
+  - __glibc >=2.17
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/ty?source=compressed-mapping
+  run_exports: {}
+  size: 11520379
+  timestamp: 1788398096040
 - conda: https://conda.anaconda.org/conda-forge/linux-64/typst-0.14.2-h4c46f8d_0.conda
   sha256: 2051dee6a67d43a0ff0fd2ff9dacd8ef533e89d0b30feedf87613fc84b00c247
   md5: 6733bfb9b4338039e182ca3a41253ab5
@@ -31500,6 +31535,24 @@ packages:
   - pkg:pypi/tornado?source=hash-mapping
   size: 909298
   timestamp: 1765836779269
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ty-0.0.78-h98cbc1d_0.conda
+  noarch: python
+  sha256: 6a50ebbabcbeb52f470d0ff175f55602fa4d59ed3081349a0bc3087943ad91b1
+  md5: 9e6fd3196325f0bce23418905f5d22c4
+  depends:
+  - python
+  - __osx >=11.0
+  - _python_abi3_support 1.*
+  - cpython >=3.11
+  constrains:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/ty?source=compressed-mapping
+  run_exports: {}
+  size: 10409035
+  timestamp: 1788398090213
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/typst-0.14.2-hd1458d2_0.conda
   sha256: 201e08fc74e3dc8161d583bb50d23ae07b4537c5efa41c8a7e1ba46a30261ea6
   md5: 750223ac708cb65d0d32fa61d84e35e4
@@ -39125,6 +39178,24 @@ packages:
   - pkg:pypi/tornado?source=hash-mapping
   size: 859726
   timestamp: 1774358173994
+- conda: https://conda.anaconda.org/conda-forge/win-64/ty-0.0.78-h0cebda5_0.conda
+  noarch: python
+  sha256: 4565f8f510348a2c01bd25891b0508d62feabc1e395f66fbd5cfb280a7b75c19
+  md5: cca528455b779886ab5e67cfc42c6cbf
+  depends:
+  - python
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - _python_abi3_support 1.*
+  - cpython >=3.11
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/ty?source=compressed-mapping
+  run_exports: {}
+  size: 11699326
+  timestamp: 1788398092117
 - conda: https://conda.anaconda.org/conda-forge/win-64/typst-0.14.2-h77a83cd_0.conda
   sha256: 6e6f4dfb5d3e43d627e248723ccc963c7889fc59e7039c67b4d6ca2aea20ea99
   md5: c7d150437cdf4a2facdb156fe1dbe9b7

--- a/pyfixest/did/did2s.py
+++ b/pyfixest/did/did2s.py
@@ -121,7 +121,8 @@ class DID2S(DID):
             treatment="is_treated",
             first_u=self._first_u,
             second_u=self._second_u,
-            cluster=self._cluster,
+            # DID2S always clusters; only the DID base class allows `None`.
+            cluster=cast(str, self._cluster),
             weights=self._weights_name,
         )
 
@@ -302,7 +303,10 @@ def _did2s_vcov(
         A variance covariance matrix.
     """
     cluster_col = data[cluster]
-    _, clustid = pd.factorize(cluster_col)
+    # `pd.factorize` returns the distinct levels as an ndarray or an Index
+    # depending on the input; the cluster loop and count below need an Index.
+    _, clustid_levels = pd.factorize(cluster_col)
+    clustid = pd.Index(clustid_levels)
 
     _G = clustid.nunique()  # actually not used here, neither in did2s
 

--- a/pyfixest/did/did2s.py
+++ b/pyfixest/did/did2s.py
@@ -369,7 +369,7 @@ def _did2s_vcov(
     first_u *= weights_array
     second_u *= weights_array
 
-    X10 = X1.copy().tocsr()  # type: ignore
+    X10 = X1.copy().tocsr()
     treated_rows = np.where(data[treatment], 0, 1)
     X10 = X10.multiply(treated_rows[:, None])
 
@@ -377,13 +377,13 @@ def _did2s_vcov(
     X2X1 = X2.T.dot(X1)
     X2X2 = X2.T.dot(X2)  # tocsc() to fix spsolve efficiency warning
 
-    V = spsolve(X10X10.tocsc(), X2X1.T.tocsc()).T  # type: ignore
+    V = spsolve(X10X10.tocsc(), X2X1.T.tocsc()).T
 
     k = X2.shape[1]
     vcov = np.zeros((k, k))
 
     X10 = X10.tocsr()
-    X2 = X2.tocsr()  # type: ignore
+    X2 = X2.tocsr()
 
     for _, g in enumerate(clustid):
         idx_g: np.ndarray = cluster_col.values == g

--- a/pyfixest/did/estimation.py
+++ b/pyfixest/did/estimation.py
@@ -164,7 +164,10 @@ def event_study(
         fit._att = saturated._att
 
         fit._method = "saturated"
-        fit.iplot = saturated.iplot.__get__(fit, type(fit))
+        # Rebinding the saturated event-study methods onto a plain `Feols`
+        # replaces `Feols.iplot`, which is a `functools.partial` attribute.
+        # Follow-up: give the saturated estimator its own result class.
+        fit.iplot = saturated.iplot.__get__(fit, type(fit))  # ty: ignore[invalid-assignment]
         fit.test_treatment_heterogeneity = (
             saturated.test_treatment_heterogeneity.__get__(fit, type(fit))
         )
@@ -321,7 +324,7 @@ def lpdid(
     post_window: int | None = None,
     never_treated: int = 0,
     att: bool = True,
-    xfml=None,
+    xfml: str | None = None,
 ) -> LPDID:
     """
     Local projections approach to estimation.

--- a/pyfixest/did/lpdid.py
+++ b/pyfixest/did/lpdid.py
@@ -26,7 +26,7 @@ class LPDID(DID):
         The name of the time variable.
     gname : str
         The name of the group variable.
-    xfml : str
+    xfml : str, optional
         The transformation to apply to the data.
     att : str
         The attribute to consider in the model.
@@ -49,7 +49,7 @@ class LPDID(DID):
         idname: str,
         tname: str,
         gname: str,
-        xfml: str,
+        xfml: str | None,
         att: bool,
         cluster: str,
         vcov: VcovTypeOptions | dict[str, str] | None = None,

--- a/pyfixest/did/lpdid.py
+++ b/pyfixest/did/lpdid.py
@@ -286,7 +286,7 @@ def _lpdid_estimate(
 
             fit_tidy = cast(pd.Series, fit.tidy().xs("treat_diff"))
             fit_tidy["N"] = int(fit._N)
-            fit_tidy.name = h  # type: ignore[union-attr]
+            fit_tidy.name = h
             fit_all.append(fit_tidy)
 
         for h in range(pre_window + 1):
@@ -301,7 +301,7 @@ def _lpdid_estimate(
 
             fit_tidy = cast(pd.Series, fit.tidy().xs("treat_diff"))
             fit_tidy["N"] = int(fit._N)
-            fit_tidy.name = -h  # type: ignore[union-attr]
+            fit_tidy.name = -h
             fit_all.append(fit_tidy)
 
         res = pd.DataFrame(fit_all).sort_index()

--- a/pyfixest/did/saturated_twfe.py
+++ b/pyfixest/did/saturated_twfe.py
@@ -112,6 +112,11 @@ class SaturatedEventStudy(DID):
         Feols
             The fitted Feols model object.
         """
+        # `event_study()` resolves the cluster variable to the unit id before
+        # constructing this estimator, and the class documents it as required:
+        # the saturated study reports CRV1 inference on it.
+        assert self._cluster is not None, "cluster must be set"
+
         self.mod, self._res_cohort_eventtime_dict = _saturated_event_study(
             self._data,
             outcome=self._yname,
@@ -352,10 +357,10 @@ def _saturated_event_study(
     outcome: str,
     time_id: str,
     unit_id: str,
-    cluster: str | None = None,
+    cluster: str,
 ):
     ff = f"{outcome} ~ i(rel_time, first_treated_period, ref = -1, ref2=0) | {unit_id} + {time_id}"
-    m = feols(fml=ff, data=df, vcov={"CRV1": cluster})  # type: ignore
+    m = feols(fml=ff, data=df, vcov={"CRV1": cluster})
     res = m.tidy().reset_index()
     res = res.join(
         res["Coefficient"].str.extract(

--- a/pyfixest/did/visualize.py
+++ b/pyfixest/did/visualize.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import pandas as pd
 
@@ -27,7 +27,7 @@ def panelview(
     ax: plt.Axes | None = None,
     xlim: tuple | None = None,
     ylim: tuple | None = None,
-) -> None:
+) -> plt.Axes:
     """
     Generate a panel view of the treatment variable over time for each unit.
 
@@ -210,11 +210,11 @@ def _prepare_panelview_df_for_outcome_plot(
         def get_treatment_start(x: pd.DataFrame) -> pd.Timestamp:
             return x[x[treat]][time].min()
 
-        treatment_starts = (
-            data.groupby(unit)
-            .apply(get_treatment_start)
-            .reset_index(name="treatment_start")
-        )
+        # A scalar-valued `apply` reduces each group to one row, so the result
+        # is a Series and `reset_index` can name its value column.
+        treatment_starts = cast(
+            "pd.Series", data.groupby(unit).apply(get_treatment_start)
+        ).reset_index(name="treatment_start")
 
         data = data.merge(treatment_starts, on=unit, how="left")
         data_agg = (

--- a/pyfixest/estimation/api/feglm.py
+++ b/pyfixest/estimation/api/feglm.py
@@ -30,7 +30,7 @@ from pyfixest.utils.utils import ssc as ssc_func
 
 def feglm(
     fml: str,
-    data: DataFrameType,  # type: ignore
+    data: DataFrameType,
     family: FamilyOptions,
     vcov: VcovTypeOptions | dict[str, str] | None = None,
     vcov_kwargs: dict[str, str | int] | None = None,

--- a/pyfixest/estimation/api/feols.py
+++ b/pyfixest/estimation/api/feols.py
@@ -28,7 +28,7 @@ from pyfixest.utils.utils import ssc as ssc_func
 
 def feols(
     fml: str,
-    data: DataFrameType,  # type: ignore
+    data: DataFrameType,
     vcov: VcovTypeOptions | dict[str, str] | None = None,
     vcov_kwargs: dict[str, str | int] | None = None,
     weights: str | None = None,

--- a/pyfixest/estimation/api/fepois.py
+++ b/pyfixest/estimation/api/fepois.py
@@ -18,7 +18,7 @@ from pyfixest.utils.dev_utils import DataFrameType
 
 def fepois(
     fml: str,
-    data: DataFrameType,  # type: ignore
+    data: DataFrameType,
     vcov: VcovTypeOptions | dict[str, str] | None = None,
     vcov_kwargs: dict[str, str | int] | None = None,
     weights: str | None = None,

--- a/pyfixest/estimation/api/quantreg.py
+++ b/pyfixest/estimation/api/quantreg.py
@@ -45,7 +45,7 @@ def _quantreg_input_checks(quantile: float, tol: float, maxiter: int | None):
 
 def quantreg(
     fml: str,
-    data: DataFrameType,  # type: ignore
+    data: DataFrameType,
     vcov: VcovTypeOptions | dict[str, str] | None = "nid",
     quantile: float = 0.5,
     method: QuantregMethodOptions = "fn",

--- a/pyfixest/estimation/config.py
+++ b/pyfixest/estimation/config.py
@@ -9,6 +9,7 @@ from pyfixest.estimation.internals.literals import (
     QuantregMethodOptions,
     QuantregMultiOptions,
     SolverOptions,
+    WeightsTypeOptions,
 )
 
 
@@ -52,7 +53,7 @@ class EstimationConfig:
 
     # --- weights ---
     weights: str | None = None
-    weights_type: str = "aweights"
+    weights_type: WeightsTypeOptions = "aweights"
 
     # --- splits ---
     split: str | None = None

--- a/pyfixest/estimation/formula/formulaic_compat.py
+++ b/pyfixest/estimation/formula/formulaic_compat.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable, Iterator, Mapping
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypeAlias, cast
 
 import formulaic
 import formulaic.formula
@@ -20,19 +20,55 @@ from pyfixest.estimation.formula.transforms.factor_interaction import (
 if TYPE_CHECKING:
     from formulaic.model_spec import ModelSpec
 
+# One side of a parsed formula: a flat list of terms, or, for an IV
+# specification, formulaic's nested `[endogenous ~ instruments]` container.
+FormulaSide: TypeAlias = (
+    formulaic.formula.SimpleFormula | formulaic.formula.StructuredFormula
+)
+
 
 class FormulaicCompatibilityError(RuntimeError):
     """Raised when formulaic internals no longer match pyfixest expectations."""
 
 
-def terms_without_intercept(formula: formulaic.formula.Formula) -> Iterator[Any]:
+def formula_lhs(
+    formula: formulaic.formula.Formula,
+) -> formulaic.formula.SimpleFormula:
+    """Return the dependent-variable side of a parsed formulaic formula."""
+    # formulaic internal: `StructuredFormula` serves `lhs`, `rhs` and `root`
+    # from `Structured.__getattr__`, so they are invisible to a type checker
+    # on the `Formula` base class the parser is declared to return.
+    return formula.lhs  # ty: ignore[unresolved-attribute]
+
+
+def formula_rhs(
+    formula: formulaic.formula.Formula,
+) -> FormulaSide | tuple[FormulaSide, ...]:
+    """
+    Return the covariate side of a parsed formulaic formula.
+
+    A `|`-separated (MULTIPART) formula returns one entry per part.
+    """
+    # formulaic internal: see `formula_lhs`.
+    return formula.rhs  # ty: ignore[unresolved-attribute]
+
+
+def simple_formula(terms: Iterable[Any]) -> formulaic.formula.SimpleFormula:
+    """Build a flat formulaic formula from an iterable of terms."""
+    # formulaic internal: the `Formula` metaclass annotates `__call__` as
+    # returning the `Formula` base class, also for `SimpleFormula(...)`, and
+    # only accepts a materialized sequence of terms.
+    return cast(
+        "formulaic.formula.SimpleFormula",
+        formulaic.formula.SimpleFormula(list(terms)),
+    )
+
+
+def terms_without_intercept(
+    formula: formulaic.formula.SimpleFormula,
+) -> Iterator[Any]:
     """Yield formula terms excluding Formulaic's intercept term."""
     return (term for term in formula if term != "1")
-
-
-def is_structured_formula(rhs: formulaic.formula.Formula) -> bool:
-    """Return whether formulaic parsed an IV RHS as a StructuredFormula."""
-    return isinstance(rhs, formulaic.formula.StructuredFormula)
 
 
 def count_multistage_blocks(rhs: formulaic.formula.Formula) -> int:
@@ -45,14 +81,14 @@ def count_multistage_blocks(rhs: formulaic.formula.Formula) -> int:
 
 def get_first_multistage_lhs(
     rhs: formulaic.formula.Formula,
-) -> formulaic.formula.Formula:
+) -> formulaic.formula.SimpleFormula:
     """Return the endogenous formula from a formulaic MULTISTAGE RHS."""
     return _get_single_multistage_block(rhs).lhs
 
 
 def get_first_multistage_rhs(
     rhs: formulaic.formula.Formula,
-) -> formulaic.formula.Formula:
+) -> formulaic.formula.SimpleFormula:
     """Return the instrument formula from a formulaic MULTISTAGE RHS."""
     return _get_single_multistage_block(rhs).rhs
 
@@ -75,7 +111,7 @@ def _get_single_multistage_block(rhs: formulaic.formula.Formula) -> Any:
 
 
 def filter_multistage_endogenous_terms(
-    exogenous: formulaic.formula.Formula,
+    exogenous: formulaic.formula.StructuredFormula,
     endogenous_terms: Iterable[Any],
 ) -> formulaic.formula.SimpleFormula:
     """Drop formulaic's generated ``<endogenous term>_hat`` second-stage terms."""
@@ -90,8 +126,8 @@ def filter_multistage_endogenous_terms(
             "formulaic MULTISTAGE endogenous suffix changed: expected generated "
             f"second-stage terms {sorted(missing)} to be present before filtering."
         )
-    return formulaic.formula.SimpleFormula(
-        [term for term in terms if str(term) not in generated_endogenous]
+    return simple_formula(
+        term for term in terms if str(term) not in generated_endogenous
     )
 
 
@@ -109,7 +145,11 @@ def materialize_model_spec_with_unseen_mask(
 ) -> tuple[formulaic.ModelMatrix, np.ndarray]:
     """Materialize a prediction matrix and flag unseen categorical levels."""
     materializer = rhs_spec.get_materializer(newdata, context=context)
-    model_matrix = materializer.get_model_matrix(rhs_spec)
+    # formulaic returns its structured `ModelMatrices` container only for a
+    # structured spec; a single `ModelSpec` always materializes one matrix.
+    model_matrix = cast(
+        "formulaic.ModelMatrix", materializer.get_model_matrix(rhs_spec)
+    )
     unseen = rows_with_unseen_contrast_levels(
         rhs_spec, newdata, materializer.factor_cache
     )

--- a/pyfixest/estimation/formula/formulaic_compat.py
+++ b/pyfixest/estimation/formula/formulaic_compat.py
@@ -9,7 +9,9 @@ import formulaic
 import formulaic.formula
 import numpy as np
 import pandas as pd
+from formulaic.parser import DefaultFormulaParser
 from formulaic.parser.types import Factor
+from formulaic.utils.structured import Structured
 
 from pyfixest.estimation.formula.transforms.factor_interaction import (
     bin_mapping_state_key,
@@ -25,6 +27,11 @@ if TYPE_CHECKING:
 FormulaSide: TypeAlias = (
     formulaic.formula.SimpleFormula | formulaic.formula.StructuredFormula
 )
+
+# What `Formula.get_model_matrix` materializes: one matrix for a flat formula,
+# and formulaic's structured container for the multi-part formulas pyfixest
+# builds. Both are navigated by role key and both serve the same attributes.
+AnyModelMatrix: TypeAlias = formulaic.ModelMatrix | Structured[formulaic.ModelMatrix]
 
 
 class FormulaicCompatibilityError(RuntimeError):
@@ -51,6 +58,37 @@ def formula_rhs(
     """
     # formulaic internal: see `formula_lhs`.
     return formula.rhs  # ty: ignore[unresolved-attribute]
+
+
+def model_spec_lhs(spec: ModelSpec) -> ModelSpec:
+    """Return the dependent-variable spec of a two-sided sub-formula."""
+    # formulaic internal: a two-sided sub-formula materializes into the
+    # structured `ModelSpecs` container, which serves `lhs` and `rhs` from
+    # `Structured.__getattr__`. A `ModelSpec` mapping is typed in terms of the
+    # single-spec leaf, so the two sides are invisible to a type checker.
+    return spec.lhs  # ty: ignore[unresolved-attribute]
+
+
+def model_spec_rhs(spec: ModelSpec) -> ModelSpec:
+    """Return the covariate spec of a two-sided sub-formula."""
+    # formulaic internal: see `model_spec_lhs`.
+    return spec.rhs  # ty: ignore[unresolved-attribute]
+
+
+def parsed_simple_formula(
+    expressions: Iterable[str], *, include_intercept: bool = False
+) -> formulaic.formula.SimpleFormula:
+    """Parse formula expressions into a flat formulaic formula."""
+    # formulaic internal: the `Formula` metaclass annotates `__call__` as
+    # returning the `Formula` base class; a flat list of expressions always
+    # parses into `SimpleFormula`, the only side that iterates over terms.
+    return cast(
+        "formulaic.formula.SimpleFormula",
+        formulaic.formula.Formula(
+            list(expressions),
+            _parser=DefaultFormulaParser(include_intercept=include_intercept),
+        ),
+    )
 
 
 def simple_formula(terms: Iterable[Any]) -> formulaic.formula.SimpleFormula:
@@ -131,7 +169,7 @@ def filter_multistage_endogenous_terms(
     )
 
 
-def flatten_model_matrix(model_matrix: formulaic.ModelMatrix) -> list[pd.DataFrame]:
+def flatten_model_matrix(model_matrix: AnyModelMatrix) -> list[pd.DataFrame]:
     """Return the leaf data frames from a possibly structured ModelMatrix."""
     # formulaic internal: `_flatten()` is private and its iteration order is
     # documented as unstable. Callers must not rely on the returned order.

--- a/pyfixest/estimation/formula/model_matrix.py
+++ b/pyfixest/estimation/formula/model_matrix.py
@@ -14,7 +14,11 @@ from numpy.typing import NDArray
 
 from pyfixest.core.detect_singletons import detect_singletons
 from pyfixest.estimation.formula import FORMULAIC_FEATURE_FLAG, FORMULAIC_TRANSFORMS
-from pyfixest.estimation.formula.formulaic_compat import flatten_model_matrix
+from pyfixest.estimation.formula.formulaic_compat import (
+    AnyModelMatrix,
+    flatten_model_matrix,
+    model_spec_lhs,
+)
 from pyfixest.estimation.formula.parse import Formula
 from pyfixest.estimation.formula.utils import _get_weights
 from pyfixest.utils.utils import capture_context
@@ -74,7 +78,7 @@ class ModelMatrix:
 
     def __init__(
         self,
-        model_matrix: formulaic.ModelMatrix,
+        model_matrix: AnyModelMatrix,
         drop_rows: frozenset[int],
         drop_singletons: bool = True,
         drop_intercept: bool = False,
@@ -87,7 +91,7 @@ class ModelMatrix:
         self._process(drop_singletons=drop_singletons)
 
     @staticmethod
-    def _get_columns(mm: formulaic.ModelMatrix, *keys: str) -> list[str] | None:
+    def _get_columns(mm: AnyModelMatrix, *keys: str) -> list[str] | None:
         """Extract column names by traversing nested keys, or None if missing."""
         try:
             result = mm
@@ -97,7 +101,7 @@ class ModelMatrix:
         except KeyError:
             return None
 
-    def _collect_columns(self, model_matrix: formulaic.ModelMatrix) -> None:
+    def _collect_columns(self, model_matrix: AnyModelMatrix) -> None:
         self._dependent = self._get_columns(model_matrix, _ModelMatrixKey.main, "lhs")
         self._independent = self._get_columns(model_matrix, _ModelMatrixKey.main, "rhs")
         self._fixed_effects = self._get_columns(
@@ -112,7 +116,7 @@ class ModelMatrix:
         self._weights = self._get_columns(model_matrix, _ModelMatrixKey.weights)
         self._offset = self._get_columns(model_matrix, _ModelMatrixKey.offset)
 
-    def _collect_data(self, model_matrix: formulaic.ModelMatrix) -> None:
+    def _collect_data(self, model_matrix: AnyModelMatrix) -> None:
         datas = flatten_model_matrix(model_matrix)
         if not all(datas[0].index.identical(other.index) for other in datas[1:]):
             raise ValueError("All design matrix data must have the same index.")
@@ -120,15 +124,15 @@ class ModelMatrix:
         self._data = data.loc[:, ~data.columns.duplicated()]
 
     def _process(self, drop_singletons: bool = False) -> None:
-        if self.model_spec[_ModelMatrixKey.main].lhs.factor_contrasts:
+        if model_spec_lhs(self.model_spec[_ModelMatrixKey.main]).factor_contrasts:
             raise TypeError("The dependent variable must be numeric.")
         elif self._dependent is None or len(self._dependent) != 1:
             raise TypeError("The model must contain exactly one dependent variable.")
 
         if self._endogenous is not None:
-            if self.model_spec[
-                _ModelMatrixKey.instrumental_variable
-            ].lhs.factor_contrasts:
+            if model_spec_lhs(
+                self.model_spec[_ModelMatrixKey.instrumental_variable]
+            ).factor_contrasts:
                 raise TypeError("The endogenous variable must be numeric.")
             elif len(self._endogenous) != 1:
                 raise TypeError(

--- a/pyfixest/estimation/formula/parse.py
+++ b/pyfixest/estimation/formula/parse.py
@@ -1,7 +1,7 @@
 import itertools
 from collections.abc import Iterator
 from dataclasses import dataclass
-from typing import Final
+from typing import Final, cast
 
 import formulaic
 import formulaic.formula
@@ -16,11 +16,14 @@ from pyfixest.errors import (
 )
 from pyfixest.estimation.formula import FORMULAIC_FEATURE_FLAG
 from pyfixest.estimation.formula.formulaic_compat import (
+    FormulaSide,
     count_multistage_blocks,
     filter_multistage_endogenous_terms,
+    formula_lhs,
+    formula_rhs,
     get_first_multistage_lhs,
     get_first_multistage_rhs,
-    is_structured_formula,
+    simple_formula,
     terms_without_intercept,
 )
 from pyfixest.estimation.formula.utils import (
@@ -149,54 +152,60 @@ class Formula:
     @property
     def _left_hand_side(self) -> formulaic.formula.SimpleFormula:
         """The left hand side of the formula."""
-        return self._formula.lhs
+        return formula_lhs(self._formula)
 
     @property
-    def _right_hand_side(self) -> formulaic.formula.SimpleFormula:
+    def _right_hand_side(self) -> FormulaSide:
         """The right hand side of the formula excluding fixed effects."""
+        right_hand_side = formula_rhs(self._formula)
         return (
-            self._formula.rhs[0]
-            if isinstance(self._formula.rhs, tuple)
-            else self._formula.rhs
+            right_hand_side[0]
+            if isinstance(right_hand_side, tuple)
+            else right_hand_side
         )
 
     @property
     def is_instrumental_variable(self) -> bool:
         """Boolean indicating whether the formula is an instrumental variable specification."""
-        return is_structured_formula(self._right_hand_side)
+        # formulaic parses an IV right hand side into a nested StructuredFormula
+        return isinstance(self._right_hand_side, formulaic.formula.StructuredFormula)
 
     @property
     def is_fixed_effects(self) -> bool:
         """Boolean indicating whether the formula is a fixed effects specification."""
         # A MULTIPART formula is a tuple of formulas on the right hand side
+        right_hand_side = formula_rhs(self._formula)
         return (
-            isinstance(self._formula.rhs, tuple)
-            and str(self._formula.rhs[-1]) not in ["", "0", "1"]  # ignore intercept
+            isinstance(right_hand_side, tuple)
+            and str(right_hand_side[-1]) not in ["", "0", "1"]  # ignore intercept
         )
 
     @property
-    def dependent(self) -> formulaic.formula.Formula:
+    def dependent(self) -> formulaic.formula.SimpleFormula:
         """The dependent variable."""
         return self._left_hand_side
 
     @property
-    def exogenous(self) -> formulaic.formula.Formula:
+    def exogenous(self) -> formulaic.formula.SimpleFormula:
         """Exogenous aka covariates aka independent variables."""
-        exogenous = self._right_hand_side
-        if self.is_instrumental_variable:
-            exogenous = filter_multistage_endogenous_terms(exogenous, self.endogenous)
+        right_hand_side = self._right_hand_side
+        exogenous = (
+            filter_multistage_endogenous_terms(right_hand_side, self.endogenous)
+            if isinstance(right_hand_side, formulaic.formula.StructuredFormula)
+            else right_hand_side
+        )
 
         exogenous_terms = tuple(terms_without_intercept(exogenous))
         if self.is_fixed_effects and exogenous_terms:
             # Drop the intercept for fixed effects regressions, except for
             # intercept-only specifications such as `Y ~ 1 | f1`; these can be
             # used to demean dependent variables.
-            exogenous = formulaic.formula.SimpleFormula(exogenous_terms)
+            exogenous = simple_formula(exogenous_terms)
 
         return exogenous
 
     @property
-    def endogenous(self) -> formulaic.formula.Formula:
+    def endogenous(self) -> formulaic.formula.SimpleFormula:
         """Endogenous variables of an instrumental variable specification."""
         if not self.is_instrumental_variable:
             raise AttributeError(
@@ -205,7 +214,7 @@ class Formula:
         return get_first_multistage_lhs(self._right_hand_side)
 
     @property
-    def instruments(self) -> formulaic.formula.Formula:
+    def instruments(self) -> formulaic.formula.SimpleFormula:
         """Instruments of an instrumental variable specification."""
         if not self.is_instrumental_variable:
             raise AttributeError(
@@ -214,13 +223,18 @@ class Formula:
         return get_first_multistage_rhs(self._right_hand_side)
 
     @property
-    def fixed_effects(self) -> formulaic.formula.Formula:
+    def fixed_effects(self) -> formulaic.formula.SimpleFormula:
         """The fixed effects of a formula."""
         if not self.is_fixed_effects:
             raise AttributeError("Not a fixed effects specification")
-        return formulaic.formula.SimpleFormula(
-            terms_without_intercept(self._formula.rhs[1])
+        # `is_fixed_effects` guarantees a MULTIPART right hand side, and
+        # formulaic nests an IV block only in its first part, so the
+        # fixed-effect part is always a flat list of terms.
+        parts = cast(
+            "tuple[FormulaSide, formulaic.formula.SimpleFormula]",
+            formula_rhs(self._formula),
         )
+        return simple_formula(terms_without_intercept(parts[1]))
 
     @property
     def fixed_effects_wrapped(self) -> formulaic.formula.Formula:
@@ -236,14 +250,14 @@ class Formula:
         right_hand_side = list(self.exogenous)
         if self.is_instrumental_variable:
             right_hand_side += list(self.endogenous)
-        return f"{self.dependent} ~ {formulaic.formula.SimpleFormula(right_hand_side)}"
+        return f"{self.dependent} ~ {simple_formula(right_hand_side)}"
 
     @property
     def first_stage(self) -> str:
         """The first stage formula of an instrumental variable specification."""
         if not self.is_instrumental_variable:
             raise TypeError("Not an instrumental variable specification.")
-        return f"{self.endogenous} ~ {formulaic.formula.SimpleFormula([term for term in itertools.chain(self.instruments, self.exogenous)])}"
+        return f"{self.endogenous} ~ {simple_formula(itertools.chain(self.instruments, self.exogenous))}"
 
     @classmethod
     def parse(cls, formula: str) -> list["Formula"]:

--- a/pyfixest/estimation/formula/parse.py
+++ b/pyfixest/estimation/formula/parse.py
@@ -23,6 +23,7 @@ from pyfixest.estimation.formula.formulaic_compat import (
     formula_rhs,
     get_first_multistage_lhs,
     get_first_multistage_rhs,
+    parsed_simple_formula,
     simple_formula,
     terms_without_intercept,
 )
@@ -237,11 +238,10 @@ class Formula:
         return simple_formula(terms_without_intercept(parts[1]))
 
     @property
-    def fixed_effects_wrapped(self) -> formulaic.formula.Formula:
+    def fixed_effects_wrapped(self) -> formulaic.formula.SimpleFormula:
         """Wrapped fixed effects for proper encoding."""
-        return formulaic.formula.Formula(
-            [f"__fixed_effect__{term.factors}" for term in self.fixed_effects],
-            _parser=DefaultFormulaParser(include_intercept=False),
+        return parsed_simple_formula(
+            f"__fixed_effect__{term.factors}" for term in self.fixed_effects
         )
 
     @property

--- a/pyfixest/estimation/formula/transforms/fixed_effects_encoding.py
+++ b/pyfixest/estimation/formula/transforms/fixed_effects_encoding.py
@@ -1,4 +1,4 @@
-from typing import Final
+from typing import Any, Final, cast
 
 import pandas as pd
 from formulaic.utils.stateful_transforms import stateful_transform
@@ -9,13 +9,16 @@ FIXED_EFFECT_ENCODING: Final[str] = "__fixed_effect_encoding__"
 @stateful_transform
 def encode_fixed_effects(*args, _state=None, _metadata=None, _spec=None):
     """Encode fixed effect interactions for model matrix construction."""
+    # formulaic's `stateful_transform` always injects the mutable state
+    # dictionary; the `None` default only keeps the plain signature valid.
+    state = cast("dict[str, Any]", _state)
     data = pd.concat(args, axis=1)
-    if FIXED_EFFECT_ENCODING not in _state:
+    if FIXED_EFFECT_ENCODING not in state:
         data[FIXED_EFFECT_ENCODING] = data.groupby(data.columns.tolist()).ngroup()
         encoded_state = data.dropna(subset=[FIXED_EFFECT_ENCODING]).drop_duplicates()
-        _state[FIXED_EFFECT_ENCODING] = encoded_state
+        state[FIXED_EFFECT_ENCODING] = encoded_state
         return data[FIXED_EFFECT_ENCODING]
 
     return data.merge(
-        _state[FIXED_EFFECT_ENCODING], on=data.columns.tolist(), how="left"
+        state[FIXED_EFFECT_ENCODING], on=data.columns.tolist(), how="left"
     )[FIXED_EFFECT_ENCODING]

--- a/pyfixest/estimation/internals/literals.py
+++ b/pyfixest/estimation/internals/literals.py
@@ -1,7 +1,10 @@
 from typing import Any, Literal, get_args
 
 PredictionType = Literal["response", "link"]
-VcovTypeOptions = Literal["iid", "hetero", "HC1", "HC2", "HC3", "nid"]
+# The `vcov` strings the estimation entries accept. "NW" and "DK" additionally
+# require `vcov_kwargs`; "nid" is quantile-regression only. Clustered inference
+# is requested as a `{"CRV1": ...}` mapping rather than a string.
+VcovTypeOptions = Literal["iid", "hetero", "HC1", "HC2", "HC3", "NW", "DK", "nid"]
 WeightsTypeOptions = Literal["aweights", "fweights"]
 FixedRmOptions = Literal["singleton", "none"]
 FamilyOptions = Literal["logit", "probit", "gaussian", "poisson"]

--- a/pyfixest/estimation/internals/separation.py
+++ b/pyfixest/estimation/internals/separation.py
@@ -4,12 +4,15 @@ import re
 import warnings
 from functools import partial
 from importlib import import_module
-from typing import Protocol
+from typing import TYPE_CHECKING, Protocol, cast
 
 import numpy as np
 import pandas as pd
 
 from pyfixest.demeaners import AnyDemeaner
+
+if TYPE_CHECKING:
+    from pyfixest.estimation.models.feols_ import Feols
 
 
 def check_for_separation(
@@ -238,7 +241,11 @@ def _check_for_separation_ir(
         iteration += 1
         # regress U on X
         # TODO: check acceleration in ppmlhdfe's implementation: https://github.com/sergiocorreia/ppmlhdfe/blob/master/src/ppmlhdfe_separation_relu.mata#L135
-        fitted = feols(fml_separation, data=tmp, weights="omega", demeaner=demeaner)
+        # A single formula without multiple estimation always fits one model.
+        fitted = cast(
+            "Feols",
+            feols(fml_separation, data=tmp, weights="omega", demeaner=demeaner),
+        )
         tmp["Uhat"] = pd.Series(
             data=fitted.predict(), index=fitted._data.index, name="Uhat"
         )

--- a/pyfixest/estimation/internals/vcov_utils.py
+++ b/pyfixest/estimation/internals/vcov_utils.py
@@ -40,7 +40,7 @@ def prepare_cluster_state(
     ssc_dict: dict,
     fixef: str | None,
     fe: pd.DataFrame | np.ndarray | None,
-    k_fe: np.ndarray | pd.Series,
+    k_fe: np.ndarray | pd.Series | None,
 ) -> ClusterPrep:
     "Build cluster_df, int-factorized cluster array, G, and nested-FE counts."
     cluster_df = _get_cluster_df(data=data, clustervar=clustervar)
@@ -60,8 +60,10 @@ def prepare_cluster_state(
     k_fe_nested = 0
     n_fe_fully_nested = 0
     if fixef is not None and ssc_dict["k_fixef"] == "nonnested":
-        if fe is None:
-            raise ValueError("`fe` must not be None when `fixef` is specified.")
+        if fe is None or k_fe is None:
+            raise ValueError(
+                "`fe` and `k_fe` must not be None when `fixef` is specified."
+            )
         k_fe_nested_flag, n_fe_fully_nested = count_fixef_fully_nested_all(
             all_fixef_array=np.array(fixef.split("+"), dtype=str),
             cluster_colnames=np.array(cluster_df.columns, dtype=str),

--- a/pyfixest/estimation/internals/vcov_utils.py
+++ b/pyfixest/estimation/internals/vcov_utils.py
@@ -15,7 +15,7 @@ from pyfixest.core.nw import (
     nw_meat_time as _nw_meat_time_rs,
 )
 from pyfixest.errors import NanInClusterVarError
-from pyfixest.utils.dev_utils import DataFrameType, _narwhals_to_pandas
+from pyfixest.utils.dev_utils import _narwhals_to_pandas
 from pyfixest.utils.utils import get_ssc
 
 
@@ -32,7 +32,10 @@ class ClusterPrep:
 
 def prepare_cluster_state(
     *,
-    data: DataFrameType,
+    # `_get_cluster_df` inspects `data.empty` and `_check_cluster_df` its shape,
+    # so the CRV path requires a pandas frame rather than any narwhals-native
+    # frame the public `vcov()` signature accepts.
+    data: pd.DataFrame,
     clustervar: list[str],
     ssc_dict: dict,
     fixef: str | None,

--- a/pyfixest/estimation/models/base_regression_.py
+++ b/pyfixest/estimation/models/base_regression_.py
@@ -7,7 +7,7 @@ from dataclasses import replace
 from functools import partial
 from importlib import import_module
 from types import MappingProxyType
-from typing import Any, ClassVar, Final, Literal, cast
+from typing import Any, ClassVar, Final, cast
 
 import numpy as np
 import pandas as pd
@@ -52,6 +52,8 @@ from pyfixest.estimation.internals.model_state import (
     WithinLinearData,
 )
 from pyfixest.estimation.internals.vcov_ import (
+    HacVcovTypeOptions,
+    HeteroVcovTypeOptions,
     vcov_crv1,
     vcov_hac,
     vcov_hetero,
@@ -1070,6 +1072,8 @@ class BaseRegression(TidyColumnAccessors):
 
     def _vcov_hetero(self):
         observation_weights = self._observation_weights.values
+        # `_deparse_vcov_input` maps exactly the four HC details onto the
+        # "hetero" family this method is dispatched for.
         return vcov_hetero(
             scores=self._scores,
             X=self._X,
@@ -1082,7 +1086,7 @@ class BaseRegression(TidyColumnAccessors):
             ),
             leverage_weights=self._leverage_weights(),
             weights_type=self._weights_type,
-            vcov_type_detail=self._vcov_type_detail,
+            vcov_type_detail=cast(HeteroVcovTypeOptions, self._vcov_type_detail),
             bread=self._bread,
             is_iv=self._is_iv,
             tXZ=self._tXZ,
@@ -1112,7 +1116,7 @@ class BaseRegression(TidyColumnAccessors):
             time_arr=_time_arr,
             panel_arr=_panel_arr,
             lag=cast(int | None, self._lag),
-            vcov_type_detail=cast(Literal["NW", "DK"], self._vcov_type_detail),
+            vcov_type_detail=cast(HacVcovTypeOptions, self._vcov_type_detail),
             bread=self._bread,
             is_iv=self._is_iv,
             tXZ=self._tXZ,

--- a/pyfixest/estimation/models/base_regression_.py
+++ b/pyfixest/estimation/models/base_regression_.py
@@ -135,7 +135,7 @@ class BaseRegression(TidyColumnAccessors):
         Whether the intercept is dropped from the design.
     weights : str or None
         Name of the observation-weight column, or None for an unweighted fit.
-    weights_type : str or None
+    weights_type : WeightsTypeOptions
         Either `"aweights"` for analytic or `"fweights"` for frequency weights.
     collin_tol : float
         Tolerance of the collinearity check on the within design.
@@ -308,7 +308,7 @@ class BaseRegression(TidyColumnAccessors):
         drop_singletons: bool,
         drop_intercept: bool,
         weights: str | None,
-        weights_type: str | None,
+        weights_type: WeightsTypeOptions,
         collin_tol: float,
         lookup_demeaned_data: dict[frozenset[int], DemeanedData],
         solver: SolverOptions = "np.linalg.solve",
@@ -569,10 +569,9 @@ class BaseRegression(TidyColumnAccessors):
             return ObservationWeights.unweighted(n_rows=n_rows)
 
         assert self._weights_type in ("aweights", "fweights")
-        weights_kind = cast(WeightsTypeOptions, self._weights_type)
         return ObservationWeights.from_values(
             self._model_matrix.weights.to_numpy().reshape(-1),
-            kind=weights_kind,
+            kind=self._weights_type,
         )
 
     def _prepare_within_data(self) -> WithinLinearData:
@@ -709,11 +708,7 @@ class BaseRegression(TidyColumnAccessors):
             is_iv=self._is_iv,
             has_fixef=self._has_fixef,
             has_weights=self._has_weights,
-            weights_kind=(
-                cast(WeightsTypeOptions, self._weights_type)
-                if self._has_weights
-                else None
-            ),
+            weights_kind=self._weights_type if self._has_weights else None,
             is_did=self._method in DID_METHOD_LABELS,
         )
 

--- a/pyfixest/estimation/models/base_regression_.py
+++ b/pyfixest/estimation/models/base_regression_.py
@@ -273,8 +273,10 @@ class BaseRegression(TidyColumnAccessors):
     _has_fixef: bool
     _has_weights: bool
     _coefnames: list[str]
+    _coefnames_z: list[str] | None
     _icovars: list[str] | None
-    _k_fe: pd.Series
+    # Levels per fixed effect, or None when the model has no fixed effects.
+    _k_fe: pd.Series | None
     _response: NDArray[np.float64]
     _observation_weights: ObservationWeights
     _within_data: WithinLinearData
@@ -507,9 +509,9 @@ class BaseRegression(TidyColumnAccessors):
 
         return model_matrix
 
-    # Deliberately untyped: an annotation makes mypy check this body, whose published
-    # attribute types are still transitional or loose; see the typing follow-up.
-    def _publish_model_matrix(self, model_matrix):
+    def _publish_model_matrix(
+        self, model_matrix: model_matrix_fixest.ModelMatrix
+    ) -> None:
         """Publish structurally immutable formula and observation-weight state."""
         self._model_matrix = model_matrix
         self._response = model_matrix.dependent.to_numpy(dtype=np.float64).flatten()
@@ -545,8 +547,8 @@ class BaseRegression(TidyColumnAccessors):
             else None
         )
 
-        self._k_fe = self._fe.nunique(axis=0) if self._has_fixef else None
-        self._n_fe = len(self._k_fe) if self._has_fixef else 0
+        self._k_fe = self._fe.nunique(axis=0) if self._fe is not None else None
+        self._n_fe = len(self._k_fe) if self._k_fe is not None else 0
 
         self._observation_weights = self._set_observation_weights()
         self._N = self._observation_weights.n_effective
@@ -579,8 +581,8 @@ class BaseRegression(TidyColumnAccessors):
             response, design, _ = self._demean_cache.demean_yx(
                 response,
                 design,
-                y_names=response_frame.columns,
-                x_names=design_frame.columns,
+                y_names=response_frame.columns.tolist(),
+                x_names=design_frame.columns.tolist(),
                 fe=self._model_matrix.fixed_effects.to_numpy(),
                 weights=self._observation_weights.values,
                 na_index=self._na_index,
@@ -1010,7 +1012,7 @@ class BaseRegression(TidyColumnAccessors):
             "ssc_dict": self._ssc_dict,
             "N": self._N,
             "k": self._k,
-            "k_fe": self._k_fe.sum() if self._has_fixef else 0,
+            "k_fe": self._k_fe.sum() if self._k_fe is not None else 0,
             "n_fe": self._n_fe,
             "vcov_type": vcov_type,
             "G": G,
@@ -1281,7 +1283,7 @@ class BaseRegression(TidyColumnAccessors):
 
         has_intercept = not self._drop_intercept
 
-        if self._has_fixef:
+        if self._k_fe is not None:
             k_fe = np.sum(self._k_fe - 1) + 1
             adj_factor = (self._N - has_intercept) / (self._N - self._k - k_fe)
             adj_factor_within = (self._N - k_fe) / (self._N - self._k - k_fe)
@@ -1634,7 +1636,7 @@ class BaseRegression(TidyColumnAccessors):
         print(f"Python p_stat: {p_stat}")
         ```
         """
-        k_fe = np.sum(self._k_fe.values) if self._has_fixef else 0
+        k_fe = np.sum(self._k_fe.values) if self._k_fe is not None else 0
 
         # If R is None, default to the identity matrix
         R = np.eye(self._k) if R is None else np.atleast_2d(np.asarray(R, dtype=float))

--- a/pyfixest/estimation/models/base_regression_.py
+++ b/pyfixest/estimation/models/base_regression_.py
@@ -31,6 +31,7 @@ from pyfixest.estimation.formula import FORMULAIC_TRANSFORMS
 from pyfixest.estimation.formula import model_matrix as model_matrix_fixest
 from pyfixest.estimation.formula.formulaic_compat import (
     materialize_model_spec_with_unseen_mask,
+    model_spec_rhs,
 )
 from pyfixest.estimation.formula.model_matrix import _ModelMatrixKey
 from pyfixest.estimation.formula.parse import Formula as FixestFormula
@@ -1915,7 +1916,7 @@ class BaseRegression(TidyColumnAccessors):
             # Use na_action="drop" on each sub-spec separately because dependent variable
             # may not be available in newdata, then intersect indices so a NaN in *any* variable
             # (covariate or FE) marks the whole row as NaN in the output.
-            rhs_spec = self._model_spec[_ModelMatrixKey.main].rhs
+            rhs_spec = model_spec_rhs(self._model_spec[_ModelMatrixKey.main])
             X_mm, unseen = materialize_model_spec_with_unseen_mask(
                 rhs_spec, newdata, context
             )

--- a/pyfixest/estimation/models/base_regression_.py
+++ b/pyfixest/estimation/models/base_regression_.py
@@ -74,6 +74,7 @@ from pyfixest.estimation.post_estimation.fixed_effects import (
 )
 from pyfixest.estimation.post_estimation.prediction import _compute_prediction_error
 from pyfixest.estimation.post_estimation.wald import _wald_statistic
+from pyfixest.estimation.protocols import FittedResult
 from pyfixest.utils.dev_utils import (
     DataFrameType,
     _narwhals_to_pandas,
@@ -474,21 +475,24 @@ class BaseRegression(TidyColumnAccessors):
     def _bind_report_methods(self):
         """Bind summary, coefplot, iplot, and etable from pyfixest.report as instance methods."""
         _module = import_module("pyfixest.report")
+        # The report entries take the models to report on; every binding here
+        # reports on this result alone. They copy the sequence before use.
+        models: list[FittedResult] = [self]
 
         _tmp = _module.summary
-        self.summary = functools.partial(_tmp, models=[self])
+        self.summary = functools.partial(_tmp, models=models)
         self.summary.__doc__ = _tmp.__doc__
 
         _tmp = _module.coefplot
-        self.coefplot = functools.partial(_tmp, models=[self])
+        self.coefplot = functools.partial(_tmp, models=models)
         self.coefplot.__doc__ = _tmp.__doc__
 
         _tmp = _module.iplot
-        self.iplot = functools.partial(_tmp, models=[self])
+        self.iplot = functools.partial(_tmp, models=models)
         self.iplot.__doc__ = _tmp.__doc__
 
         _tmp = _module.etable
-        self.etable = functools.partial(_tmp, models=[self])
+        self.etable = functools.partial(_tmp, models=models)
         self.etable.__doc__ = _tmp.__doc__
 
     def prepare_model_matrix(self):

--- a/pyfixest/estimation/models/fegaussian_.py
+++ b/pyfixest/estimation/models/fegaussian_.py
@@ -8,6 +8,7 @@ from pyfixest.demeaners import AnyDemeaner
 from pyfixest.estimation.formula.parse import Formula as FixestFormula
 from pyfixest.estimation.internals.demean_ import DemeanedData
 from pyfixest.estimation.internals.families import GAUSSIAN
+from pyfixest.estimation.internals.literals import WeightsTypeOptions
 from pyfixest.estimation.internals.vcov_ import vcov_iid_ols
 from pyfixest.estimation.models.feglm_ import Feglm
 
@@ -23,7 +24,7 @@ class Fegaussian(Feglm):
         drop_singletons: bool,
         drop_intercept: bool,
         weights: str | None,
-        weights_type: str | None,
+        weights_type: WeightsTypeOptions,
         collin_tol: float,
         lookup_demeaned_data: dict[frozenset[int], DemeanedData],
         tol: float,

--- a/pyfixest/estimation/models/feglm_.py
+++ b/pyfixest/estimation/models/feglm_.py
@@ -20,7 +20,7 @@ from pyfixest.estimation.formula.parse import Formula as FixestFormula
 from pyfixest.estimation.internals.demean_ import DemeanedData
 from pyfixest.estimation.internals.families import GlmFamily
 from pyfixest.estimation.internals.fit_glm_ import fit_glm_irls
-from pyfixest.estimation.internals.literals import EstimatorKind
+from pyfixest.estimation.internals.literals import EstimatorKind, WeightsTypeOptions
 from pyfixest.estimation.internals.separation import check_for_separation
 from pyfixest.estimation.internals.vcov_ import vcov_iid_glm
 from pyfixest.estimation.models.base_regression_ import BaseRegression
@@ -77,7 +77,7 @@ class Feglm(BaseRegression):
         drop_singletons: bool,
         drop_intercept: bool,
         weights: str | None,
-        weights_type: str | None,
+        weights_type: WeightsTypeOptions,
         collin_tol: float,
         lookup_demeaned_data: dict[frozenset[int], DemeanedData],
         tol: float,

--- a/pyfixest/estimation/models/feglm_.py
+++ b/pyfixest/estimation/models/feglm_.py
@@ -168,7 +168,7 @@ class Feglm(BaseRegression):
 
             self.n_separation_na = len(na_separation)
             # possible to have dropped fixed effects level due to separation
-            self._n_fe = np.sum(self._k_fe > 1) if self._has_fixef else 0
+            self._n_fe = np.sum(self._k_fe > 1) if self._k_fe is not None else 0
 
         return model_matrix
 
@@ -377,7 +377,7 @@ class Feglm(BaseRegression):
 
     def _check_dependent_variable(self) -> None:
         "Validate the dependent variable according to the family's constraints."
-        self._family.check_y(self._model_matrix.dependent)
+        self._family.check_y(self._model_matrix.dependent.to_numpy())
 
     def _validate_response(self) -> None:
         """Apply family-specific response validation after matrix preparation."""

--- a/pyfixest/estimation/models/feiv_.py
+++ b/pyfixest/estimation/models/feiv_.py
@@ -4,7 +4,7 @@ import warnings
 from collections.abc import Mapping
 from dataclasses import replace
 from importlib import import_module
-from typing import Any, ClassVar, Literal
+from typing import Any, ClassVar, Literal, cast
 
 import numpy as np
 import pandas as pd
@@ -22,7 +22,10 @@ from pyfixest.estimation.formula.parse import Formula as FixestFormula
 from pyfixest.estimation.internals.collinearity import drop_multicollinear_variables
 from pyfixest.estimation.internals.demean_ import DemeanedData
 from pyfixest.estimation.internals.fit_ import fit_iv
-from pyfixest.estimation.internals.literals import WeightsTypeOptions
+from pyfixest.estimation.internals.literals import (
+    VcovTypeOptions,
+    WeightsTypeOptions,
+)
 from pyfixest.estimation.internals.model_state import WithinLinearData
 from pyfixest.estimation.models.feols_ import Feols
 
@@ -336,14 +339,15 @@ class Feiv(Feols):
         if self._has_fixef and fml_first_stage is not None:
             fml_first_stage += f" | {self._fixef}"
 
-        # Type hint to reflect that vcov_detail can be either a dict or a str
-        vcov_detail: dict[str, str] | str
+        # The first stage replays the second stage's inference request, which
+        # `feols` validates again at its own boundary.
+        vcov_detail: dict[str, str] | VcovTypeOptions
 
         if self._is_clustered:
             a = self._clustervar[0]
             vcov_detail = {self._vcov_type_detail: a}
         else:
-            vcov_detail = self._vcov_type_detail
+            vcov_detail = cast(VcovTypeOptions, self._vcov_type_detail)
 
         demeaner = self._demeaner
         cached_pre = self._demean_cache.lookup_preconditioner.get(self._na_index)

--- a/pyfixest/estimation/models/feiv_.py
+++ b/pyfixest/estimation/models/feiv_.py
@@ -22,6 +22,7 @@ from pyfixest.estimation.formula.parse import Formula as FixestFormula
 from pyfixest.estimation.internals.collinearity import drop_multicollinear_variables
 from pyfixest.estimation.internals.demean_ import DemeanedData
 from pyfixest.estimation.internals.fit_ import fit_iv
+from pyfixest.estimation.internals.literals import WeightsTypeOptions
 from pyfixest.estimation.internals.model_state import WithinLinearData
 from pyfixest.estimation.models.feols_ import Feols
 
@@ -60,7 +61,7 @@ class Feiv(Feols):
         Resolved typed demeaner configuration.
     weights_name : Optional[str]
         Name of the weights variable.
-    weights_type : Optional[str]
+    weights_type : WeightsTypeOptions
         Type of the weights variable. Either "aweights" for analytic weights
         or "fweights" for frequency weights.
 
@@ -190,7 +191,7 @@ class Feiv(Feols):
         drop_singletons: bool,
         drop_intercept: bool,
         weights: str | None,
-        weights_type: str | None,
+        weights_type: WeightsTypeOptions,
         collin_tol: float,
         lookup_demeaned_data: dict[frozenset[int], DemeanedData],
         solver: Literal[

--- a/pyfixest/estimation/models/feiv_.py
+++ b/pyfixest/estimation/models/feiv_.py
@@ -245,8 +245,8 @@ class Feiv(Feols):
             endogenous, instruments, _ = self._demean_cache.demean_yx(
                 endogenous,
                 instruments,
-                y_names=endogenous_frame.columns,
-                x_names=instrument_frame.columns,
+                y_names=endogenous_frame.columns.tolist(),
+                x_names=instrument_frame.columns.tolist(),
                 fe=self._model_matrix.fixed_effects.to_numpy(),
                 weights=self._observation_weights.values,
                 na_index=self._na_index,
@@ -318,6 +318,10 @@ class Feiv(Feols):
     def first_stage(self) -> None:
         """Implement First stage regression."""
         self._require_estimation_data("first_stage")
+
+        # An IV formula always produces instrument names; the base class keeps
+        # them optional because non-IV models have none.
+        assert self._coefnames_z is not None
 
         # Store names of instruments from Z matrix
         self._non_exo_instruments = list(set(self._coefnames_z) - set(self._coefnames))
@@ -528,6 +532,7 @@ class Feiv(Feols):
         iv_diag_statistics = iv_diag_statistics or []
 
         self._require_first_stage_state("IV_weakness_test")
+        assert self._coefnames_z is not None
 
         if "f_stat" in iv_diag_statistics:
             self._p_iv = len(self._non_exo_instruments)
@@ -562,6 +567,7 @@ class Feiv(Feols):
     def eff_F(self) -> None:
         """Compute Effective F stat (Olea and Pflueger 2013)."""
         self._require_first_stage_state("eff_F")
+        assert self._coefnames_z is not None
 
         # If vcov is iid, redo first stage regression
 

--- a/pyfixest/estimation/models/felogit_.py
+++ b/pyfixest/estimation/models/felogit_.py
@@ -8,6 +8,7 @@ from pyfixest.demeaners import AnyDemeaner
 from pyfixest.estimation.formula.parse import Formula as FixestFormula
 from pyfixest.estimation.internals.demean_ import DemeanedData
 from pyfixest.estimation.internals.families import LOGIT
+from pyfixest.estimation.internals.literals import WeightsTypeOptions
 from pyfixest.estimation.models.feglm_ import Feglm
 
 
@@ -22,7 +23,7 @@ class Felogit(Feglm):
         drop_singletons: bool,
         drop_intercept: bool,
         weights: str | None,
-        weights_type: str | None,
+        weights_type: WeightsTypeOptions,
         collin_tol: float,
         lookup_demeaned_data: dict[frozenset[int], DemeanedData],
         tol: float,

--- a/pyfixest/estimation/models/feols_.py
+++ b/pyfixest/estimation/models/feols_.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 import re
 import warnings
 from importlib import import_module
-from typing import Any, ClassVar, Literal, cast
+from typing import Any, ClassVar, Literal, cast, overload
 
 import formulaic
 import numpy as np
 import pandas as pd
-from scipy.sparse import csc_matrix, spmatrix
+from scipy.sparse import csc_matrix
 from scipy.stats import t
 
 from pyfixest.estimation.capabilities import (
@@ -201,11 +201,16 @@ class Feols(BaseRegression):
         """Replay OLS for one leave-one-cluster-out sample."""
         # lazy loading to avoid circular import
         fixest_module = import_module("pyfixest.estimation")
-        return fixest_module.feols(
-            fml=self._fml,
-            data=data,
-            vcov="iid",
-            **self._estimation_refit_kwargs(),
+        # A fitted result carries the expanded single formula and the refit
+        # passes no split, so this never returns a multiple-estimation object.
+        return cast(
+            "Feols",
+            fixest_module.feols(
+                fml=self._fml,
+                data=data,
+                vcov="iid",
+                **self._estimation_refit_kwargs(),
+            ),
         )
 
     def wildboottest(
@@ -213,13 +218,13 @@ class Feols(BaseRegression):
         reps: int,
         cluster: str | None = None,
         param: str | None = None,
-        weights_type: str | None = "rademacher",
-        impose_null: bool | None = True,
-        bootstrap_type: str | None = "11",
+        weights_type: str = "rademacher",
+        impose_null: bool = True,
+        bootstrap_type: str = "11",
         seed: int | None = None,
-        k_adj: bool | None = True,
-        G_adj: bool | None = True,
-        parallel: bool | None = False,
+        k_adj: bool = True,
+        G_adj: bool = True,
+        parallel: bool = False,
         return_bootstrapped_t_stats=False,
     ):
         """
@@ -359,6 +364,7 @@ class Feols(BaseRegression):
             boot.get_tstat()
             boot.get_pvalue(pval_type="two-tailed")
             full_enumeration_warn = False
+            small_sample_correction = boot.small_sample_correction
 
         else:
             inference = f"CRV({cluster_list[0]})"
@@ -387,6 +393,7 @@ class Feols(BaseRegression):
             boot.get_vcov()
             boot.get_tstat()
             boot.get_pvalue(pval_type="two-tailed")
+            small_sample_correction = boot.ssc
 
             if full_enumeration_warn:
                 warnings.warn(
@@ -405,7 +412,7 @@ class Feols(BaseRegression):
             "bootstrap_type": bootstrap_type,
             "inference": inference,
             "impose_null": impose_null,
-            "ssc": boot.small_sample_correction if run_heteroskedastic else boot.ssc,
+            "ssc": small_sample_correction,
         }
 
         res_df = pd.Series(res)
@@ -520,7 +527,7 @@ class Feols(BaseRegression):
         cluster_vec = data[cluster].to_numpy()
         unique_clusters = np.unique(cluster_vec)
 
-        tau_full = np.array(self.coef().xs(treatment))
+        tau_full = float(self.coef().xs(treatment))
 
         N = self._N
         G = len(unique_clusters)
@@ -579,9 +586,19 @@ class Feols(BaseRegression):
 
         return pd.concat([res_ccv, res_crv1], axis=1).T
 
+    @overload
     def _model_matrix_one_hot(
-        self, output="numpy"
-    ) -> tuple[np.ndarray, np.ndarray | spmatrix, list[str]]:
+        self, output: Literal["numpy"] = "numpy"
+    ) -> tuple[np.ndarray, np.ndarray, list[str]]: ...
+
+    @overload
+    def _model_matrix_one_hot(
+        self, output: Literal["sparse"]
+    ) -> tuple[np.ndarray, csc_matrix, list[str]]: ...
+
+    def _model_matrix_one_hot(
+        self, output: Literal["numpy", "sparse"] = "numpy"
+    ) -> tuple[np.ndarray, np.ndarray | csc_matrix, list[str]]:
         """
         Transform a model matrix with fixed effects into a one-hot encoded matrix.
 

--- a/pyfixest/estimation/models/fepois_.py
+++ b/pyfixest/estimation/models/fepois_.py
@@ -23,6 +23,7 @@ from pyfixest.estimation.internals.families import POISSON
 from pyfixest.estimation.internals.literals import (
     EstimatorKind,
     SolverOptions,
+    WeightsTypeOptions,
 )
 from pyfixest.estimation.models.feglm_ import Feglm
 
@@ -80,7 +81,7 @@ class Fepois(Feglm):
         variables that need to be available in the formula environment.
     weights_name : Optional[str]
         Name of the weights variable.
-    weights_type : Optional[str]
+    weights_type : WeightsTypeOptions
         Type of weights variable.
     _data: pd.DataFrame
         The data frame used in the estimation. Deleted if arguments `lean = True`
@@ -129,7 +130,7 @@ class Fepois(Feglm):
         drop_singletons: bool,
         drop_intercept: bool,
         weights: str | None,
-        weights_type: str | None,
+        weights_type: WeightsTypeOptions,
         collin_tol: float,
         lookup_demeaned_data: dict[frozenset[int], DemeanedData],
         tol: float,

--- a/pyfixest/estimation/models/fepois_.py
+++ b/pyfixest/estimation/models/fepois_.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from importlib import import_module
-from typing import Any, ClassVar
+from typing import Any, ClassVar, cast
 
 import numpy as np
 import pandas as pd
@@ -244,11 +244,16 @@ class Fepois(Feglm):
         """Replay Poisson estimation for one leave-one-cluster-out sample."""
         # lazy loading to avoid circular import
         fixest_module = import_module("pyfixest.estimation")
-        return fixest_module.fepois(
-            fml=self._fml,
-            data=data,
-            vcov="iid",
-            **self._estimation_refit_kwargs(),
+        # A fitted result carries the expanded single formula and the refit
+        # passes no split, so this never returns a multiple-estimation object.
+        return cast(
+            "Fepois",
+            fixest_module.fepois(
+                fml=self._fml,
+                data=data,
+                vcov="iid",
+                **self._estimation_refit_kwargs(),
+            ),
         )
 
     def _clear_attributes(self) -> None:

--- a/pyfixest/estimation/models/feprobit_.py
+++ b/pyfixest/estimation/models/feprobit_.py
@@ -8,6 +8,7 @@ from pyfixest.demeaners import AnyDemeaner
 from pyfixest.estimation.formula.parse import Formula as FixestFormula
 from pyfixest.estimation.internals.demean_ import DemeanedData
 from pyfixest.estimation.internals.families import PROBIT
+from pyfixest.estimation.internals.literals import WeightsTypeOptions
 from pyfixest.estimation.models.feglm_ import Feglm
 
 
@@ -22,7 +23,7 @@ class Feprobit(Feglm):
         drop_singletons: bool,
         drop_intercept: bool,
         weights: str | None,
-        weights_type: str | None,
+        weights_type: WeightsTypeOptions,
         collin_tol: float,
         lookup_demeaned_data: dict[frozenset[int], DemeanedData],
         tol: float,

--- a/pyfixest/estimation/numba/demean_nb.py
+++ b/pyfixest/estimation/numba/demean_nb.py
@@ -77,7 +77,9 @@ def demean(
     x_prev = np.empty((n_threads, n_samples), dtype=x.dtype)
 
     not_converged = 0
-    for k in nb.prange(n_features):
+    # numba's `prange` is a marker class whose `__new__` returns a plain
+    # `range` outside nopython mode, which static type checkers cannot see.
+    for k in nb.prange(n_features):  # ty: ignore[not-iterable]
         tid = nb.get_thread_id()
 
         xk_curr = x_curr[tid, :]

--- a/pyfixest/estimation/numba/nested_fixef_nb.py
+++ b/pyfixest/estimation/numba/nested_fixef_nb.py
@@ -35,7 +35,9 @@ def _count_fixef_fully_nested_all(
     k_fe_nested_flag = np.zeros(all_fixef_array.size, dtype=np.bool_)
     n_fe_fully_nested = 0
 
-    for fi in nb.prange(all_fixef_array.size):
+    # numba's `prange` is a marker class whose `__new__` returns a plain
+    # `range` outside nopython mode, which static type checkers cannot see.
+    for fi in nb.prange(all_fixef_array.size):  # ty: ignore[not-iterable]
         this_fe_name = all_fixef_array[fi]
 
         found_in_cluster = False

--- a/pyfixest/estimation/post_estimation/ccv.py
+++ b/pyfixest/estimation/post_estimation/ccv.py
@@ -78,7 +78,7 @@ def _compute_CCV(
             aux_tau_full = tau_full
         else:
             fit_m_full = feols(fml, data[ind_m], demeaner=demeaner)
-            aux_tau_full = float(fit_m_full.coef().xs(treatment))  # type: ignore[arg-type]
+            aux_tau_full = float(fit_m_full.coef().xs(treatment))
 
         # treatment effect in cluster for subsample
         if treatment_nested_in_cluster_split:

--- a/pyfixest/estimation/post_estimation/decomposition.py
+++ b/pyfixest/estimation/post_estimation/decomposition.py
@@ -1,15 +1,21 @@
 import itertools
 import warnings
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, TypeAlias, cast
 
 import numpy as np
 import pandas as pd
 from joblib import Parallel, delayed
 from numpy.typing import NDArray
-from scipy.sparse import diags, hstack, spmatrix, vstack
+from pandas.api.extensions import ExtensionArray
+from scipy.sparse import csc_matrix, csr_matrix, diags, hstack, spmatrix, vstack
 from scipy.sparse.linalg import lsqr
 from tqdm import tqdm
+
+# scipy's `spmatrix` only carries the matrix-semantics mixin: indexing,
+# `.multiply()` and the format converters live on the concrete classes. The
+# decomposition builds and consumes compressed matrices throughout.
+CompressedMatrix: TypeAlias = csc_matrix | csr_matrix
 
 # Panel name mappings for consistent API
 PANEL_ALIASES = {
@@ -164,7 +170,9 @@ class GelbachDecomposition:
 
     # Define attributes initialized post-creation
     cluster_dict: dict[Any, Any] | None = field(init=False, default=None)
-    unique_clusters: np.ndarray | None = field(init=False, default=None)
+    unique_clusters: np.ndarray | ExtensionArray | None = field(
+        init=False, default=None
+    )
     mask: np.ndarray = field(init=False)
     mediator_names: list[str] = field(init=False)
     X_dict: dict[Any, Any] = field(init=False, default_factory=dict)
@@ -190,10 +198,11 @@ class GelbachDecomposition:
 
         # Handle clustering setup if cluster_df is provided
         if self.cluster_df is not None and not self.only_coef:
-            self.unique_clusters = self.cluster_df.unique()
+            unique_clusters = self.cluster_df.unique()
+            self.unique_clusters = unique_clusters
             self.cluster_dict = {
                 cluster: self.cluster_df[self.cluster_df == cluster].index
-                for cluster in self.unique_clusters
+                for cluster in unique_clusters
             }
         else:
             self.unique_clusters = None
@@ -268,7 +277,7 @@ class GelbachDecomposition:
 
     def fit(
         self,
-        X: spmatrix,
+        X: CompressedMatrix,
         Y: np.ndarray,
         weights: np.ndarray | None = None,
         store: bool = True,
@@ -437,8 +446,11 @@ class GelbachDecomposition:
     def _bootstrap(self, rng: np.random.Generator):
         "Run a single bootstrap iteration."
         if self.unique_clusters is not None:
+            # A pandas ExtensionArray is an array-like the generator samples
+            # from, but numpy does not type its overloads for it.
+            unique_clusters = cast("np.ndarray", self.unique_clusters)
             idx_clusters = rng.choice(
-                self.unique_clusters, len(self.unique_clusters), replace=True
+                unique_clusters, len(unique_clusters), replace=True
             ).tolist()
 
             X = vstack([self.X_dict[g].tocsr() for g in idx_clusters])
@@ -454,7 +466,7 @@ class GelbachDecomposition:
     def compute_gelbach(
         self,
         X1: spmatrix,
-        X2: spmatrix,
+        X2: CompressedMatrix,
         Y: np.ndarray,
         X: spmatrix,
         agg_first: bool | None,

--- a/pyfixest/estimation/post_estimation/fixed_effects.py
+++ b/pyfixest/estimation/post_estimation/fixed_effects.py
@@ -313,12 +313,15 @@ def contrast_code_fixed_effects(
         context=context,
         transform_state=transform_state,
     )
+    # An unstructured formula always materializes into a single `ModelMatrix`,
+    # which carries the `ModelSpec` recorded during materialization.
+    model_spec = cast(ModelSpec, matrix.model_spec)
     coefficient_positions: dict[str, FixedEffectCoefficientPositions] = {}
     for fixed_effect_name, term in zip(
-        fixed_effect_names, matrix.model_spec.terms, strict=True
+        fixed_effect_names, model_spec.terms, strict=True
     ):
         coefficient_positions[fixed_effect_name] = (
-            get_fixed_effect_coefficient_positions(term, matrix.model_spec)
+            get_fixed_effect_coefficient_positions(term, model_spec)
         )
 
     return FixedEffectContrastCoding(

--- a/pyfixest/estimation/post_estimation/fixed_effects.py
+++ b/pyfixest/estimation/post_estimation/fixed_effects.py
@@ -13,7 +13,7 @@ from formulaic import ModelSpec
 from formulaic.parser import DefaultFormulaParser
 from formulaic.parser.types import Term
 from numpy._typing import NDArray
-from scipy.sparse import spmatrix
+from scipy.sparse import csc_matrix
 
 from pyfixest.estimation.formula.formulaic_compat import (
     FormulaicCompatibilityError,
@@ -88,14 +88,14 @@ class FixedEffectContrastCoding:
 
     Attributes
     ----------
-    matrix : spmatrix
+    matrix : csc_matrix
         Sparse one-hot encoded fixed-effect matrix used to estimate coefficients.
     coefficient_positions : Mapping[str, FixedEffectCoefficientPositions]
         Observed and retained codes with their positions in the complete
         coefficient vector, keyed by fixed effect.
     """
 
-    matrix: spmatrix
+    matrix: csc_matrix
     coefficient_positions: Mapping[str, FixedEffectCoefficientPositions]
 
 
@@ -325,6 +325,6 @@ def contrast_code_fixed_effects(
         )
 
     return FixedEffectContrastCoding(
-        matrix=cast(scipy.sparse.spmatrix, matrix),
+        matrix=cast(scipy.sparse.csc_matrix, matrix),
         coefficient_positions=coefficient_positions,
     )

--- a/pyfixest/estimation/post_estimation/multcomp.py
+++ b/pyfixest/estimation/post_estimation/multcomp.py
@@ -5,12 +5,8 @@ import numpy as np
 import pandas as pd
 from scipy.stats import t
 
-from pyfixest.estimation.FixestMulti_ import FixestMulti
 from pyfixest.estimation.models.feols_ import Feols
-from pyfixest.estimation.protocols import FittedResult
-from pyfixest.report.utils import _post_processing_input_checks
-
-ModelInputType = FixestMulti | FittedResult | list[FittedResult]
+from pyfixest.report.utils import ModelInputType, _post_processing_input_checks
 
 
 def bonferroni(models: ModelInputType, param: str) -> pd.DataFrame:

--- a/pyfixest/estimation/post_estimation/ritest.py
+++ b/pyfixest/estimation/post_estimation/ritest.py
@@ -1,30 +1,38 @@
 from importlib import import_module
+from typing import Any
 
 import numpy as np
 import pandas as pd
 from scipy.stats import norm
 from tqdm import tqdm
 
-# Numba is an optional dependency. The fast randomization-inference path uses it;
-# the slow path does not. We import lazily so the module loads cleanly even when
-# numba is not installed, and surface a clear error only when the fast path is
-# actually requested.
-try:
-    import numba as nb
-
-    from pyfixest.estimation.numba.demean_nb import demean
-
-    _HAS_NUMBA = True
-except ImportError:
-    nb = None
-    demean = None
-    _HAS_NUMBA = False
-
 _NUMBA_RITEST_ERROR = (
     "Fast randomization inference requires the optional `numba` extra. "
     "Install it with `pip install pyfixest[numba]`, or pass "
     "`choose_algorithm='slow'`."
 )
+
+
+def _import_numba() -> tuple[Any, Any]:
+    """Return `(numba, demean)`, or `(None, None)` without the numba extra.
+
+    Numba is an optional dependency. The fast randomization-inference path uses
+    it; the slow path does not. Importing it here keeps the module loadable
+    without the extra and defers the error to the fast path, which raises
+    `_NUMBA_RITEST_ERROR`. Neither numba nor its jitted kernels carry usable
+    static types, so both are returned untyped.
+    """
+    try:
+        import numba
+
+        from pyfixest.estimation.numba.demean_nb import demean
+    except ImportError:
+        return None, None
+    return numba, demean
+
+
+nb, demean = _import_numba()
+_HAS_NUMBA = nb is not None
 
 
 def _get_ritest_stats_slow(
@@ -425,7 +433,7 @@ def _plot_ritest_pvalue(
 
         plt.figure(figsize=(10, 6))
         sns.kdeplot(data=df, x="ri_stats", fill=True, color="blue", alpha=0.5)
-        plt.axvline(x=sample_stat, color="red", linestyle="--")
+        plt.axvline(x=float(sample_stat), color="red", linestyle="--")
         plt.title(title)
         plt.xlabel(x_lab)
         plt.ylabel(y_lab)

--- a/pyfixest/estimation/quantreg/QuantregMulti.py
+++ b/pyfixest/estimation/quantreg/QuantregMulti.py
@@ -16,6 +16,7 @@ from pyfixest.estimation.internals.literals import (
     QuantregMethodOptions,
     QuantregMultiOptions,
     SolverOptions,
+    WeightsTypeOptions,
 )
 from pyfixest.estimation.quantreg.quantreg_ import Quantreg
 from pyfixest.estimation.quantreg.utils import get_hall_sheather_bandwidth
@@ -34,7 +35,7 @@ class QuantregMulti:
         drop_singletons: bool,
         drop_intercept: bool,
         weights: str | None,
-        weights_type: str | None,
+        weights_type: WeightsTypeOptions,
         collin_tol: float,
         lookup_demeaned_data: dict[frozenset[int], DemeanedData],
         solver: SolverOptions = "np.linalg.solve",

--- a/pyfixest/estimation/quantreg/frisch_newton_ip.py
+++ b/pyfixest/estimation/quantreg/frisch_newton_ip.py
@@ -30,7 +30,13 @@ def _solve_ADAt(
     K = W @ W.T
 
     u_buf = u.copy()
-    lapack.dposv(K, u_buf, lower=1, overwrite_a=True, overwrite_b=True)
+    # scipy internal: `scipy.linalg.lapack` generates its wrappers at import
+    # time from the compiled LAPACK library, so none of them are visible to a
+    # type checker. `dposv` is the Cholesky solve for a symmetric positive
+    # definite system, which is what the normal equations produce here.
+    lapack.dposv(  # ty: ignore[unresolved-attribute]
+        K, u_buf, lower=1, overwrite_a=True, overwrite_b=True
+    )
     y = solve_triangular(chol.T, u_buf, lower=False, check_finite=False)
 
     # S = np.linalg.cholesky(K)

--- a/pyfixest/estimation/quantreg/quantreg_.py
+++ b/pyfixest/estimation/quantreg/quantreg_.py
@@ -15,6 +15,7 @@ from pyfixest.estimation.internals.literals import (
     EstimatorKind,
     QuantregMethodOptions,
     SolverOptions,
+    WeightsTypeOptions,
 )
 from pyfixest.estimation.models.base_regression_ import BaseRegression
 from pyfixest.estimation.quantreg.frisch_newton_ip import (
@@ -87,7 +88,7 @@ class Quantreg(BaseRegression):
         drop_singletons: bool,
         drop_intercept: bool,
         weights: str | None,
-        weights_type: str | None,
+        weights_type: WeightsTypeOptions,
         collin_tol: float,
         lookup_demeaned_data: dict[frozenset[int], DemeanedData],
         solver: SolverOptions = "np.linalg.solve",

--- a/pyfixest/estimation/quantreg/utils.py
+++ b/pyfixest/estimation/quantreg/utils.py
@@ -1,7 +1,7 @@
 from scipy.stats import norm
 
 
-def get_hall_sheather_bandwidth(q: float, N: int, alpha: float = 0.05) -> float:
+def get_hall_sheather_bandwidth(q: float, N: int | float, alpha: float = 0.05) -> float:
     "Compute the Hall-Sheather bandwidth."
     x0 = norm.ppf(q)
     f0 = norm.pdf(x0)

--- a/pyfixest/estimation/torch/demean_torch_.py
+++ b/pyfixest/estimation/torch/demean_torch_.py
@@ -75,7 +75,7 @@ def _get_device(dtype: torch.dtype = torch.float64) -> torch.device:
 @torch.no_grad()
 def _demean_torch_on_device_impl(
     x: NDArray[np.float64],
-    flist: NDArray[np.uint64],
+    flist: NDArray[np.uint64] | None,
     weights: NDArray[np.float64] | None,
     tol: float,
     maxiter: int,

--- a/pyfixest/report/_maketables_extractor.py
+++ b/pyfixest/report/_maketables_extractor.py
@@ -21,7 +21,7 @@ from maketables.extractors import PyFixestExtractor, register_extractor
 from pyfixest.estimation.models.base_regression_ import BaseRegression
 
 
-class BaseRegressionExtractor(PyFixestExtractor):  # type: ignore[misc]
+class BaseRegressionExtractor(PyFixestExtractor):
     """Extract any fitted pyfixest result, not only the `Feols` family."""
 
     def can_handle(self, model: Any) -> bool:

--- a/pyfixest/report/_maketables_extractor.py
+++ b/pyfixest/report/_maketables_extractor.py
@@ -55,7 +55,13 @@ def register_pyfixest_extractor() -> None:
         for extractor in _EXTRACTOR_REGISTRY
     ):
         return
-    register_extractor(BaseRegressionExtractor())
+    # maketables internal: its own `PyFixestExtractor`, which this class
+    # extends, does not implement the `default_stat_keys` member its
+    # `ModelExtractor` protocol declares. The registry looks the method up
+    # defensively, so the extractor works exactly as the built-in one does.
+    register_extractor(
+        BaseRegressionExtractor()  # ty: ignore[invalid-argument-type]
+    )
 
 
 register_pyfixest_extractor()

--- a/pyfixest/report/summarize.py
+++ b/pyfixest/report/summarize.py
@@ -2,12 +2,9 @@ import maketables
 import numpy as np
 import pandas as pd
 
-from pyfixest.estimation.FixestMulti_ import FixestMulti
 from pyfixest.estimation.internals.literals import InferenceType
 from pyfixest.estimation.protocols import FittedResult
-from pyfixest.report.utils import _post_processing_input_checks
-
-ModelInputType = FixestMulti | FittedResult | list[FittedResult]
+from pyfixest.report.utils import ModelInputType, _post_processing_input_checks
 
 _METHOD_DISPLAY_NAMES: dict[str, str] = {
     "fepois": "Poisson",

--- a/pyfixest/report/summarize.py
+++ b/pyfixest/report/summarize.py
@@ -4,6 +4,7 @@ import pandas as pd
 
 from pyfixest.estimation.internals.literals import InferenceType
 from pyfixest.estimation.protocols import FittedResult
+from pyfixest.estimation.quantreg.quantreg_ import Quantreg
 from pyfixest.report.utils import ModelInputType, _post_processing_input_checks
 
 _METHOD_DISPLAY_NAMES: dict[str, str] = {
@@ -20,8 +21,8 @@ def _get_estimation_method_name(fxst: FittedResult) -> str:
     """Get the display name for an estimation method."""
     if fxst._method == "feols":
         return "IV" if fxst._is_iv else "OLS"
-    if "quantreg" in fxst._method:
-        return f"quantreg: q = {fxst._quantile}"  # type: ignore
+    if isinstance(fxst, Quantreg):
+        return f"quantreg: q = {fxst._quantile}"
     if fxst._method in _METHOD_DISPLAY_NAMES:
         return _METHOD_DISPLAY_NAMES[fxst._method]
     raise ValueError(f"Unknown estimation method: {fxst._method}")

--- a/pyfixest/report/utils.py
+++ b/pyfixest/report/utils.py
@@ -2,12 +2,19 @@ import re
 import warnings
 from collections import Counter
 from collections.abc import ValuesView
+from typing import TypeAlias
 
 from pyfixest.estimation.FixestMulti_ import FixestMulti
 from pyfixest.estimation.models.base_regression_ import BaseRegression
 from pyfixest.estimation.protocols import FittedResult
 
-ModelInputType = FixestMulti | FittedResult | list[FittedResult]
+# What every reporting and post-estimation entry accepts as `models`, and what
+# `_post_processing_input_checks` below validates: one fitted result, a
+# multiple-estimation container, a list of results, or the `dict.values()` view
+# `FixestMulti` binds its own report methods to.
+ModelInputType: TypeAlias = (
+    FixestMulti | FittedResult | list[FittedResult] | ValuesView[FittedResult]
+)
 
 
 def _check_label_keys_in_covars(label_keys: list[str], covariate_names: list[str]):

--- a/pyfixest/report/visualize.py
+++ b/pyfixest/report/visualize.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import math
 from importlib.util import find_spec
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import numpy as np
 import pandas as pd
@@ -694,13 +694,14 @@ def _coefplot_matplotlib(
     if ax is None:
         f, ax = plt.subplots(figsize=figsize, **fig_kwargs)
     else:
-        f = ax.get_figure()
+        # An Axes drawn by matplotlib always belongs to a figure.
+        f = cast("plt.Figure", ax.get_figure())
 
     # Check if we have multiple models
     models = df["fml"].unique()
     is_multi_model = len(models) > 1
 
-    colors = plt.cm.jet(np.linspace(0, 1, len(models)))
+    colors = plt.get_cmap("jet")(np.linspace(0, 1, len(models)))
     color_dict = dict(zip(models, colors, strict=False))
 
     # Calculate the positions for dodging

--- a/pyfixest/report/visualize.py
+++ b/pyfixest/report/visualize.py
@@ -7,10 +7,10 @@ from typing import TYPE_CHECKING, cast
 import numpy as np
 import pandas as pd
 
-from pyfixest.estimation.FixestMulti_ import FixestMulti
 from pyfixest.estimation.protocols import FittedResult
 from pyfixest.estimation.quantreg.quantreg_ import Quantreg
 from pyfixest.report.utils import (
+    ModelInputType,
     _check_label_keys_in_covars,
     _post_processing_input_checks,
     _relabel_expvar,
@@ -22,7 +22,6 @@ if TYPE_CHECKING:
 
 _HAS_LETS_PLOT = find_spec("lets_plot") is not None
 
-ModelInputType = FixestMulti | FittedResult | list[FittedResult]
 
 
 def set_figsize(figsize: tuple[int, int] | None, plot_backend: str) -> tuple[int, int]:

--- a/pyfixest/report/visualize.py
+++ b/pyfixest/report/visualize.py
@@ -23,7 +23,6 @@ if TYPE_CHECKING:
 _HAS_LETS_PLOT = find_spec("lets_plot") is not None
 
 
-
 def set_figsize(figsize: tuple[int, int] | None, plot_backend: str) -> tuple[int, int]:
     """
     Set the figure size based on the plot backend.
@@ -809,7 +808,6 @@ def _qplot(
     k = len(coeffs)
 
     if nrow is not None:
-        assert nrow is not None  # for mypy, do people really do this?
         rows, cols = nrow, math.ceil(k / nrow)
     else:
         assert ncol is not None
@@ -895,7 +893,7 @@ def _get_model_df(
             .merge(df_joint, on="Coefficient", how="left")
         )
 
-        df_joint_full["fml"] += " (joint CIs)"  # type: ignore[operator]
+        df_joint_full["fml"] += " (joint CIs)"
 
         if joint == "both":
             df_model = pd.concat([df_model, df_joint_full], axis=0)

--- a/pyfixest/utils/check_r_install.py
+++ b/pyfixest/utils/check_r_install.py
@@ -1,4 +1,6 @@
-from rpy2.robjects.packages import importr
+# rpy2 ships only with the `r` pixi feature, so it is absent from the
+# environment the type checker resolves imports from.
+from rpy2.robjects.packages import importr  # ty: ignore[unresolved-import]
 
 
 def _catch_import_issue(name: str, strict: bool) -> bool | None:

--- a/pyfixest/utils/dev_utils.py
+++ b/pyfixest/utils/dev_utils.py
@@ -8,7 +8,7 @@ from narwhals.typing import IntoDataFrame
 DataFrameType = IntoDataFrame
 
 
-def _narwhals_to_pandas(data: IntoDataFrame) -> pd.DataFrame:  # type: ignore
+def _narwhals_to_pandas(data: IntoDataFrame) -> pd.DataFrame:
     return nw.from_native(data, eager_or_interchange_only=True).to_pandas()
 
 

--- a/pyfixest/utils/set_rpy2_path.py
+++ b/pyfixest/utils/set_rpy2_path.py
@@ -1,5 +1,7 @@
-import rpy2.robjects as robjects
-from rpy2.robjects.packages import importr
+# rpy2 ships only with the `r` pixi feature, so it is absent from the
+# environment the type checker resolves imports from.
+import rpy2.robjects as robjects  # ty: ignore[unresolved-import]
+from rpy2.robjects.packages import importr  # ty: ignore[unresolved-import]
 
 
 def update_r_paths():

--- a/pyfixest/utils/utils.py
+++ b/pyfixest/utils/utils.py
@@ -1,6 +1,6 @@
 import warnings
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, cast
 
 import numpy as np
 import pandas as pd
@@ -483,7 +483,11 @@ def capture_context(context: int | Mapping[str, Any]) -> Mapping[str, Any]:
         The context that should be later passed to the Formulaic materialization
         procedure like: `.get_model_matrix(..., context=<this object>)`.
     """
-    return _capture_context(context + 2) if isinstance(context, int) else context
+    if not isinstance(context, int):
+        return context
+    # formulaic returns `None` only on interpreters without `sys._getframe`;
+    # a frame offset always resolves to a mapping on CPython.
+    return cast("Mapping[str, Any]", _capture_context(context + 2))
 
 
 def _check_balanced(panel_arr: np.ndarray, time_arr: np.ndarray) -> bool:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,35 +162,12 @@ convention = "numpy"
 docstring-code-format = true
 docstring-code-line-length = 88
 
-[tool.mypy]
-
-[[tool.mypy.overrides]]
-module = [
-    "pandas.*",
-    "numpy.*",
-    "scipy.*",
-    "numba.*",
-    "lets_plot.*",
-    "formulaic.*",
-    "wildboottest.*",
-    "tabulate.*",
-    "joblib.*",
-    "narwhals.*",
-    "tqdm.*",
-]
-ignore_missing_imports = true
-
 [tool.ty.src]
 include = ["pyfixest"]
 exclude = [
     # Superseded formula plumbing kept for backwards compatibility.
     "pyfixest/estimation/deprecated",
 ]
-
-[tool.ty.rules]
-# mypy still runs as a pre-commit hook and owns the `# type: ignore` comments
-# in this repository, so ty must not report them as unused.
-unused-type-ignore-comment = "ignore"
 
 # --------------------------------------------------------------------------------------
 # pixi configuration
@@ -345,7 +322,7 @@ lint = { cmd = "prek run --all-files", description = "Run all pre-commit hooks v
 # CPython >= 3.11 and would make the py310 environment unsolvable.
 
 [tool.pixi.feature.typecheck.dependencies]
-ty = ">=0.0.78"
+ty = ">=0.0.78,<0.1"
 
 [tool.pixi.feature.typecheck.tasks]
 type-check = { cmd = "ty check", description = "Type-check pyfixest with ty" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -180,6 +180,31 @@ module = [
 ]
 ignore_missing_imports = true
 
+[tool.ty.src]
+include = ["pyfixest"]
+exclude = [
+    # Superseded formula plumbing kept for backwards compatibility.
+    "pyfixest/estimation/deprecated",
+    # Temporary: these files are rewritten by the open estimation-state stack
+    # (#1499-#1501). They are type-checked by the mypy-to-ty migration layer
+    # that lands on top of that stack, so that the two efforts do not conflict.
+    "pyfixest/estimation/FixestMulti_.py",
+    "pyfixest/estimation/formula/model_matrix.py",
+    "pyfixest/estimation/models/_result_accessor_mixin.py",
+    "pyfixest/estimation/models/feglm_.py",
+    "pyfixest/estimation/models/feiv_.py",
+    "pyfixest/estimation/models/feols_.py",
+    "pyfixest/estimation/post_estimation/ritest.py",
+    "pyfixest/estimation/quantreg/QuantregMulti.py",
+    "pyfixest/estimation/quantreg/frisch_newton_ip.py",
+    "pyfixest/estimation/quantreg/quantreg_.py",
+]
+
+[tool.ty.rules]
+# mypy still runs as a pre-commit hook and owns the `# type: ignore` comments
+# in this repository, so ty must not report them as unused.
+unused-type-ignore-comment = "ignore"
+
 # --------------------------------------------------------------------------------------
 # pixi configuration
 # --------------------------------------------------------------------------------------
@@ -326,6 +351,18 @@ prek = ">=0.3.4"
 [tool.pixi.feature.lint.tasks]
 lint = { cmd = "prek run --all-files", description = "Run all pre-commit hooks via prek" }
 
+# -- type-check feature ------------------------------------------------------------------
+# ty resolves imports from the environment it runs in, so it is paired with the
+# runtime dependencies rather than with the standalone lint environment. It is a
+# feature rather than a default dependency because conda-forge's `ty` requires
+# CPython >= 3.11 and would make the py310 environment unsolvable.
+
+[tool.pixi.feature.typecheck.dependencies]
+ty = ">=0.0.78"
+
+[tool.pixi.feature.typecheck.tasks]
+type-check = { cmd = "ty check", description = "Type-check pyfixest with ty" }
+
 # -- benchmark feature -----------------------------------------------------------------
 
 [tool.pixi.feature.benchmark]
@@ -352,10 +389,10 @@ torch = { version = ">=2.7.0", index = "https://download.pytorch.org/whl/cu128" 
 
 [tool.pixi.environments]
 py310 = ["py310", "torch"]
-py311 = ["py311", "torch"]
-py312 = ["py312", "torch"]
-py313 = ["py313", "torch"]
-py314 = ["py314", "torch"]
+py311 = ["py311", "torch", "typecheck"]
+py312 = ["py312", "torch", "typecheck"]
+py313 = ["py313", "torch", "typecheck"]
+py314 = ["py314", "torch", "typecheck"]
 py310-r = { features = ["py310", "torch", "r"], solve-group = "py310" }
 py311-r = { features = ["py311", "torch", "r"], solve-group = "py311" }
 py312-r = { features = ["py312", "torch", "r"], solve-group = "py312" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,19 +185,6 @@ include = ["pyfixest"]
 exclude = [
     # Superseded formula plumbing kept for backwards compatibility.
     "pyfixest/estimation/deprecated",
-    # Temporary: these files are rewritten by the open estimation-state stack
-    # (#1499-#1501). They are type-checked by the mypy-to-ty migration layer
-    # that lands on top of that stack, so that the two efforts do not conflict.
-    "pyfixest/estimation/FixestMulti_.py",
-    "pyfixest/estimation/formula/model_matrix.py",
-    "pyfixest/estimation/models/_result_accessor_mixin.py",
-    "pyfixest/estimation/models/feglm_.py",
-    "pyfixest/estimation/models/feiv_.py",
-    "pyfixest/estimation/models/feols_.py",
-    "pyfixest/estimation/post_estimation/ritest.py",
-    "pyfixest/estimation/quantreg/QuantregMulti.py",
-    "pyfixest/estimation/quantreg/frisch_newton_ip.py",
-    "pyfixest/estimation/quantreg/quantreg_.py",
 ]
 
 [tool.ty.rules]


### PR DESCRIPTION
Layer 6 of the estimation-state stack, based on `refactor/base-regression` (#1507). Completes the migration from mypy to ty (#1104): ty is the only type checker, it runs as the blocking `Type Check` CI job, and it reports zero diagnostics for the whole package.

The branch first carries the six commits of #1505 (ty alongside mypy, based on master) because its configuration is needed here; their files are disjoint from the stack, and a rebase after #1505 merges drops them automatically. On top of that, the temporary exclusions for the stack-touched files are gone and their diagnostics are fixed at the source: the model-matrix publication seam is annotated, structured formulaic specs are read through typed accessors, the weights-type literal is carried through estimation, the covariance detail each path requires is named, and the bootstrap, decomposition, and report inputs declare what they accept. The mypy hook, its configuration, and its ignore comments are removed; every remaining suppression is a `# ty: ignore[rule]` naming a third-party gap. No runtime behavior changes.

- Public annotations tighten only where the runtime already required the value (`weights_type`, the wild-bootstrap options, `vcov="NW"`/`"DK"` literals).
- Pre-existing and left alone: `vcov="NW"` without `vcov_kwargs` is not rejected at the API boundary, and an IV first-stage refit forwards HAC without its kwargs.

## Verification

Passed locally at the head: `ty check` clean with no unused ignores, all pre-commit hooks with mypy removed, release contract 1355/1355, fast live-R 22/22, targeted R comparison suites for IV, DiD, quantreg, multcomp, and prediction, broad Python-only suite (pre-existing `torch_mps` failures excluded). `pixi.lock` is unchanged beyond #1505's ty entry. Deferred to CI: the `Type Check` job through the pixi task, HAC, docs.
