### PR TITLE
docs(review): make correctness understandable from code

### DIFF
--- a/.agents/skills/pr-review/SKILL.md
+++ b/.agents/skills/pr-review/SKILL.md
@@ -33,6 +33,33 @@ Prioritize findings that can produce silently wrong numbers:
 Check that a new estimator is an add-on and that every claimed support path is
 tested or rejected explicitly.
 
+## Make correctness understandable from the code being reviewed
+
+For numerical changes and estimator-state refactors, trace each changed value
+through construction, fitting, inference, post-estimation, and cleanup. Identify
+its mathematical role and scale, row and column ordering, ownership, and
+lifetime. Map changed scores, weights, projections, and covariance expressions
+to the estimator equations, including weight factors already incorporated into
+another value.
+
+Check whether accurate econometric names, meaningful intermediate results, and
+control flow expose the invariants needed to verify the implementation. For
+copies, shared array views, read-only flags, and frozen objects, distinguish
+attribute rebinding from element mutation and state who may mutate the
+underlying data. Identify the concrete correctness guarantee or avoided work
+behind an optimization; do not make performance claims without measurements.
+
+Keep enduring contracts and useful mathematical explanations in code
+documentation. Put migration history and review-only motivation in the PR or a
+design note. Before removing a wrapper or shared accessor, audit its callers,
+subclass overrides, and supported estimator paths; fewer abstractions are not
+automatically clearer or safer.
+
+Separate demonstrated defects, pre-existing issues, intentional compatibility
+decisions, questions, and optional maintainability improvements. Answer
+questions directly and support disagreements with evidence rather than treating
+unfamiliar syntax or a naming preference as a correctness bug.
+
 ## Spend verification budget on unresolved risk
 
 Select checks with the `change-verification` skill, but review differs from

--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -24,6 +24,8 @@ fit3 = pf.feols("Y ~ X1 + X2 | f1", data = df)
   preparation for contributors and coding agents.
 - PR reviews now select verification from unresolved risk, reuse successful
   exact-head CI evidence, and avoid redundant broad local test runs.
+- PR reviews now also trace numerical meaning, array ownership, and state
+  lifetime so correctness arguments remain understandable from the code.
 - A new `test-r-fixest-fast` task runs a compact edit-time comparison of
   `feols`, `fepois`, and `feglm` with R `fixest`, and `quantreg` with R
   `quantreg`. The existing estimator-specific R suites remain the authoritative


### PR DESCRIPTION
Strengthens PR reviews by making numerical correctness understandable from the code, not only from passing tests. The review skill now asks reviewers to trace mathematical roles, array scales and ordering, ownership, and lifecycle boundaries, and to connect changed calculations to their equations.

The guidance distinguishes correctness defects from questions and optional maintainability improvements. It encourages meaningful names and caller audits without blanket stylistic rules. Existing risk priorities, exact-head CI reuse, and the human merge gate are unchanged.

Validated skill frontmatter, relative references, and diff whitespace. Astra reviewed the guidance against representative weighting, ownership, IV naming, shared-accessor, and reviewer-question cases. This is guidance-only; no estimator tests or documentation build are required. Independent of the estimator stack.
