### PR TITLE
fix(vcov): validate CRV3 refit coefficients

### DIFF
--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -280,6 +280,9 @@ We also removed:
 
 ### Bug Fixes
 
+- CRV3 covariance estimation now rejects leave-one-cluster-out refits that drop,
+  add, or duplicate coefficient names instead of broadcasting or misaligning
+  coefficients.
 - Post-estimation `vcov()` updates are now transactional. Validation,
   covariance-computation, or later-child failures preserve the previous
   covariance metadata and derived inference for single and multiple-estimation

--- a/pyfixest/estimation/models/base_regression_.py
+++ b/pyfixest/estimation/models/base_regression_.py
@@ -19,7 +19,11 @@ from scipy.stats import chi2, f
 
 from pyfixest.core.demean import Preconditioner, WithinPreconditionerName
 from pyfixest.demeaners import AnyDemeaner, LsmrDemeaner, MapDemeaner
-from pyfixest.errors import EmptyVcovError, VcovTypeNotSupportedError
+from pyfixest.errors import (
+    EmptyVcovError,
+    MatrixNotFullRankError,
+    VcovTypeNotSupportedError,
+)
 from pyfixest.estimation.api.utils import _ALL_SAMPLE, _AllSampleSentinel
 from pyfixest.estimation.capabilities import (
     DID_METHOD_LABELS,
@@ -1301,12 +1305,25 @@ class BaseRegression(TidyColumnAccessors):
         data: pd.DataFrame,
     ) -> np.ndarray:
         beta_jack = np.zeros((len(clustid), self._k))
+        full_terms = pd.Index(self._coefnames)
 
         for ixg, g in enumerate(clustid):
             # direct leave one cluster out implementation
             refit_data = data[~np.equal(g, cluster_col)]
             fit = self._crv3_refit(data=refit_data)
-            beta_jack[ixg, :] = fit.coef().to_numpy()
+            refit_coef = fit.coef()
+            duplicate = (
+                refit_coef.index[refit_coef.index.duplicated()].unique().tolist()
+            )
+            missing = full_terms.difference(refit_coef.index, sort=False).tolist()
+            unexpected = refit_coef.index.difference(full_terms, sort=False).tolist()
+            if duplicate or missing or unexpected:
+                raise MatrixNotFullRankError(
+                    "CRV3 leave-one-cluster-out refit omitting cluster "
+                    f"{g!r} changed coefficient names; missing terms: {missing}; "
+                    f"unexpected terms: {unexpected}; duplicate terms: {duplicate}."
+                )
+            beta_jack[ixg, :] = refit_coef.reindex(full_terms).to_numpy()
 
         # optional: beta_bar in MNW (2022)
         # center = "estimate"

--- a/tests/test_ses.py
+++ b/tests/test_ses.py
@@ -1,11 +1,18 @@
+from types import SimpleNamespace
+
 import numpy as np
 import pandas as pd
 import pytest
 
 import pyfixest.estimation as estimation
 from pyfixest.demeaners import LsmrDemeaner, MapDemeaner
+from pyfixest.errors import MatrixNotFullRankError
 from pyfixest.estimation import feols, fepois
 from pyfixest.utils.utils import get_data, ssc
+from tests.test_estimator_state_lifecycle import (
+    _assert_inference_unchanged,
+    _snapshot_inference,
+)
 
 
 @pytest.mark.parametrize("seed", [3212, 3213, 3214])
@@ -343,6 +350,94 @@ def test_crv3_rebuilds_preconditioner_for_each_changed_design():
     )
 
     assert np.isfinite(fit._vcov).all()
+
+
+def _crv3_rank_loss_data() -> pd.DataFrame:
+    """Build a sample where omitting cluster zero makes z collinear with x."""
+    rng = np.random.default_rng(1499)
+    n = 120
+    cluster = np.repeat(np.arange(6), 20)
+    x = rng.normal(size=n)
+    z = x + 1e-5 * rng.normal(size=n)
+    z[cluster == 0] += rng.normal(size=20)
+    return pd.DataFrame(
+        {
+            "y": 0.5 * x + 2 * z + rng.normal(scale=0.01, size=n),
+            "x": x,
+            "z": z,
+            "fixed_effect": np.tile(np.arange(4), 30),
+            "cluster": cluster,
+        }
+    )
+
+
+def test_crv3_rejects_leave_cluster_out_coefficient_mismatch():
+    """CRV3 must not broadcast a rank-deficient refit's coefficients."""
+    data = _crv3_rank_loss_data()
+    error = (
+        r"omitting cluster .*0.*missing terms: \['z'\]; "
+        r"unexpected terms: \[\]"
+    )
+
+    with pytest.raises(MatrixNotFullRankError, match=error):
+        feols(
+            "y ~ x + z | fixed_effect",
+            data=data,
+            vcov={"CRV3": "cluster"},
+            collin_tol=1e-4,
+        )
+
+    fit = feols(
+        "y ~ x + z | fixed_effect",
+        data=data,
+        vcov="iid",
+        collin_tol=1e-4,
+    )
+    before = _snapshot_inference(fit)
+    with pytest.raises(MatrixNotFullRankError, match=error):
+        fit.vcov({"CRV3": "cluster"})
+    _assert_inference_unchanged(fit, before)
+
+
+def test_crv3_aligns_refit_coefficient_names(monkeypatch):
+    """Slow CRV3 aligns names and rejects unexpected or duplicate terms."""
+    data = _crv3_rank_loss_data()
+    fit = feols(
+        "y ~ x + z | fixed_effect",
+        data=data,
+        vcov="iid",
+        collin_tol=1e-4,
+    )
+    refit_coefs = []
+
+    def reordered_refit(*, data):
+        i = len(refit_coefs)
+        coef = pd.Series([20.0 + i, 10.0 + i], index=["z", "x"])
+        refit_coefs.append(coef)
+        return SimpleNamespace(coef=lambda: coef)
+
+    monkeypatch.setattr(fit, "_crv3_refit", reordered_refit)
+    fit.vcov({"CRV3": "cluster"})
+    expected = np.zeros_like(fit._vcov)
+    for coef in refit_coefs:
+        centered = coef.reindex(fit._coefnames).to_numpy() - fit._beta_hat
+        expected += np.outer(centered, centered)
+    np.testing.assert_allclose(fit._vcov, fit._ssc * expected)
+
+    invalid_refits = [
+        (pd.Series([1.0, 2.0, 3.0], index=["x", "z", "w"]), "unexpected.*w"),
+        (pd.Series([1.0, 2.0, 3.0], index=["x", "x", "z"]), "duplicate.*x"),
+    ]
+    for coef, error in invalid_refits:
+        monkeypatch.setattr(
+            fit,
+            "_crv3_refit",
+            lambda *, data, coef=coef: SimpleNamespace(coef=lambda: coef),
+        )
+        before = _snapshot_inference(fit)
+        with pytest.raises(MatrixNotFullRankError, match=error):
+            fit.vcov({"CRV3": "cluster"})
+        _assert_inference_unchanged(fit, before)
 
 
 @pytest.mark.parametrize("vcov", ["NW", "DK"])

--- a/tests/test_ses.py
+++ b/tests/test_ses.py
@@ -422,7 +422,11 @@ def test_crv3_aligns_refit_coefficient_names(monkeypatch):
     for coef in refit_coefs:
         centered = coef.reindex(fit._coefnames).to_numpy() - fit._beta_hat
         expected += np.outer(centered, centered)
-    np.testing.assert_allclose(fit._vcov, fit._ssc * expected)
+    np.testing.assert_allclose(
+        fit._vcov,
+        fit._ssc * expected,
+        err_msg="CRV3 covariance differs after coefficient-name alignment",
+    )
 
     invalid_refits = [
         (pd.Series([1.0, 2.0, 3.0], index=["x", "z", "w"]), "unexpected.*w"),


### PR DESCRIPTION
CRV3 now raises `MatrixNotFullRankError` when a leave-cluster-out refit loses required coefficient names or returns duplicate/unexpected terms. Previously, a one-coefficient refit could broadcast across jackknife columns and return finite but invalid standard errors. Matching coefficients are explicitly reordered by name; estimation-option replay and preconditioner rebuilding remain unchanged.

Review order: #1512 → **this PR** → #1514.

The deterministic rank-loss reproduction covers initial estimation and failed updates with preserved inference. Existing OLS/Poisson success cases remain green. Review found no remaining actionable issue.

Verification at `a586ec744df0509b12461b4346f04df5fd5506d4`: **240 passed (32.85s)**. Cumulative Python/R/HAC, release-contract, lint/type and documentation evidence, including exact commands and limitations, is recorded in #1514. Human maintainer review is required before merge.

<details>
<summary>Exact layer verification command</summary>

Run from `/tmp/pyfixest-stack-fixes/crv3-integration`:

```sh
env PYTHONPATH=/tmp/pyfixest-stack-fixes/crv3-integration NUMBA_CACHE_DIR=/tmp/pyfixest-stack-review/numba MPLCONFIGDIR=/tmp/pyfixest-stack-review/mpl OPENBLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 MKL_NUM_THREADS=1 VECLIB_MAXIMUM_THREADS=1 NUMEXPR_NUM_THREADS=1 pixi run --as-is --manifest-path /Users/admin/Documents/pyfixest/pyproject.toml -e py312 python -m pytest tests/test_ses.py --no-cov -q
```

</details>
