### PR TITLE
fix(vcov): publish inference updates atomically

### DIFF
--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -280,6 +280,10 @@ We also removed:
 
 ### Bug Fixes
 
+- Post-estimation `vcov()` updates are now transactional. Validation,
+  covariance-computation, or later-child failures preserve the previous
+  covariance metadata and derived inference for single and multiple-estimation
+  results.
 - `lean=True` results keep the formula specification and evaluation context, so
   `predict(newdata=...)` keeps working for models without fixed effects; methods
   that need discarded state now raise an informative `RuntimeError` instead of

--- a/docs/developer/architecture.md
+++ b/docs/developer/architecture.md
@@ -166,8 +166,13 @@ runner then mutates the model through preparation, fitting, covariance
 calculation, inference, performance statistics or IV first stages, and finally
 `_clear_attributes()`. `store_data=False` deletes `_data`; `lean=True` deletes
 the retained matrices and several fit products. The public `vcov()` method is
-intentionally in-place and remains a post-fit mutation boundary. User input is
-copied by default, with the documented `copy_data=False` path as the exception.
+intentionally in-place and remains a post-fit mutation boundary. It computes a
+complete typed inference state on a private staging copy before publishing any
+fields. Multiple-estimation containers prepare every child's update before
+publishing the first, so validation or numerical failure preserves all prior
+covariance metadata, derived inference, and quantile-solver random state.
+User input is copied by default, with the documented `copy_data=False` path as
+the exception.
 
 ## Formula-state and lifecycle boundaries
 

--- a/pyfixest/estimation/FixestMulti_.py
+++ b/pyfixest/estimation/FixestMulti_.py
@@ -8,6 +8,7 @@ from typing import Any, Generic, TypeVar, cast
 import pandas as pd
 
 from pyfixest.estimation.config import EstimationConfig
+from pyfixest.estimation.internals.vcov_utils import InferenceState
 from pyfixest.estimation.models._tidy_accessors import TidyColumnAccessors
 from pyfixest.estimation.models.feols_ import Feols
 from pyfixest.estimation.plan_ import ParsedFormula
@@ -152,8 +153,13 @@ class FixestMulti(TidyColumnAccessors, Generic[ResultT]):
         that support them, post-fit clustered or HAC covariance updates require
         `store_data=True` and `lean=False`.
         """
+        prepared: list[tuple[ResultT, InferenceState]] = []
         for fxst in self.all_fitted_models.values():
-            fxst.vcov(vcov=vcov, vcov_kwargs=vcov_kwargs)
+            state = fxst._prepare_vcov(vcov=vcov, vcov_kwargs=vcov_kwargs)
+            prepared.append((fxst, state))
+
+        for fxst, state in prepared:
+            fxst._apply_vcov(state)
         return self
 
     def tidy(self) -> pd.DataFrame:

--- a/pyfixest/estimation/internals/families.py
+++ b/pyfixest/estimation/internals/families.py
@@ -17,8 +17,8 @@ class InferenceDist:
     The `df_t` argument is ignored for the normal distribution.
     """
 
-    pvalue: Callable[[np.ndarray, int], np.ndarray]
-    crit_val: Callable[[float, int], float]
+    pvalue: Callable[[np.ndarray, int | float], np.ndarray]
+    crit_val: Callable[[float, int | float], float]
 
 
 T_DIST = InferenceDist(

--- a/pyfixest/estimation/internals/vcov_utils.py
+++ b/pyfixest/estimation/internals/vcov_utils.py
@@ -1,5 +1,6 @@
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import Any
 
 import numpy as np
 import pandas as pd
@@ -28,6 +29,45 @@ class ClusterPrep:
     G: list[int]  # cluster counts per column, post ssc_dict["G_df"] adjustment
     k_fe_nested: int
     n_fe_fully_nested: int
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class HacMetadata:
+    "Metadata needed to describe and recompute a HAC covariance estimate."
+
+    lag: int | None
+    time_id: str
+    panel_id: str | None
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class GeneratorState:
+    "Copied bit-generator state advanced by staged covariance computation."
+
+    state: dict[str, Any]
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class InferenceState:
+    "Complete covariance and derived-inference state prepared for publication."
+
+    vcov_type: str
+    vcov_type_detail: str
+    is_clustered: bool
+    clustervar: list[str]
+    G: list[int]
+    bread: np.ndarray
+    ssc: np.ndarray
+    vcov: np.ndarray
+    df_k: int
+    df_t: int | float
+    se: np.ndarray
+    tstat: np.ndarray
+    pvalue: np.ndarray
+    conf_int: np.ndarray
+    cluster_df: pd.DataFrame | None
+    hac: HacMetadata | None
+    generator: GeneratorState | None
 
 
 def prepare_cluster_state(

--- a/pyfixest/estimation/models/base_regression_.py
+++ b/pyfixest/estimation/models/base_regression_.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import functools
 import warnings
 from collections.abc import Mapping
+from copy import copy as shallow_copy
 from dataclasses import replace
 from functools import partial
 from importlib import import_module
@@ -60,6 +61,9 @@ from pyfixest.estimation.internals.vcov_ import (
     vcov_iid_ols,
 )
 from pyfixest.estimation.internals.vcov_utils import (
+    GeneratorState,
+    HacMetadata,
+    InferenceState,
     _compute_bread,
     prepare_cluster_state,
     run_crv_loop,
@@ -287,7 +291,7 @@ class BaseRegression(TidyColumnAccessors):
     _N: int | float
     _N_rows: int
     _k: int
-    _df_t: int
+    _df_t: int | float
     _vcov: NDArray[np.float64]
     _beta_hat: NDArray[np.float64]
     _u_hat: NDArray[np.float64]
@@ -895,6 +899,17 @@ class BaseRegression(TidyColumnAccessors):
         See [On Small Sample Corrections](/explanation/ssc.qmd) for how the
         `ssc` adjustments interact with each estimator.
         """
+        state = self._prepare_vcov(vcov=vcov, vcov_kwargs=vcov_kwargs)
+        self._apply_vcov(state)
+        return self
+
+    def _prepare_vcov(
+        self,
+        *,
+        vcov: str | dict[str, str],
+        vcov_kwargs: dict[str, str | int] | None,
+    ) -> InferenceState:
+        """Compute a complete inference update without mutating this result."""
         self._require_fit_arrays(
             "vcov",
             arrays="the required estimation arrays",
@@ -911,6 +926,8 @@ class BaseRegression(TidyColumnAccessors):
         vcov_type, vcov_type_detail, is_clustered, clustervar = _deparse_vcov_input(
             vcov, self._has_fixef, self._is_iv
         )
+        vcov_type_detail = cast(str, vcov_type_detail)
+        clustervar = [] if clustervar is None else clustervar
 
         # Reject before any inference state is overwritten, so a failed update
         # leaves the previous covariance estimate intact.
@@ -920,10 +937,60 @@ class BaseRegression(TidyColumnAccessors):
                 remedy="Refit with store_data=True and lean=False.",
             )
 
+        self._require_vcov_support(
+            vcov_type=vcov_type,
+            vcov_type_detail=vcov_type_detail,
+        )
+
+        staged = self._vcov_staging_copy()
+        staged._compute_vcov(
+            vcov_type=vcov_type,
+            vcov_type_detail=vcov_type_detail,
+            is_clustered=is_clustered,
+            clustervar=clustervar,
+            vcov_kwargs=vcov_kwargs,
+            data=data,
+        )
+        return staged._capture_inference_state()
+
+    def _require_vcov_support(
+        self,
+        *,
+        vcov_type: str,
+        vcov_type_detail: str,
+    ) -> None:
+        """Reject unsupported covariance requests before staging any work."""
+        if vcov_type == "HAC":
+            self._require_support("hac", subject="HAC inference (NW, DK)")
+        elif vcov_type_detail == "CRV3":
+            self._require_support("crv3", subject="CRV3 inference")
+        elif vcov_type == "nid":
+            self._require_support("nid", subject="'nid' inference")
+
+    def _vcov_staging_copy(self) -> BaseRegression:
+        """Return a shallow private copy whose inference fields may be replaced."""
+        return shallow_copy(self)
+
+    def _compute_vcov(
+        self,
+        *,
+        vcov_type: str,
+        vcov_type_detail: str,
+        is_clustered: bool,
+        clustervar: list[str],
+        vcov_kwargs: dict[str, str | int] | None,
+        data: pd.DataFrame | None,
+    ) -> None:
+        """Compute covariance and inference in place on a private staging copy."""
         self._vcov_type = vcov_type
         self._vcov_type_detail = vcov_type_detail
         self._is_clustered = is_clustered
         self._clustervar = clustervar
+        self._G = []
+        self._cluster_df = None
+        self._lag = None
+        self._time_id = None
+        self._panel_id = None
 
         self._bread = _compute_bread(
             self._is_iv, self._tXZ, self._tZZinv, self._tZX, self._hessian
@@ -983,7 +1050,65 @@ class BaseRegression(TidyColumnAccessors):
         # update p-value, t-stat, standard error, confint
         self.get_inference()
 
-        return self
+    def _capture_inference_state(self) -> InferenceState:
+        """Return the completed staged fields as one publication payload."""
+        hac = (
+            HacMetadata(
+                lag=cast(int | None, self._lag),
+                time_id=cast(str, self._time_id),
+                panel_id=cast(str | None, self._panel_id),
+            )
+            if self._vcov_type == "HAC"
+            else None
+        )
+        return InferenceState(
+            vcov_type=self._vcov_type,
+            vcov_type_detail=self._vcov_type_detail,
+            is_clustered=self._is_clustered,
+            clustervar=list(self._clustervar),
+            G=list(self._G),
+            bread=self._bread,
+            ssc=self._ssc,
+            vcov=self._vcov,
+            df_k=self._df_k,
+            df_t=self._df_t,
+            se=self._se,
+            tstat=self._tstat,
+            pvalue=self._pvalue,
+            conf_int=self._conf_int,
+            cluster_df=self._cluster_df,
+            hac=hac,
+            generator=self._capture_vcov_generator_state(),
+        )
+
+    def _capture_vcov_generator_state(self) -> GeneratorState | None:
+        """Return estimator-specific random state advanced during staging."""
+        return None
+
+    def _apply_vcov_generator_state(self, state: GeneratorState | None) -> None:
+        """Publish estimator-specific random state after successful staging."""
+
+    def _apply_vcov(self, state: InferenceState) -> None:
+        """Publish one fully prepared inference update on this fitted result."""
+        self._apply_vcov_generator_state(state.generator)
+        self._vcov_type = state.vcov_type
+        self._vcov_type_detail = state.vcov_type_detail
+        self._is_clustered = state.is_clustered
+        self._clustervar = state.clustervar
+        self._G = state.G
+        self._bread = state.bread
+        self._ssc = state.ssc
+        self._vcov = state.vcov
+        self._df_k = state.df_k
+        self._df_t = state.df_t
+        self._se = state.se
+        self._tstat = state.tstat
+        self._pvalue = state.pvalue
+        self._conf_int = state.conf_int
+        self._cluster_df = state.cluster_df
+        self._lag = None if state.hac is None else state.hac.lag
+        self._time_id = None if state.hac is None else state.hac.time_id
+        self._panel_id = None if state.hac is None else state.hac.panel_id
 
     def _make_ssc_kwargs(
         self,

--- a/pyfixest/estimation/models/feols_.py
+++ b/pyfixest/estimation/models/feols_.py
@@ -491,7 +491,7 @@ class Feols(BaseRegression):
         self._require_estimation_data("ccv")
 
         if cluster is None:
-            if self._clustervar is None:
+            if not self._clustervar:
                 raise ValueError("No cluster variable found in the model fit.")
             elif len(self._clustervar) > 1:
                 raise ValueError(

--- a/pyfixest/estimation/protocols.py
+++ b/pyfixest/estimation/protocols.py
@@ -7,6 +7,7 @@ if TYPE_CHECKING:
     import pandas as pd
 
     from pyfixest.estimation.internals.literals import InferenceType
+    from pyfixest.estimation.internals.vcov_utils import InferenceState
     from pyfixest.estimation.models.base_regression_ import BaseRegression
 
 
@@ -135,6 +136,19 @@ class FittedResult(Protocol):
         vcov_kwargs: dict[str, str | int] | None = None,
     ) -> FittedResult:
         """Replace the covariance estimate and the inference derived from it."""
+        ...
+
+    def _prepare_vcov(
+        self,
+        *,
+        vcov: str | dict[str, str],
+        vcov_kwargs: dict[str, str | int] | None,
+    ) -> InferenceState:
+        """Prepare a covariance update without mutating this result."""
+        ...
+
+    def _apply_vcov(self, state: InferenceState) -> None:
+        """Publish one fully prepared covariance update."""
         ...
 
     def get_inference(self, alpha: float = 0.05) -> None:

--- a/pyfixest/estimation/quantreg/QuantregMulti.py
+++ b/pyfixest/estimation/quantreg/QuantregMulti.py
@@ -18,6 +18,7 @@ from pyfixest.estimation.internals.literals import (
     SolverOptions,
     WeightsTypeOptions,
 )
+from pyfixest.estimation.internals.vcov_utils import InferenceState
 from pyfixest.estimation.quantreg.quantreg_ import Quantreg
 from pyfixest.estimation.quantreg.utils import get_hall_sheather_bandwidth
 
@@ -207,8 +208,13 @@ class QuantregMulti:
         vcov_kwargs: dict[str, str | int] | None = None,
     ) -> dict[float, Quantreg]:
         "Compute variance-covariance matrices for all models in the quantile regression process."
+        prepared: list[tuple[Quantreg, InferenceState]] = []
         for quantreg in self.all_quantregs.values():
-            quantreg.vcov(vcov=vcov, vcov_kwargs=vcov_kwargs)
+            state = quantreg._prepare_vcov(vcov=vcov, vcov_kwargs=vcov_kwargs)
+            prepared.append((quantreg, state))
+
+        for quantreg, state in prepared:
+            quantreg._apply_vcov(state)
 
         return self.all_quantregs
 

--- a/pyfixest/estimation/quantreg/quantreg_.py
+++ b/pyfixest/estimation/quantreg/quantreg_.py
@@ -1,6 +1,10 @@
+from __future__ import annotations
+
 import warnings
 from collections.abc import Callable, Mapping
+from copy import deepcopy
 from functools import partial
+from types import MethodType
 from typing import Any, ClassVar, cast
 
 import numpy as np
@@ -17,6 +21,7 @@ from pyfixest.estimation.internals.literals import (
     SolverOptions,
     WeightsTypeOptions,
 )
+from pyfixest.estimation.internals.vcov_utils import GeneratorState
 from pyfixest.estimation.models.base_regression_ import BaseRegression
 from pyfixest.estimation.quantreg.frisch_newton_ip import (
     frisch_newton_solver,
@@ -455,6 +460,44 @@ class Quantreg(BaseRegression):
             method=cast(QuantregMethodOptions, self._method),
             fit=self._fit,
         )
+
+    def _vcov_staging_copy(self) -> Quantreg:
+        """Copy the NID solver callback and its RNG for transactional staging."""
+        staged = cast("Quantreg", super()._vcov_staging_copy())
+        fit = self._fit
+        if not isinstance(fit, partial):
+            return staged
+
+        keywords = dict(fit.keywords or {})
+        rng = keywords.get("rng")
+        if isinstance(rng, np.random.Generator):
+            keywords["rng"] = deepcopy(rng)
+
+        fit_function = fit.func
+        if isinstance(fit_function, MethodType) and fit_function.__self__ is self:
+            fit_function = getattr(staged, fit_function.__name__)
+        staged._fit = partial(fit_function, *fit.args, **keywords)
+        return staged
+
+    def _capture_vcov_generator_state(self) -> GeneratorState | None:
+        """Capture a staged PFN generator without exposing its mutable object."""
+        fit = self._fit
+        if not isinstance(fit, partial):
+            return None
+        rng = (fit.keywords or {}).get("rng")
+        if not isinstance(rng, np.random.Generator):
+            return None
+        return GeneratorState(state=deepcopy(rng.bit_generator.state))
+
+    def _apply_vcov_generator_state(self, state: GeneratorState | None) -> None:
+        """Advance the original PFN generator only after covariance succeeds."""
+        if state is None:
+            return
+        fit = self._fit
+        assert isinstance(fit, partial)
+        rng = (fit.keywords or {}).get("rng")
+        assert isinstance(rng, np.random.Generator)
+        rng.bit_generator.state = deepcopy(state.state)
 
     def _vcov_crv1(self, clustid: np.ndarray, cluster_col: np.ndarray):
         """

--- a/tests/test_ccv.py
+++ b/tests/test_ccv.py
@@ -203,3 +203,23 @@ def test_against_stata(data):
 
     assert np.abs(res_ccv4["2.5%"] - 0.428) < 1e-02
     assert np.abs(res_ccv4["97.5%"] - 0.503) < 1e-02
+
+
+@pytest.mark.parametrize("switch_from_crv", [False, True])
+def test_ccv_without_cluster_raises_after_nonclustered_inference(switch_from_crv):
+    """CCV requires an explicit cluster after IID inference is published."""
+    rng = np.random.default_rng(20260905)
+    data = pd.DataFrame(
+        {
+            "y": rng.normal(size=24),
+            "treatment": np.tile([0, 1], 12),
+            "cluster": np.repeat(np.arange(6), 4),
+        }
+    )
+    vcov = {"CRV1": "cluster"} if switch_from_crv else "iid"
+    fit = feols("y ~ treatment", data=data, vcov=vcov)
+    if switch_from_crv:
+        fit.vcov("iid")
+
+    with pytest.raises(ValueError, match="No cluster variable found in the model fit"):
+        fit.ccv(treatment="treatment")

--- a/tests/test_estimator_state_lifecycle.py
+++ b/tests/test_estimator_state_lifecycle.py
@@ -7,6 +7,7 @@ and row-sample seams locked here are not observable from those suites.
 
 from __future__ import annotations
 
+from copy import deepcopy
 from dataclasses import FrozenInstanceError
 
 import numpy as np
@@ -14,6 +15,8 @@ import pandas as pd
 import pytest
 
 import pyfixest as pf
+import pyfixest.estimation.models.base_regression_ as base_regression_module
+from pyfixest.errors import NanInClusterVarError, VcovTypeNotSupportedError
 from pyfixest.estimation.FixestMulti_ import FixestMulti
 from pyfixest.estimation.formula.model_matrix import ModelMatrix, create_model_matrix
 from pyfixest.estimation.formula.parse import Formula
@@ -23,6 +26,59 @@ from pyfixest.estimation.internals.model_state import (
     ObservationWeights,
     WithinLinearData,
 )
+from pyfixest.estimation.quantreg.quantreg_ import Quantreg
+from pyfixest.estimation.quantreg.QuantregMulti import QuantregMulti
+
+INFERENCE_FIELDS = (
+    "_vcov_type",
+    "_vcov_type_detail",
+    "_is_clustered",
+    "_clustervar",
+    "_G",
+    "_bread",
+    "_ssc",
+    "_vcov",
+    "_df_k",
+    "_df_t",
+    "_se",
+    "_tstat",
+    "_pvalue",
+    "_conf_int",
+    "_cluster_df",
+    "_lag",
+    "_time_id",
+    "_panel_id",
+)
+_MISSING = object()
+
+
+def _snapshot_inference(model) -> dict[str, object]:
+    """Copy only covariance metadata and derived inference fields."""
+    snapshot: dict[str, object] = {}
+    for field in INFERENCE_FIELDS:
+        value = getattr(model, field, _MISSING)
+        if isinstance(value, np.ndarray):
+            value = value.copy()
+        elif isinstance(value, pd.DataFrame):
+            value = value.copy(deep=True)
+        elif isinstance(value, list):
+            value = list(value)
+        snapshot[field] = value
+    return snapshot
+
+
+def _assert_inference_unchanged(model, before: dict[str, object]) -> None:
+    """Assert exact preservation of covariance metadata and inference arrays."""
+    after = _snapshot_inference(model)
+    assert after.keys() == before.keys()
+    for field, expected in before.items():
+        actual = after[field]
+        if isinstance(expected, np.ndarray):
+            np.testing.assert_array_equal(actual, expected, err_msg=field)
+        elif isinstance(expected, pd.DataFrame):
+            pd.testing.assert_frame_equal(actual, expected, obj=field)
+        else:
+            assert actual == expected, field
 
 
 @pytest.fixture
@@ -618,6 +674,159 @@ def test_store_data_false_rejects_data_dependent_vcov(
         match=r"vcov\(\).*store_data=False.*Refit with store_data=True",
     ):
         fit.vcov({"CRV1": "fe"})
+
+
+def test_rejected_glm_crv3_preserves_inference_state(
+    lifecycle_data: pd.DataFrame,
+) -> None:
+    """An unsupported covariance request leaves every published field unchanged."""
+    fit = pf.feglm("y ~ x", data=lifecycle_data, family="gaussian", vcov="iid")
+    before = _snapshot_inference(fit)
+
+    with pytest.raises(VcovTypeNotSupportedError, match="CRV3 inference"):
+        fit.vcov({"CRV3": "fe"})
+
+    _assert_inference_unchanged(fit, before)
+
+
+@pytest.mark.parametrize("failure", ["validation", "computation"])
+def test_failed_hac_update_preserves_inference_state(
+    lifecycle_data: pd.DataFrame,
+    monkeypatch: pytest.MonkeyPatch,
+    failure: str,
+) -> None:
+    """HAC validation and kernel failures cannot publish partial metadata."""
+    data = lifecycle_data.assign(time=np.arange(len(lifecycle_data)))
+    if failure == "validation":
+        data["time"] = pd.Series(["invalid"] * len(data), dtype=object)
+    else:
+
+        def fail_hac_computation(**kwargs):
+            raise RuntimeError("forced HAC computation failure")
+
+        monkeypatch.setattr(base_regression_module, "vcov_hac", fail_hac_computation)
+
+    fit = pf.feols("y ~ x", data=data, vcov={"CRV1": "fe"})
+    before = _snapshot_inference(fit)
+    error = ValueError if failure == "validation" else RuntimeError
+    message = (
+        "time variable must be numeric"
+        if failure == "validation"
+        else "forced HAC computation failure"
+    )
+
+    with pytest.raises(error, match=message):
+        fit.vcov("NW", vcov_kwargs={"time_id": "time", "lag": 1})
+
+    _assert_inference_unchanged(fit, before)
+
+
+def test_fixest_multi_vcov_prepares_every_child_before_publish(
+    lifecycle_data: pd.DataFrame,
+) -> None:
+    """A later child's failure leaves every model in a FixestMulti unchanged."""
+    data = lifecycle_data.assign(
+        cluster=np.tile(["g1", "g2", "g3"], 8),
+        time=np.arange(len(lifecycle_data)),
+    )
+    data.loc[0, ["x", "cluster"]] = np.nan
+    fit = pf.feols(
+        "y ~ sw(x, x2)",
+        data=data,
+        vcov="NW",
+        vcov_kwargs={"time_id": "time", "lag": 1},
+    )
+    children = fit.to_list()
+    child_ids = [id(child) for child in children]
+    before = [_snapshot_inference(child) for child in children]
+
+    with pytest.raises(NanInClusterVarError, match="missing values"):
+        fit.vcov({"CRV1": "cluster"})
+
+    assert [id(child) for child in fit.to_list()] == child_ids
+    for child, state in zip(children, before, strict=True):
+        _assert_inference_unchanged(child, state)
+
+
+def test_quantreg_multi_vcov_isolates_later_child_rng_failure(
+    lifecycle_data: pd.DataFrame,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Quantile staging binds a private solver and advances no RNG on failure."""
+    with pytest.warns(FutureWarning, match="experimental"):
+        fit = pf.quantreg(
+            "y ~ x",
+            data=lifecycle_data,
+            quantile=[0.25, 0.75],
+            method="pfn",
+            vcov="iid",
+            seed=42,
+        )
+    children = fit.to_list()
+    wrapper = QuantregMulti.__new__(QuantregMulti)
+    wrapper.all_quantregs = {child._quantile: child for child in children}
+    child_ids = [id(child) for child in children]
+    inference_before = [_snapshot_inference(child) for child in children]
+    rng_before = [
+        deepcopy(child._fit.keywords["rng"].bit_generator.state) for child in children
+    ]
+    rng_objects = [child._fit.keywords["rng"] for child in children]
+    original_vcov_nid = Quantreg._vcov_nid
+
+    def fail_second_child(self: Quantreg) -> np.ndarray:
+        if self._quantile == 0.75:
+            assert self._fit.func.__self__ is self
+            self._fit.keywords["rng"].random()
+            raise RuntimeError("forced quantile covariance failure")
+        return original_vcov_nid(self)
+
+    monkeypatch.setattr(Quantreg, "_vcov_nid", fail_second_child)
+
+    with pytest.raises(RuntimeError, match="forced quantile covariance failure"):
+        wrapper.vcov("nid")
+
+    assert [id(child) for child in wrapper.all_quantregs.values()] == child_ids
+    for child, inference, rng_state in zip(
+        children, inference_before, rng_before, strict=True
+    ):
+        _assert_inference_unchanged(child, inference)
+        assert child._fit.keywords["rng"].bit_generator.state == rng_state
+
+    def successful_nid(self: Quantreg) -> np.ndarray:
+        assert self._fit.func.__self__ is self
+        self._fit.keywords["rng"].random()
+        return self._vcov.copy()
+
+    monkeypatch.setattr(Quantreg, "_vcov_nid", successful_nid)
+    assert wrapper.vcov("nid") is wrapper.all_quantregs
+    for child, rng, rng_state in zip(children, rng_objects, rng_before, strict=True):
+        assert child._fit.keywords["rng"] is rng
+        assert rng.bit_generator.state != rng_state
+
+
+@pytest.mark.parametrize(
+    ("initial_vcov", "vcov_kwargs"),
+    [({"CRV1": "fe"}, None), ("NW", {"time_id": "time", "lag": 1})],
+    ids=["cluster", "hac"],
+)
+def test_successful_vcov_update_resets_type_specific_metadata(
+    lifecycle_data: pd.DataFrame,
+    initial_vcov: str | dict[str, str],
+    vcov_kwargs: dict[str, str | int] | None,
+) -> None:
+    """Publishing IID inference clears metadata owned by prior CRV or HAC state."""
+    data = lifecycle_data.assign(time=np.arange(len(lifecycle_data)))
+    fit = pf.feols("y ~ x", data=data, vcov=initial_vcov, vcov_kwargs=vcov_kwargs)
+
+    assert fit.vcov("iid") is fit
+    assert fit._vcov_type == "iid"
+    assert fit._is_clustered is False
+    assert fit._clustervar == []
+    assert fit._G == []
+    assert fit._cluster_df is None
+    assert fit._lag is None
+    assert fit._time_id is None
+    assert fit._panel_id is None
 
 
 def test_lean_vcov_fails_with_storage_guidance(


### PR DESCRIPTION
Failed `vcov()` updates now preserve covariance, degrees of freedom, labels and derived inference. Models prepare a typed inference payload on a private staging copy; containers prepare every child before publishing any update. Quantile solver callbacks and RNG state are isolated during preparation. Successful updates preserve result identity and clear obsolete covariance metadata.

Review order: #1511 → **this PR** → #1513 → #1514.

Existing covariance kernels remain unchanged. Tests cover rejected GLM CRV3, validation/kernel failures, a later child's failure, RNG preservation and CCV's missing-cluster error. Review found no remaining actionable issue.

Verification at `0ec4b9604643fcf08365de2d9139bcada7f28419`: **66 passed, 5 deselected (3.42s)**. Cumulative Python/R/HAC, release-contract, lint/type and documentation evidence, including exact commands and limitations, is recorded in #1514. Human maintainer review is required before merge.

<details>
<summary>Exact layer verification command</summary>

Run from `/tmp/pyfixest-stack-fixes/atomic-repair`:

```sh
env PYTHONPATH=/tmp/pyfixest-stack-fixes/atomic-repair NUMBA_CACHE_DIR=/tmp/pyfixest-stack-review/numba MPLCONFIGDIR=/tmp/pyfixest-stack-review/mpl OPENBLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 MKL_NUM_THREADS=1 VECLIB_MAXIMUM_THREADS=1 NUMEXPR_NUM_THREADS=1 pixi run --as-is --manifest-path /Users/admin/Documents/pyfixest/pyproject.toml -e py312 python -m pytest tests/test_estimator_state_lifecycle.py tests/test_ccv.py -m 'not extended' --no-cov -q
```

</details>
