### PR TITLE
ci(release): ship the agent corpus in wheels and sdist

### DIFF
--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -11,6 +11,7 @@ on:
       - master
     tags:
       - '*'
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -27,9 +28,32 @@ jobs:
       - name: Check tag matches Cargo.toml version
         run: python .github/check_version.py
 
+  agent-docs:
+    # Renders the documentation once per release and hands the bundled corpus
+    # to every build job, so that all archives ship identical docs.
+    if: ${{ startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: prefix-dev/setup-pixi@v0.10.2
+        with:
+          pixi-version: v0.76.2
+          cache: true
+          cache-write: false
+          frozen: true
+          environments: docs
+      - name: Render and bundle agent docs
+        run: pixi run -e docs docs-bundle
+      - name: Upload agent docs
+        uses: actions/upload-artifact@v7
+        with:
+          name: agent-docs
+          path: pyfixest/docs
+          if-no-files-found: error
+
   linux:
-    needs: [check-version]
-    if: ${{ always() && (needs.check-version.result == 'success' || needs.check-version.result == 'skipped') }}
+    needs: [check-version, agent-docs]
+    if: ${{ always() && (needs.check-version.result == 'success' || needs.check-version.result == 'skipped') && (needs.agent-docs.result == 'success' || needs.agent-docs.result == 'skipped') }}
     runs-on: ${{ matrix.platform.runner }}
     strategy:
       matrix:
@@ -51,6 +75,12 @@ jobs:
       - uses: actions/setup-python@v7
         with:
           python-version: 3.x
+      - name: Download agent docs
+        if: ${{ needs.agent-docs.result == 'success' }}
+        uses: actions/download-artifact@v8
+        with:
+          name: agent-docs
+          path: pyfixest/docs
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
@@ -65,8 +95,8 @@ jobs:
           path: dist
 
   musllinux:
-    needs: [check-version]
-    if: ${{ always() && (needs.check-version.result == 'success' || needs.check-version.result == 'skipped') }}
+    needs: [check-version, agent-docs]
+    if: ${{ always() && (needs.check-version.result == 'success' || needs.check-version.result == 'skipped') && (needs.agent-docs.result == 'success' || needs.agent-docs.result == 'skipped') }}
     runs-on: ${{ matrix.platform.runner }}
     strategy:
       matrix:
@@ -84,6 +114,12 @@ jobs:
       - uses: actions/setup-python@v7
         with:
           python-version: 3.x
+      - name: Download agent docs
+        if: ${{ needs.agent-docs.result == 'success' }}
+        uses: actions/download-artifact@v8
+        with:
+          name: agent-docs
+          path: pyfixest/docs
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
@@ -98,8 +134,8 @@ jobs:
           path: dist
 
   windows:
-    needs: [check-version]
-    if: ${{ always() && (needs.check-version.result == 'success' || needs.check-version.result == 'skipped') }}
+    needs: [check-version, agent-docs]
+    if: ${{ always() && (needs.check-version.result == 'success' || needs.check-version.result == 'skipped') && (needs.agent-docs.result == 'success' || needs.agent-docs.result == 'skipped') }}
     runs-on: ${{ matrix.platform.runner }}
     strategy:
       matrix:
@@ -114,6 +150,12 @@ jobs:
         with:
           python-version: 3.x
           architecture: ${{ matrix.platform.target }}
+      - name: Download agent docs
+        if: ${{ needs.agent-docs.result == 'success' }}
+        uses: actions/download-artifact@v8
+        with:
+          name: agent-docs
+          path: pyfixest/docs
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
@@ -127,8 +169,8 @@ jobs:
           path: dist
 
   macos:
-    needs: [check-version]
-    if: ${{ always() && (needs.check-version.result == 'success' || needs.check-version.result == 'skipped') }}
+    needs: [check-version, agent-docs]
+    if: ${{ always() && (needs.check-version.result == 'success' || needs.check-version.result == 'skipped') && (needs.agent-docs.result == 'success' || needs.agent-docs.result == 'skipped') }}
     runs-on: ${{ matrix.platform.runner }}
     strategy:
       matrix:
@@ -142,6 +184,12 @@ jobs:
       - uses: actions/setup-python@v7
         with:
           python-version: 3.x
+      - name: Download agent docs
+        if: ${{ needs.agent-docs.result == 'success' }}
+        uses: actions/download-artifact@v8
+        with:
+          name: agent-docs
+          path: pyfixest/docs
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
@@ -155,11 +203,17 @@ jobs:
           path: dist
 
   sdist:
-    needs: [check-version]
-    if: ${{ always() && (needs.check-version.result == 'success' || needs.check-version.result == 'skipped') }}
+    needs: [check-version, agent-docs]
+    if: ${{ always() && (needs.check-version.result == 'success' || needs.check-version.result == 'skipped') && (needs.agent-docs.result == 'success' || needs.agent-docs.result == 'skipped') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+      - name: Download agent docs
+        if: ${{ needs.agent-docs.result == 'success' }}
+        uses: actions/download-artifact@v8
+        with:
+          name: agent-docs
+          path: pyfixest/docs
       - name: Build sdist
         uses: PyO3/maturin-action@v1
         with:
@@ -189,6 +243,37 @@ jobs:
         uses: actions/attest-build-provenance@v4
         with:
           subject-path: 'wheels-*/*'
+      - uses: actions/setup-python@v7
+        with:
+          python-version: 3.x
+      - name: Check bundled docs in archives
+        # PR #1473 adds skills/pyfixest/SKILL.md; extend REQUIRED with
+        # "skills/pyfixest/SKILL.md" once that file is on master.
+        run: |
+          python - <<'PY'
+          import glob
+          import sys
+          import tarfile
+          import zipfile
+
+          REQUIRED = ["pyfixest/docs/llms.txt"]
+
+          archives = sorted(glob.glob("wheels-*/*.whl")) + sorted(glob.glob("wheels-sdist/*.tar.gz"))
+          if not archives:
+              sys.exit("no wheels or sdist found to check")
+
+          for archive in archives:
+              if archive.endswith(".whl"):
+                  with zipfile.ZipFile(archive) as handle:
+                      names = handle.namelist()
+              else:
+                  with tarfile.open(archive) as handle:
+                      names = handle.getnames()
+              for required in REQUIRED:
+                  if not any(name.endswith(required) for name in names):
+                      sys.exit(f"{archive} does not contain {required}")
+              print(f"{archive}: ok")
+          PY
       - name: Publish to PyPI
         if: ${{ startsWith(github.ref, 'refs/tags/') }}
         uses: PyO3/maturin-action@v1

--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -31,8 +31,12 @@ jobs:
   agent-docs:
     # Renders the documentation once per release and hands the bundled corpus
     # to every build job, so that all archives ship identical docs.
+    # docs-bundle-fresh deletes docs/_freeze and executes every page (45-70
+    # minutes) instead of reusing frozen results, so the bundled output is
+    # produced by the code being released rather than by an older version.
     if: ${{ startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     steps:
       - uses: actions/checkout@v7
       - uses: prefix-dev/setup-pixi@v0.10.2
@@ -43,7 +47,7 @@ jobs:
           frozen: true
           environments: docs
       - name: Render and bundle agent docs
-        run: pixi run -e docs docs-bundle
+        run: pixi run -e docs docs-bundle-fresh
       - name: Upload agent docs
         uses: actions/upload-artifact@v7
         with:
@@ -243,9 +247,15 @@ jobs:
         uses: actions/attest-build-provenance@v4
         with:
           subject-path: 'wheels-*/*'
+      # Checked out into a subdirectory on purpose: a checkout of the workspace
+      # root would delete the artifacts downloaded above, and a `pyfixest/`
+      # source tree next to the script would shadow the installed wheel.
+      - uses: actions/checkout@v7
+        with:
+          path: repo
       - uses: actions/setup-python@v7
         with:
-          python-version: 3.x
+          python-version: "3.12"
       - name: Check bundled docs in archives
         # PR #1473 adds skills/pyfixest/SKILL.md; extend REQUIRED with
         # "skills/pyfixest/SKILL.md" once that file is on master.
@@ -273,6 +283,75 @@ jobs:
                   if not any(name.endswith(required) for name in names):
                       sys.exit(f"{archive} does not contain {required}")
               print(f"{archive}: ok")
+          PY
+      - name: Install a wheel and verify the bundled docs
+        run: |
+          python -m pip install --upgrade pip
+          WHEEL=$(ls wheels-linux-x86_64/pyfixest-*-cp312-cp312-manylinux*_x86_64*.whl | head -n 1)
+          test -n "$WHEEL"
+          python -m pip install "$WHEEL"
+          python - <<'PY'
+          import importlib.resources
+          import os
+          import pathlib
+          import re
+          import sys
+
+          # Reuse the version rules of the check-version job so both gates agree,
+          # including on pre-releases ("0.60.0-alpha.1" -> "0.60.0a1").
+          sys.path.insert(0, "repo/.github")
+          from check_version import cargo_to_python_version, get_cargo_version  # noqa: E402
+
+          import pyfixest  # noqa: E402
+
+          docs = importlib.resources.files("pyfixest") / "docs"
+          problems = []
+
+          for name in ("llms.txt", "cheatsheet.llms.md"):
+              if (docs / name).is_file():
+                  print(f"ok: installed pyfixest/docs/{name}")
+              else:
+                  problems.append(f"the installed wheel has no pyfixest/docs/{name}")
+          if problems:
+              sys.exit("\n".join(problems))
+
+          if os.environ.get("GITHUB_REF_TYPE") == "tag":
+              expected = os.environ["GITHUB_REF_NAME"].removeprefix("v")
+              source = "the git tag"
+          else:
+              expected = cargo_to_python_version(get_cargo_version())
+              source = "Cargo.toml"
+
+          text = (docs / "llms.txt").read_text(encoding="utf-8")
+          stamp = re.search(r"^Version:\s*(\S+)\s*$", text, re.MULTILINE)
+          if stamp is None:
+              sys.exit("the bundled llms.txt carries no 'Version:' line")
+
+          bundled = cargo_to_python_version(stamp[1])
+          if bundled == expected:
+              print(f"ok: bundled docs are stamped {bundled!r} ({source})")
+          else:
+              problems.append(f"bundled docs are stamped {bundled!r}, expected {expected!r} from {source}")
+
+          if pyfixest.__version__ == expected:
+              print(f"ok: installed pyfixest reports {pyfixest.__version__!r}")
+          else:
+              problems.append(f"installed pyfixest reports {pyfixest.__version__!r}, expected {expected!r} from {source}")
+
+          # PR #1473 adds skills/pyfixest/SKILL.md; this check turns itself on as
+          # soon as that file is in the checkout, and stays quiet until then.
+          if (pathlib.Path("repo") / "skills" / "pyfixest" / "SKILL.md").is_file():
+              skill = pathlib.Path(pyfixest.__file__).parents[1] / "skills" / "pyfixest" / "SKILL.md"
+              if skill.is_file():
+                  print(f"ok: installed {skill}")
+              else:
+                  problems.append(f"the installed wheel has no skills/pyfixest/SKILL.md at {skill}")
+          else:
+              print("skip: skills/pyfixest/SKILL.md is not in the checkout yet")
+
+          if problems:
+              sys.exit("\n".join(problems))
+          print("installed wheel verified")
           PY
       - name: Publish to PyPI
         if: ${{ startsWith(github.ref, 'refs/tags/') }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,7 +169,10 @@ Always update `docs/changelog.qmd`. Documentation ships with the feature. New
 public functions/classes require quartodoc registration; user workflows usually
 need a `docs/how-to/` guide or an extension to the nearest existing guide.
 Never hand-edit generated `docs/reference/**`. The hosted pages and the
-`.llms.md` pages bundled into `pyfixest/docs/` are the same Quarto output.
+`.llms.md` pages bundled into `pyfixest/docs/` are the same Quarto output. The
+`agent-docs` job in `.github/workflows/build-and-release.yaml` produces that
+bundle once per release and hands it to every wheel and the sdist; a
+`workflow_dispatch` run exercises the same path without publishing.
 
 ## Git and review
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,8 +171,11 @@ need a `docs/how-to/` guide or an extension to the nearest existing guide.
 Never hand-edit generated `docs/reference/**`. The hosted pages and the
 `.llms.md` pages bundled into `pyfixest/docs/` are the same Quarto output. The
 `agent-docs` job in `.github/workflows/build-and-release.yaml` produces that
-bundle once per release and hands it to every wheel and the sdist; a
-`workflow_dispatch` run exercises the same path without publishing.
+bundle once per release, rendering every page from scratch rather than from
+frozen results, and hands it to every wheel and the sdist. The `release` job
+then installs one wheel and verifies the bundled pages, their version stamp,
+and the skill before publishing; a `workflow_dispatch` run exercises the same
+path without publishing.
 
 ## Git and review
 

--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -48,6 +48,9 @@ fit3 = pf.feols("Y ~ X1 + X2 | f1", data = df)
   with executed output), generated at build time from the same Quarto sources
   as the website. The bundled `llms.txt` describes each page, and release builds
   render every page from scratch so the bundled output matches the released code.
+- Release builds render the documentation once and ship it in every wheel and
+  the source distribution; the release job refuses to upload archives without
+  it.
 
 ### Inference Types
 

--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -50,7 +50,8 @@ fit3 = pf.feols("Y ~ X1 + X2 | f1", data = df)
   render every page from scratch so the bundled output matches the released code.
 - Release builds render the documentation once and ship it in every wheel and
   the source distribution; the release job refuses to upload archives without
-  it.
+  it. They render every page from scratch and install one wheel to verify the
+  bundled documentation, its version stamp, and the skill before publishing.
 
 ### Inference Types
 


### PR DESCRIPTION
## Summary

Released wheels and sdists now carry the rendered documentation, and the release job refuses to upload any archive that is missing it. `.github/workflows/build-and-release.yaml` gains an `agent-docs` job that runs `pixi run -e docs docs-bundle` once per release and uploads `pyfixest/docs` as an artifact. Every build job downloads that artifact before maturin runs, so all wheels and the sdist ship an identical corpus, and the release job asserts `pyfixest/docs/llms.txt` inside each archive before publishing to PyPI. Adding `workflow_dispatch` makes the whole path runnable by hand without publishing. Non-tag pushes to master are unaffected: `agent-docs` is skipped, the download steps are skipped, and wheels build exactly as today. Stacked on #1472, which adds the bundler, the `docs-bundle` task, and the maturin include; the assertion for `skills/pyfixest/SKILL.md` is added by whichever of this PR and #1473 merges second.

## Verification

`prek run check-github-workflows`, `check-yaml`, and the whitespace hooks on the changed files pass. Local dry run: bundler (94 pages), `maturin sdist`, then the workflow's own assertion extracted verbatim, passes; rebuilt with `pyfixest/docs` removed, the assertion fails as intended. The workflow itself is deferred to a post-merge `workflow_dispatch` run.

A second pass closes two gaps. The `agent-docs` job now runs `docs-bundle-fresh`, which clears `docs/_freeze` and executes every page against the code being released (120-minute job timeout for the 45 to 70 minute render), because `freeze: auto` would otherwise ship output produced by an older pyfixest. The release gate now installs the cp312 manylinux wheel and verifies the installed `pyfixest/docs/llms.txt` and `cheatsheet.llms.md`, the `Version:` stamp against the tag (normalised through `check_version.cargo_to_python_version`, so `0.60.0-alpha.1` matches `v0.60.0a1`) or `Cargo.toml` on a manual run, and `pyfixest.__version__`. The checkout is scoped to `repo/` so it neither deletes the downloaded artifacts nor shadows the installed package; the skill assertion turns itself on once `skills/pyfixest/SKILL.md` is in the checkout (#1473).
