### PR TITLE
refactor(vcov): use model-owned estimation data

### DIFF
--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -274,21 +274,23 @@ As previously announced, we removed:
 We also removed:
 
 - Removed `pf.dtable()`; use `maketables.DTable()` directly instead.
+- Removed the `data` argument from fitted-model `vcov()` methods. Data-dependent
+  covariance updates now use only the model's filtered estimation sample and
+  require fitting with `store_data=True` and `lean=False`.
 
 ### Bug Fixes
 
 - `lean=True` results keep the formula specification and evaluation context, so
   `predict(newdata=...)` keeps working for models without fixed effects; methods
   that need discarded state now raise an informative `RuntimeError` instead of
-  `AttributeError`. `vcov(..., data=...)` now validates that the explicit sample
-  matches the fitted rows.
+  `AttributeError`.
 - `store_data=False` and `lean=True` now apply to retained IV first stages; lean
   fits also discard demeaning caches, GLM working state, and quantile solver
   outputs.
 - `store_data=False` and `lean=True` now apply to multiple-estimation
-  containers; `FixestMulti.vcov()` accepts a common explicit estimation sample;
-  default multi-quantile results retain the arrays needed for prediction and
-  covariance updates.
+  containers; every child model uses its own filtered sample for covariance
+  updates; default multi-quantile results retain the arrays needed for prediction
+  and covariance updates.
 - Fitted models and non-plotting DiD and reporting paths no longer import
   plotting dependencies eagerly. `ritest()` loads its numerical helpers on use,
   while Matplotlib, Seaborn, and Lets-Plot load only when plotting.

--- a/docs/developer/architecture.md
+++ b/docs/developer/architecture.md
@@ -285,15 +285,14 @@ within state, GLM working state, demeaning caches, quantile solver outputs, and
 large first-stage arrays. Lean results do keep the formula specification and
 evaluation context, so `predict(newdata=...)` still works for models without
 fixed effects. Array-only covariance updates remain available after
-`store_data=False`; cluster and HAC updates require the estimation sample
-through the documented `vcov(data=...)` argument. Explicit covariance data must
-already be filtered to the fitted row sample and retain its estimation order; a
-row-count check rejects misaligned inputs before covariance dispatch, and
-`FixestMulti.vcov(data=...)` validates one common sample for every child before
-any child is updated. Lean results reject post-fit covariance updates because
-their numerical arrays have been discarded. Every other method that needs
-discarded state raises an informative error naming the storage option and its
-remedy.
+`store_data=False`; cluster and HAC updates read only the model's retained,
+filtered estimation sample and reject the update after that sample has been
+discarded. Each child in a multiple-estimation result reads its own sample, so
+formula missingness, singleton removal, GLM separation, and sample splitting stay
+aligned with that child's arrays. Lean results reject post-fit covariance updates
+because their numerical arrays have been discarded. Every other method that
+needs discarded state raises an informative error naming the storage option and
+its remedy.
 
 Keeping canonical arrays unpremultiplied favors readability without moving
 weight work out of the numerical hot path: each solver still performs the same

--- a/pyfixest/estimation/FixestMulti_.py
+++ b/pyfixest/estimation/FixestMulti_.py
@@ -12,7 +12,6 @@ from pyfixest.estimation.models._tidy_accessors import TidyColumnAccessors
 from pyfixest.estimation.models.feols_ import Feols
 from pyfixest.estimation.plan_ import ParsedFormula
 from pyfixest.estimation.protocols import FittedResult
-from pyfixest.utils.dev_utils import DataFrameType, _narwhals_to_pandas
 
 ResultT = TypeVar("ResultT", bound=FittedResult)
 
@@ -122,7 +121,6 @@ class FixestMulti(TidyColumnAccessors, Generic[ResultT]):
         self,
         vcov: str | dict[str, str],
         vcov_kwargs: dict[str, str | int] | None = None,
-        data: DataFrameType | None = None,
     ) -> FixestMulti[ResultT]:
         """
         Update regression inference "on the fly".
@@ -141,54 +139,21 @@ class FixestMulti(TidyColumnAccessors, Generic[ResultT]):
             for CRV1 inference or {"CRV3": "clustervar"} for CRV3 inference.
         vcov_kwargs : Optional[dict[str, any]]
              Additional keyword arguments for the variance-covariance matrix.
-        data : DataFrameType, optional
-            The common, already-filtered estimation sample in its original order.
-            Required for data-dependent covariance updates when the fitted models
-            were created with `store_data=False`. Defaults to None.
 
         Returns
         -------
         FixestMulti
             This result container with updated inference.
+
+        Notes
+        -----
+        Each child reads cluster, time, and panel variables from its own filtered
+        estimation data, whether or not they appear in the formula. For estimators
+        that support them, post-fit clustered or HAC covariance updates require
+        `store_data=True` and `lean=False`.
         """
-        data_to_forward = data
-        if data is not None:
-            try:
-                data_to_forward = _narwhals_to_pandas(data)
-            except TypeError as exc:
-                raise TypeError(
-                    f"The data set must be a DataFrame type. Received: {type(data)}"
-                ) from exc
-
-            models = list(self.all_fitted_models.values())
-            expected_rows = sorted({model._N_rows for model in models})
-            received_rows = len(data_to_forward)
-            if any(n_rows != received_rows for n_rows in expected_rows):
-                raise ValueError(
-                    "`data` passed to FixestMulti.vcov() must contain the common, "
-                    "already-filtered estimation sample in its original order for "
-                    "every child model; expected child row counts "
-                    f"{expected_rows}, received {received_rows}. Fetch each child "
-                    "model and call vcov(..., data=...) separately when estimation "
-                    "samples differ."
-                )
-
-            reference = models[0] if models else None
-            if reference is not None and any(
-                model._sample_split_var != reference._sample_split_var
-                or model._sample_split_value != reference._sample_split_value
-                or model._na_index != reference._na_index
-                for model in models[1:]
-            ):
-                raise ValueError(
-                    "`data` cannot be forwarded by FixestMulti.vcov() because its "
-                    "child models use different estimation samples. Fetch each "
-                    "child model and call vcov(..., data=...) with that model's "
-                    "already-filtered estimation sample instead."
-                )
-
         for fxst in self.all_fitted_models.values():
-            fxst.vcov(vcov=vcov, vcov_kwargs=vcov_kwargs, data=data_to_forward)
+            fxst.vcov(vcov=vcov, vcov_kwargs=vcov_kwargs)
         return self
 
     def tidy(self) -> pd.DataFrame:

--- a/pyfixest/estimation/models/base_regression_.py
+++ b/pyfixest/estimation/models/base_regression_.py
@@ -845,7 +845,6 @@ class BaseRegression(TidyColumnAccessors):
         self,
         vcov: str | dict[str, str],
         vcov_kwargs: dict[str, str | int] | None = None,
-        data: DataFrameType | None = None,
     ) -> BaseRegression:
         """
         Compute covariance matrices for an estimated regression model.
@@ -862,18 +861,19 @@ class BaseRegression(TidyColumnAccessors):
             for IV estimation.
         vcov_kwargs : Optional[dict[str, any]]
              Additional keyword arguments for the variance-covariance matrix.
-        data: Optional[DataFrameType], optional
-            The already-filtered estimation sample in its original estimation
-            order. This is required for data-dependent covariance updates when
-            the fitted model does not retain its input data. If None, tries to
-            fetch the data from the model object. Defaults to None.
-
 
         Returns
         -------
         BaseRegression
             The fitted result itself, with the covariance matrix and every
             derived inference quantity replaced.
+
+        Notes
+        -----
+        Cluster, time, and panel variables are read from the model's filtered
+        estimation data and do not need to appear in its formula. For estimators
+        that support them, post-fit clustered or HAC covariance updates require
+        `store_data=True` and `lean=False`.
 
         Examples
         --------
@@ -901,27 +901,12 @@ class BaseRegression(TidyColumnAccessors):
             remedy="Set vcov at estimation time or refit with lean=False.",
         )
 
-        data_to_check: pd.DataFrame | None
-        if data is None:
-            data_to_check = getattr(self, "_data", None)
-        else:
-            try:
-                data_to_check = _narwhals_to_pandas(data)
-            except TypeError as e:
-                raise TypeError(
-                    f"The data set must be a DataFrame type. Received: {type(data)}"
-                ) from e
-            if len(data_to_check) != self._N_rows:
-                raise ValueError(
-                    "`data` passed to vcov() must contain exactly the already-filtered "
-                    "estimation sample in its original estimation order; expected "
-                    f"{self._N_rows} rows, received {len(data_to_check)}."
-                )
+        data = getattr(self, "_data", None)
 
         # assign estimated fixed effects, and fixed effects nested within cluster.
 
         # deparse vcov input
-        _check_vcov_input(vcov=vcov, vcov_kwargs=vcov_kwargs, data=data_to_check)
+        _check_vcov_input(vcov=vcov, vcov_kwargs=vcov_kwargs, data=data)
 
         vcov_type, vcov_type_detail, is_clustered, clustervar = _deparse_vcov_input(
             vcov, self._has_fixef, self._is_iv
@@ -929,10 +914,10 @@ class BaseRegression(TidyColumnAccessors):
 
         # Reject before any inference state is overwritten, so a failed update
         # leaves the previous covariance estimate intact.
-        if vcov_type in {"HAC", "CRV"} and data_to_check is None:
+        if vcov_type in {"HAC", "CRV"} and data is None:
             self._require_estimation_data(
                 "vcov",
-                remedy="Pass the estimation sample via data= or refit with store_data=True.",
+                remedy="Refit with store_data=True and lean=False.",
             )
 
         self._vcov_type = vcov_type
@@ -958,7 +943,7 @@ class BaseRegression(TidyColumnAccessors):
             self._vcov = self._ssc * self._vcov_hetero()
 
         elif self._vcov_type == "HAC":
-            assert data_to_check is not None
+            assert data is not None
             kw = vcov_kwargs or {}
             self._lag = kw.get("lag")
             self._time_id = kw.get("time_id")
@@ -966,10 +951,10 @@ class BaseRegression(TidyColumnAccessors):
             self._ssc, self._df_k, self._df_t = get_ssc(
                 **self._make_ssc_kwargs(
                     vcov_type="HAC",
-                    G=np.unique(data_to_check[self._time_id]).shape[0],
+                    G=np.unique(data[self._time_id]).shape[0],
                 )  # number of unique time periods T used
             )
-            self._vcov = self._ssc * self._vcov_hac(data=data_to_check)
+            self._vcov = self._ssc * self._vcov_hac(data=data)
 
         elif self._vcov_type == "nid":
             self._ssc, self._df_k, self._df_t = get_ssc(
@@ -978,9 +963,9 @@ class BaseRegression(TidyColumnAccessors):
             self._vcov = self._ssc * self._vcov_nid()
 
         elif self._vcov_type == "CRV":
-            assert data_to_check is not None
+            assert data is not None
             prep = prepare_cluster_state(
-                data=data_to_check,
+                data=data,
                 clustervar=self._clustervar,
                 ssc_dict=self._ssc_dict,
                 fixef=self._fixef,
@@ -993,7 +978,7 @@ class BaseRegression(TidyColumnAccessors):
                 prep=prep,
                 k=self._k,
                 make_ssc_kwargs=self._make_ssc_kwargs,
-                cluster_vcov=partial(self._vcov_crv_cluster, data=data_to_check),
+                cluster_vcov=partial(self._vcov_crv_cluster, data=data),
             )
         # update p-value, t-stat, standard error, confint
         self.get_inference()
@@ -2288,8 +2273,8 @@ def _check_vcov_input(
         assert all(isinstance(v, str) for v in vcov), "vcov list must contain strings"
         if data is None:
             raise RuntimeError(
-                "A vcov column list requires estimation data. Pass data= or fit "
-                "with store_data=True."
+                "A vcov column list requires estimation data. Refit with "
+                "store_data=True and lean=False."
             )
         assert all(v in data.columns for v in vcov), (
             "vcov list must contain columns in the data"

--- a/pyfixest/estimation/plan_.py
+++ b/pyfixest/estimation/plan_.py
@@ -319,7 +319,7 @@ def fit_one(
     # if X is empty: no inference (empty X only as shorthand for demeaning)
     if not FIT._X_is_empty:
         vcov_type = _get_vcov_type(vcov)
-        # vcov() reads the model's retained estimation data when data is None
+        # vcov() reads the model's filtered estimation data before cleanup.
         FIT.vcov(vcov=vcov_type, vcov_kwargs=vcov_kwargs)
 
         FIT.get_inference()

--- a/pyfixest/estimation/protocols.py
+++ b/pyfixest/estimation/protocols.py
@@ -32,7 +32,6 @@ class FittedModel(Protocol):
         self,
         vcov: str | dict[str, str],
         vcov_kwargs: dict[str, str | int] | None = None,
-        data: Any = None,
     ) -> object:
         """Compute the requested covariance matrix."""
         ...
@@ -134,7 +133,6 @@ class FittedResult(Protocol):
         self,
         vcov: str | dict[str, str],
         vcov_kwargs: dict[str, str | int] | None = None,
-        data: Any = None,
     ) -> FittedResult:
         """Replace the covariance estimate and the inference derived from it."""
         ...

--- a/pyfixest/estimation/quantreg/QuantregMulti.py
+++ b/pyfixest/estimation/quantreg/QuantregMulti.py
@@ -20,7 +20,6 @@ from pyfixest.estimation.internals.literals import (
 )
 from pyfixest.estimation.quantreg.quantreg_ import Quantreg
 from pyfixest.estimation.quantreg.utils import get_hall_sheather_bandwidth
-from pyfixest.utils.dev_utils import DataFrameType
 
 
 class QuantregMulti:
@@ -206,11 +205,10 @@ class QuantregMulti:
         self,
         vcov: str | dict[str, str],
         vcov_kwargs: dict[str, str | int] | None = None,
-        data: DataFrameType | None = None,
     ) -> dict[float, Quantreg]:
         "Compute variance-covariance matrices for all models in the quantile regression process."
         for quantreg in self.all_quantregs.values():
-            quantreg.vcov(vcov=vcov, vcov_kwargs=vcov_kwargs, data=data)
+            quantreg.vcov(vcov=vcov, vcov_kwargs=vcov_kwargs)
 
         return self.all_quantregs
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -56,11 +56,13 @@ def test_cluster_na():
         feols(fml="Y ~ X1", data=data, vcov={"CRV1": "f3"})
 
 
-def test_cluster_vcov_without_stored_or_explicit_data_is_informative():
-    """Data-dependent vcov updates explain how to supply stripped data."""
+def test_cluster_vcov_without_stored_data_is_informative():
+    """Data-dependent vcov updates explain that the model must be refit."""
     data = get_data()
     fit = feols("Y ~ X1", data=data, store_data=False)
-    with pytest.raises(RuntimeError, match=r"store_data=False.*Pass.*data="):
+    with pytest.raises(
+        RuntimeError, match=r"store_data=False.*Refit with store_data=True"
+    ):
         fit.vcov({"CRV1": "f2"})
 
 

--- a/tests/test_estimator_state_lifecycle.py
+++ b/tests/test_estimator_state_lifecycle.py
@@ -552,7 +552,11 @@ def test_vcov_uses_filtered_model_data_for_non_formula_cluster(
     assert fit._data.index.equals(fit._model_matrix.dependent.index)
     fit.vcov({"CRV1": "cluster"})
 
-    np.testing.assert_allclose(fit._vcov, expected._vcov)
+    np.testing.assert_allclose(
+        fit._vcov,
+        expected._vcov,
+        err_msg="CRV1 covariance differs between post-fit update and initial fit",
+    )
 
 
 def test_glm_vcov_uses_post_separation_model_data() -> None:
@@ -579,7 +583,11 @@ def test_glm_vcov_uses_post_separation_model_data() -> None:
     assert fit._data.index.equals(fit._model_matrix.dependent.index)
     fit.vcov({"CRV1": "cluster"})
 
-    np.testing.assert_allclose(fit._vcov, expected._vcov)
+    np.testing.assert_allclose(
+        fit._vcov,
+        expected._vcov,
+        err_msg="Poisson CRV1 covariance differs after separation filtering",
+    )
 
 
 def test_fixest_multi_vcov_uses_each_split_child_sample(
@@ -604,7 +612,11 @@ def test_fixest_multi_vcov_uses_each_split_child_sample(
     assert {child._N_rows for child in fit.to_list()} == {11, 12}
     for child, expected_child in zip(fit.to_list(), expected.to_list(), strict=True):
         assert child._data.index.equals(child._model_matrix.dependent.index)
-        np.testing.assert_allclose(child._vcov, expected_child._vcov)
+        np.testing.assert_allclose(
+            child._vcov,
+            expected_child._vcov,
+            err_msg="Split-child CRV1 covariance differs from initial fit",
+        )
 
 
 def test_store_data_false_rejects_data_dependent_vcov(

--- a/tests/test_estimator_state_lifecycle.py
+++ b/tests/test_estimator_state_lifecycle.py
@@ -7,7 +7,6 @@ and row-sample seams locked here are not observable from those suites.
 
 from __future__ import annotations
 
-from copy import deepcopy
 from dataclasses import FrozenInstanceError
 
 import numpy as np
@@ -524,199 +523,101 @@ def test_store_data_false_allows_array_only_vcov_updates(
     assert not hasattr(stripped, "_data")
 
 
-def test_store_data_false_vcov_uses_explicit_estimation_sample(
+@pytest.mark.parametrize(
+    "expected_fit_kwargs",
+    [{}, {"store_data": False}, {"lean": True}],
+    ids=["retained", "store_data_false", "lean"],
+)
+def test_vcov_uses_filtered_model_data_for_non_formula_cluster(
     lifecycle_data: pd.DataFrame,
+    expected_fit_kwargs: dict[str, bool],
 ) -> None:
-    """Data-dependent covariance updates use the documented data argument."""
-    stripped = pf.feols("y ~ x | fe", data=lifecycle_data, vcov="iid", store_data=False)
-    expected = pf.feols("y ~ x | fe", data=lifecycle_data, vcov={"CRV1": "fe"})
-
-    metadata_before = deepcopy(
-        (
-            stripped._vcov_type,
-            stripped._vcov_type_detail,
-            stripped._is_clustered,
-            stripped._clustervar,
-            stripped._G,
-            stripped._df_k,
-            stripped._df_t,
-        )
-    )
-    arrays_before = {
-        attr: getattr(stripped, attr).copy()
-        for attr in (
-            "_bread",
-            "_ssc",
-            "_vcov",
-            "_se",
-            "_tstat",
-            "_pvalue",
-            "_conf_int",
-        )
-    }
-
-    with pytest.raises(RuntimeError, match=r"store_data=False.*Pass.*data="):
-        stripped.vcov({"CRV1": "fe"})
-
-    assert (
-        stripped._vcov_type,
-        stripped._vcov_type_detail,
-        stripped._is_clustered,
-        stripped._clustervar,
-        stripped._G,
-        stripped._df_k,
-        stripped._df_t,
-    ) == metadata_before
-    for attr, value in arrays_before.items():
-        np.testing.assert_array_equal(getattr(stripped, attr), value)
-
-    stripped.vcov({"CRV1": "fe"}, data=lifecycle_data)
-
-    np.testing.assert_allclose(stripped._vcov, expected._vcov)
-    assert not hasattr(stripped, "_data")
-
-
-def test_fixest_multi_forwards_explicit_vcov_data(
-    lifecycle_data: pd.DataFrame,
-) -> None:
-    """Multiple-estimation covariance updates forward an explicit sample."""
-    stripped = pf.feols(
-        "y ~ sw(x, x2) | fe",
-        data=lifecycle_data,
-        vcov="iid",
-        store_data=False,
-    )
-    expected = pf.feols(
-        "y ~ sw(x, x2) | fe",
-        data=lifecycle_data,
-        vcov={"CRV1": "fe"},
-    )
-
-    stripped.vcov({"CRV1": "fe"}, data=lifecycle_data)
-
-    for stripped_model, expected_model in zip(
-        stripped.to_list(), expected.to_list(), strict=True
-    ):
-        np.testing.assert_allclose(stripped_model._vcov, expected_model._vcov)
-        assert not hasattr(stripped_model, "_data")
-
-
-def test_fixest_multi_vcov_preflights_different_estimation_samples(
-    lifecycle_data: pd.DataFrame,
-) -> None:
-    """A common-sample mismatch leaves every child model unchanged."""
-    data = lifecycle_data.copy()
-    data.loc[data.index[:3], "x2"] = np.nan
-    fit = pf.feols(
-        "y ~ sw(x, x2) | fe",
-        data=data,
-        vcov="iid",
-        store_data=False,
-    )
-    children = fit.to_list()
-    inference_before = [
-        (child._vcov_type_detail, child._vcov.copy()) for child in children
-    ]
-
-    with pytest.raises(
-        ValueError,
-        match=r"common, already-filtered estimation sample.*\[21, 24\], received 24",
-    ):
-        fit.vcov({"CRV1": "fe"}, data=data)
-
-    for child, (vcov_type_detail, vcov) in zip(children, inference_before, strict=True):
-        assert child._vcov_type_detail == vcov_type_detail
-        np.testing.assert_array_equal(child._vcov, vcov)
-
-
-def test_fixest_multi_vcov_rejects_equal_size_split_samples(
-    lifecycle_data: pd.DataFrame,
-) -> None:
-    """Equal row counts do not make distinct split samples interchangeable."""
-    data = lifecycle_data.assign(sample=np.tile(["left", "right"], 12))
-    fit = pf.feols(
-        "y ~ x | fe",
-        data=data,
-        split="sample",
-        vcov="iid",
-        store_data=False,
-    )
-    children = fit.to_list()
-    inference_before = [
-        (child._vcov_type_detail, child._vcov.copy()) for child in children
-    ]
-    left_sample = data.loc[data["sample"] == "left"]
-
-    with pytest.raises(
-        ValueError,
-        match=r"child models use different estimation samples.*Fetch each child",
-    ):
-        fit.vcov({"CRV1": "fe"}, data=left_sample)
-
-    for child, (vcov_type_detail, vcov) in zip(children, inference_before, strict=True):
-        assert child._vcov_type_detail == vcov_type_detail
-        np.testing.assert_array_equal(child._vcov, vcov)
-
-
-def test_fixest_multi_vcov_rejects_equal_size_distinct_na_masks(
-    lifecycle_data: pd.DataFrame,
-) -> None:
-    """Equal-sized formula expansions must retain the same source rows."""
+    """Clustering reads filtered model data before and after storage cleanup."""
     data = lifecycle_data.copy()
     data.loc[data.index[0], "x"] = np.nan
-    data.loc[data.index[1], "x2"] = np.nan
-    fit = pf.feols(
-        "y ~ sw(x, x2) | fe",
-        data=data,
-        vcov="iid",
-        store_data=False,
+    data.loc[data.index[-1], "fe"] = "singleton"
+    data["cluster"] = np.tile(["g1", "g2", "g3"], 8)
+
+    with pytest.warns(UserWarning, match="singleton fixed effect"):
+        fit = pf.feols("y ~ x | fe", data=data, vcov="iid")
+    with pytest.warns(UserWarning, match="singleton fixed effect"):
+        expected = pf.feols(
+            "y ~ x | fe",
+            data=data,
+            vcov={"CRV1": "cluster"},
+            **expected_fit_kwargs,
+        )
+
+    assert "cluster" not in fit._model_matrix.independent.columns
+    assert fit._data.index.equals(fit._model_matrix.dependent.index)
+    fit.vcov({"CRV1": "cluster"})
+
+    np.testing.assert_allclose(fit._vcov, expected._vcov)
+
+
+def test_glm_vcov_uses_post_separation_model_data() -> None:
+    """A GLM covariance update uses rows left after singleton and separation filters."""
+    data = pd.DataFrame(
+        {
+            "y": [0, 0, 0, 1, 2, 3],
+            "fe": ["a", "a", "b", "b", "b", "c"],
+            "x": [-1.0, 0.5, 0.25, 1.0, -0.5, 1.5],
+            "cluster": ["u", "u", "v", "v", "w", "w"],
+        }
     )
-    children = fit.to_list()
-    inference_before = [
-        (child._vcov_type_detail, child._vcov.copy()) for child in children
-    ]
 
-    with pytest.raises(
-        ValueError,
-        match=r"child models use different estimation samples.*Fetch each child",
-    ):
-        fit.vcov({"CRV1": "fe"}, data=data.drop(index=0))
+    with pytest.warns(UserWarning, match="observations removed because of separation"):
+        fit = pf.fepois("y ~ x | fe", data=data, vcov="iid", separation_check=["fe"])
+    with pytest.warns(UserWarning, match="observations removed because of separation"):
+        expected = pf.fepois(
+            "y ~ x | fe",
+            data=data,
+            vcov={"CRV1": "cluster"},
+            separation_check=["fe"],
+        )
 
-    for child, (vcov_type_detail, vcov) in zip(children, inference_before, strict=True):
-        assert child._vcov_type_detail == vcov_type_detail
-        np.testing.assert_array_equal(child._vcov, vcov)
+    assert fit._data.index.equals(fit._model_matrix.dependent.index)
+    fit.vcov({"CRV1": "cluster"})
+
+    np.testing.assert_allclose(fit._vcov, expected._vcov)
 
 
-def test_vcov_rejects_unfiltered_explicit_data(
+def test_fixest_multi_vcov_uses_each_split_child_sample(
     lifecycle_data: pd.DataFrame,
 ) -> None:
-    """An explicit covariance sample must align with the fitted row arrays."""
-    data = lifecycle_data.copy()
-    data.loc[data.index[0], "y"] = np.nan
-    estimation_sample = data.dropna(subset=["y", "x", "fe"])
-    stripped = pf.feols(
-        "y ~ x | fe",
-        data=data,
-        vcov="iid",
-        store_data=False,
+    """Split and stepwise children cluster on their own retained row samples."""
+    data = lifecycle_data.assign(
+        sample=np.tile(["left", "right"], 12),
+        cluster=np.tile(["g1", "g2", "g3"], 8),
     )
+    data.loc[[0, 13], "x2"] = np.nan
+    fit = pf.feols("y ~ sw(x, x2) | fe", data=data, split="sample", vcov="iid")
     expected = pf.feols(
-        "y ~ x | fe",
-        data=estimation_sample,
-        vcov={"CRV1": "fe"},
+        "y ~ sw(x, x2) | fe",
+        data=data,
+        split="sample",
+        vcov={"CRV1": "cluster"},
     )
+
+    fit.vcov({"CRV1": "cluster"})
+
+    assert {child._N_rows for child in fit.to_list()} == {11, 12}
+    for child, expected_child in zip(fit.to_list(), expected.to_list(), strict=True):
+        assert child._data.index.equals(child._model_matrix.dependent.index)
+        np.testing.assert_allclose(child._vcov, expected_child._vcov)
+
+
+def test_store_data_false_rejects_data_dependent_vcov(
+    lifecycle_data: pd.DataFrame,
+) -> None:
+    """A stripped fit cannot reconstruct cluster columns from retained arrays."""
+    fit = pf.feols("y ~ x", data=lifecycle_data, vcov="iid", store_data=False)
 
     with pytest.raises(
-        ValueError,
-        match=(
-            r"already-filtered estimation sample.*original estimation order; "
-            r"expected 23 rows, received 24"
-        ),
+        RuntimeError,
+        match=r"vcov\(\).*store_data=False.*Refit with store_data=True",
     ):
-        stripped.vcov({"CRV1": "fe"}, data=data)
-
-    stripped.vcov({"CRV1": "fe"}, data=estimation_sample)
-    np.testing.assert_allclose(stripped._vcov, expected._vcov)
+        fit.vcov({"CRV1": "fe"})
 
 
 def test_lean_vcov_fails_with_storage_guidance(

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -324,9 +324,8 @@ def test_fit_one_uses_the_structural_lifecycle_contract():
         def get_fit(self):
             self.events.append("fit")
 
-        def vcov(self, vcov, vcov_kwargs=None, data=None):
+        def vcov(self, vcov, vcov_kwargs=None):
             assert vcov == "iid"
-            assert data is None
             self.events.append("vcov")
 
         def get_inference(self):


### PR DESCRIPTION
Covariance updates now use each model's own filtered estimation sample. Removes the unintended `data` argument from covariance methods, containers and protocols. Non-formula cluster variables work during initial inference before storage cleanup; later data-dependent updates require retained data. Array-only updates remain available where supported, and each multiple-estimation child uses its own sample.

Review order: #1509 → **this PR** → #1512 → #1513 → #1514.

The lifecycle tests cover formula missingness, singleton removal, separation, split samples and storage options. Review found no remaining actionable issue in this layer.

Verification at `7b6ee9dcd8a805d502d80d9d5d58be09f533b30b`: **170 passed, 1 skipped (30.90s)**. Cumulative Python/R/HAC, release-contract, lint/type and documentation evidence, including exact commands and limitations, is recorded in #1514. Human maintainer review is required before merge.

<details>
<summary>Exact layer verification command</summary>

Run from `/tmp/pyfixest-stack-fixes/data-repair`:

```sh
env PYTHONPATH=/tmp/pyfixest-stack-fixes/data-repair NUMBA_CACHE_DIR=/tmp/pyfixest-stack-review/numba MPLCONFIGDIR=/tmp/pyfixest-stack-review/mpl OPENBLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 MKL_NUM_THREADS=1 VECLIB_MAXIMUM_THREADS=1 NUMEXPR_NUM_THREADS=1 pixi run --as-is --manifest-path /Users/admin/Documents/pyfixest/pyproject.toml -e py312 python -m pytest tests/test_estimator_state_lifecycle.py tests/test_plan.py tests/test_errors.py --no-cov -q
```

</details>
