### PR TITLE
docs(workflow): batch verification by changed risk

### DIFF
--- a/.agents/skills/change-verification/SKILL.md
+++ b/.agents/skills/change-verification/SKILL.md
@@ -17,20 +17,29 @@ is authoritative, including for which changes justify a documentation build.
 For a change confined to the documentation or workflow-metadata rows of that
 matrix, the row is the whole procedure: run its listed checks and report them.
 
-For a refactor declared invariant, run the release contract first and on every
-iteration; it is the cheapest check that can falsify the whole change. Cite it
-only when it reports passed cases: a skip means no baseline, not success. A
-failure ends the refactor classification. Fix it or follow the numerics row.
-Never widen a contract tolerance to get green.
+For a refactor declared invariant, follow the release-contract cadence in
+`docs/developer/testing.md`. Run focused behavior and caller tests while a
+related change batch is active, then satisfy the contract requirement at
+stabilization using still-applicable evidence. Run missing or invalidated checks,
+normally once on the cumulative head. Run the contract earlier when focused
+tests leave shared numerical risk unresolved or it is needed for investigation
+or baseline setup. Cite it only when it reports passed cases: a skip means no
+baseline, not success. A failure ends the refactor classification. Fix it or
+follow the numerics row; never widen a contract tolerance to get green.
 
 Start with targeted tests and changed-file format/lint/type checks. Once the
-implementation stabilizes, run the selected broader baseline once and assign
-each required long check to a local run or exact-head CI.
+implementation stabilizes, identify and satisfy still-missing required evidence
+using the policy cadence, and assign each required long check to a local run or
+exact-head CI.
 
-Unknown paths require the conservative PR baseline. For a stack, run targeted
-checks for each layer against its immediate parent and the broad suites once on
-the cumulative top against the trunk, unless each layer must be independently
-releasable.
+Unknown paths require the conservative PR baseline. Apply the general cadence
+to initial work, batches of review feedback, and stack reconstruction. Run
+focused checks for each independently functional layer against its immediate
+parent, and coordinate one owner to run broad suites once on the stabilized
+cumulative head against the trunk where a new run is needed. Repeat them only
+when later work invalidates the evidence, unresolved risk requires it, or an
+explicit acceptance requirement does. Run broad suites per layer only when each
+layer must be independently releasable.
 
 Complete the required edit and handoff checks locally. A long check listed as
 merge evidence may be deferred to exact-head CI when a local run would add no
@@ -44,9 +53,14 @@ For every applicable check record:
 
 - status: passed, failed, deferred, or not run;
 - exact command;
+- revision, environment, and tested scope;
 - elapsed time;
 - reason and destination for a deferred check;
 - for the release contract, the passed case count or the skip reason.
+
+Evidence from an earlier revision may still cover an unchanged seam, but must
+not be reported as exact-head evidence. State the intervening scope and rerun
+only what it invalidated.
 
 Do not claim implementation handoff while required local checks are unreported
 or failing, and do not claim merge readiness until all required exact-head

--- a/.agents/skills/change-verification/SKILL.md
+++ b/.agents/skills/change-verification/SKILL.md
@@ -17,29 +17,18 @@ is authoritative, including for which changes justify a documentation build.
 For a change confined to the documentation or workflow-metadata rows of that
 matrix, the row is the whole procedure: run its listed checks and report them.
 
-For a refactor declared invariant, follow the release-contract cadence in
-`docs/developer/testing.md`. Run focused behavior and caller tests while a
-related change batch is active, then satisfy the contract requirement at
-stabilization using still-applicable evidence. Run missing or invalidated checks,
-normally once on the cumulative head. Run the contract earlier when focused
-tests leave shared numerical risk unresolved or it is needed for investigation
-or baseline setup. Cite it only when it reports passed cases: a skip means no
-baseline, not success. A failure ends the refactor classification. Fix it or
-follow the numerics row; never widen a contract tolerance to get green.
+For a refactor declared invariant, follow the release contract's rules and
+timing in `docs/developer/testing.md`. Cite it only when it reports passed
+cases, and treat a failure as the end of the refactor classification: fix it or
+follow the numerics row.
 
 Start with targeted tests and changed-file format/lint/type checks. Once the
-implementation stabilizes, identify and satisfy still-missing required evidence
-using the policy cadence, and assign each required long check to a local run or
-exact-head CI.
+implementation stabilizes, identify and satisfy still-missing required evidence,
+and assign each required long check to a local run or exact-head CI.
 
-Unknown paths require the conservative PR baseline. Apply the general cadence
-to initial work, batches of review feedback, and stack reconstruction. Run
-focused checks for each independently functional layer against its immediate
-parent, and coordinate one owner to run broad suites once on the stabilized
-cumulative head against the trunk where a new run is needed. Repeat them only
-when later work invalidates the evidence, unresolved risk requires it, or an
-explicit acceptance requirement does. Run broad suites per layer only when each
-layer must be independently releasable.
+Unknown paths require the conservative PR baseline. For a stack, run focused
+checks for each layer against its immediate parent and follow the broad-check
+ownership rule in `docs/developer/testing.md`.
 
 Complete the required edit and handoff checks locally. A long check listed as
 merge evidence may be deferred to exact-head CI when a local run would add no
@@ -57,10 +46,6 @@ For every applicable check record:
 - elapsed time;
 - reason and destination for a deferred check;
 - for the release contract, the passed case count or the skip reason.
-
-Evidence from an earlier revision may still cover an unchanged seam, but must
-not be reported as exact-head evidence. State the intervening scope and rerun
-only what it invalidated.
 
 Do not claim implementation handoff while required local checks are unreported
 or failing, and do not claim merge readiness until all required exact-head

--- a/.agents/skills/implementation-strategy/SKILL.md
+++ b/.agents/skills/implementation-strategy/SKILL.md
@@ -41,9 +41,8 @@ carry the durable parts into the PR body's opening paragraph:
 7. the external numerical reference and permanent-test location, chosen by the
    preference order in `docs/developer/testing.md`;
 8. documentation, exports, and changelog wiring;
-9. whether results are intended to be invariant. If yes, route release-contract
-   timing through the risk-based cadence in `docs/developer/testing.md`; any
-   failure is a regression. If no, list the quantities and estimators expected
+9. whether results are intended to be invariant. If yes, any release-contract
+   failure is a regression; if no, list the quantities and estimators expected
    to move, because each becomes a `reason`ed declaration in
    `tests/test_release_contract.py`.
 

--- a/.agents/skills/implementation-strategy/SKILL.md
+++ b/.agents/skills/implementation-strategy/SKILL.md
@@ -41,10 +41,11 @@ carry the durable parts into the PR body's opening paragraph:
 7. the external numerical reference and permanent-test location, chosen by the
    preference order in `docs/developer/testing.md`;
 8. documentation, exports, and changelog wiring;
-9. whether results are intended to be invariant. If yes, the release contract
-   is the edit-loop gate and any failure is a regression; if no, list the
-   quantities and estimators expected to move, because each becomes a
-   `reason`ed declaration in `tests/test_release_contract.py`.
+9. whether results are intended to be invariant. If yes, route release-contract
+   timing through the risk-based cadence in `docs/developer/testing.md`; any
+   failure is a regression. If no, list the quantities and estimators expected
+   to move, because each becomes a `reason`ed declaration in
+   `tests/test_release_contract.py`.
 
 If the support matrix or external reference is unresolved, resolve it before
 implementation rather than allowing the code to choose policy implicitly.

--- a/.agents/skills/pr-handoff/SKILL.md
+++ b/.agents/skills/pr-handoff/SKILL.md
@@ -6,9 +6,10 @@ description: Curate agent-owned pyfixest commits and prepare a reviewer-ready si
 # Hand off work for review
 
 Use this skill after implementation and required verification stabilize, before
-the first remote submission. Required long checks may still be running in
-exact-head CI when clearly reported. Branch, commit, and PR-body conventions
-live in `docs/developer/git-and-pr-style.md`.
+the first remote submission; submission itself is not a revalidation gate (see
+the verification cadence in `docs/developer/testing.md`). Required long checks
+may still be running in exact-head CI when clearly reported. Branch, commit, and
+PR-body conventions live in `docs/developer/git-and-pr-style.md`.
 
 ## Decide whether history needs curation
 
@@ -65,11 +66,6 @@ When reconstructing a stack, complete and inspect the coherent stack before
 publication by default. Publish an incomplete draft sequence only when the user
 explicitly requests that workflow or a concrete early-CI dependency makes it
 useful.
-
-Committing, pushing, or opening a PR delivers already selected evidence; those
-actions are not revalidation gates. Follow the cadence in
-`docs/developer/testing.md`, reuse revision-scoped evidence that later changes
-did not invalidate, and coordinate one owner for broad cumulative checks.
 
 ## Draft the body and stop
 

--- a/.agents/skills/pr-handoff/SKILL.md
+++ b/.agents/skills/pr-handoff/SKILL.md
@@ -61,6 +61,15 @@ must be testable against its immediate parent and contain no unrelated cleanup.
 
 Before submission, inspect every layer's log/diff and the cumulative diff.
 Identify the immediate parent only when it is not obvious from the PR base.
+When reconstructing a stack, complete and inspect the coherent stack before
+publication by default. Publish an incomplete draft sequence only when the user
+explicitly requests that workflow or a concrete early-CI dependency makes it
+useful.
+
+Committing, pushing, or opening a PR delivers already selected evidence; those
+actions are not revalidation gates. Follow the cadence in
+`docs/developer/testing.md`, reuse revision-scoped evidence that later changes
+did not invalidate, and coordinate one owner for broad cumulative checks.
 
 ## Draft the body and stop
 

--- a/.agents/skills/pr-review/SKILL.md
+++ b/.agents/skills/pr-review/SKILL.md
@@ -69,11 +69,23 @@ the exact head SHA and inventory completed CI for that SHA, then run only the
 cheapest check that can answer each remaining review question.
 
 Do not duplicate an expensive successful exact-head CI job locally without a
-concrete reason. Escalate to a broad suite only when a narrow check fails or
-leaves material uncertainty, the diff crosses subsystems, equivalent exact-head
-CI is missing, stale, cancelled, or non-equivalent, or repository policy
-requires that suite. Before starting a multi-minute local check, state which
-unresolved risk it addresses and why existing CI is insufficient.
+concrete reason. During an active feedback batch, escalate to a broad suite only
+when a narrow check fails or leaves material uncertainty, or when a
+cross-subsystem diff creates shared risk that focused checks do not cover.
+Missing, stale, cancelled, or non-equivalent exact-head CI must be reported
+honestly, but does not alone restart broad checks after every edit. Run required
+missing evidence when the change reaches its stabilized acceptance boundary, or
+earlier to resolve an actual review risk. Before starting a multi-minute local
+check, state which unresolved risk or acceptance requirement it addresses and
+why existing evidence is insufficient.
+
+For incremental review, group related feedback into a change batch and reuse
+valid evidence. A new comment, commit, push, or reviewer handoff is not an
+automatic rerun trigger. Record the revision and scope of earlier evidence; do
+not call it exact-head evidence, and rerun only when the intervening diff can
+affect it, a review question remains unresolved, or acceptance explicitly
+requires a newer run. Coordinate one owner for broad checks to avoid duplicating
+the same evidence across author, reviewer, and agents.
 
 For a stack, inspect every layer's diff and run targeted checks wherever
 behavior changes. If the stated acceptance boundary is the cumulative stack, run

--- a/.agents/skills/pr-review/SKILL.md
+++ b/.agents/skills/pr-review/SKILL.md
@@ -69,23 +69,16 @@ the exact head SHA and inventory completed CI for that SHA, then run only the
 cheapest check that can answer each remaining review question.
 
 Do not duplicate an expensive successful exact-head CI job locally without a
-concrete reason. During an active feedback batch, escalate to a broad suite only
-when a narrow check fails or leaves material uncertainty, or when a
-cross-subsystem diff creates shared risk that focused checks do not cover.
-Missing, stale, cancelled, or non-equivalent exact-head CI must be reported
-honestly, but does not alone restart broad checks after every edit. Run required
-missing evidence when the change reaches its stabilized acceptance boundary, or
-earlier to resolve an actual review risk. Before starting a multi-minute local
-check, state which unresolved risk or acceptance requirement it addresses and
-why existing evidence is insufficient.
+concrete reason. Escalate to a broad suite only when a narrow check fails or
+leaves material uncertainty, the diff crosses subsystems with shared risk that
+focused checks do not cover, or repository policy requires that suite. Missing,
+stale, cancelled, or non-equivalent exact-head CI must be reported honestly.
+Before starting a multi-minute local check, state which unresolved risk or
+acceptance requirement it addresses and why existing evidence is insufficient.
 
-For incremental review, group related feedback into a change batch and reuse
-valid evidence. A new comment, commit, push, or reviewer handoff is not an
-automatic rerun trigger. Record the revision and scope of earlier evidence; do
-not call it exact-head evidence, and rerun only when the intervening diff can
-affect it, a review question remains unresolved, or acceptance explicitly
-requires a newer run. Coordinate one owner for broad checks to avoid duplicating
-the same evidence across author, reviewer, and agents.
+Incremental review follows the verification cadence in
+`docs/developer/testing.md`; a new comment, commit, push, or reviewer handoff is
+not by itself a rerun trigger.
 
 For a stack, inspect every layer's diff and run targeted checks wherever
 behavior changes. If the stated acceptance boundary is the cumulative stack, run

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,11 +139,11 @@ owns reference selection, markers, tolerances, the runtime tiers, and the
 selection matrix that decides which checks a change requires; the
 `change-verification` skill applies it.
 
-For internal or backend refactors that must not change results, the release
-contract (`test-release-contract`) is the edit-loop gate: it replays the public
-estimator matrix against a pinned pyfixest release in seconds. It is a
-regression alarm, not an external correctness reference; a released pyfixest
-result never substitutes for R.
+For internal or backend refactors that must not change results, route the
+release contract (`test-release-contract`) through the risk-based cadence in
+`docs/developer/testing.md`. It replays the public estimator matrix against a
+pinned pyfixest release and is a regression alarm, not an external correctness
+reference; a released pyfixest result never substitutes for R.
 
 Four rules that are easy to get wrong:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,10 +139,9 @@ owns reference selection, markers, tolerances, the runtime tiers, and the
 selection matrix that decides which checks a change requires; the
 `change-verification` skill applies it.
 
-For internal or backend refactors that must not change results, route the
-release contract (`test-release-contract`) through the risk-based cadence in
-`docs/developer/testing.md`. It replays the public estimator matrix against a
-pinned pyfixest release and is a regression alarm, not an external correctness
+For internal or backend refactors that must not change results, the release
+contract (`test-release-contract`) replays the public estimator matrix against a
+pinned pyfixest release. It is a regression alarm, not an external correctness
 reference; a released pyfixest result never substitutes for R.
 
 Four rules that are easy to get wrong:

--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -26,6 +26,9 @@ fit3 = pf.feols("Y ~ X1 + X2 | f1", data = df)
   exact-head CI evidence, and avoid redundant broad local test runs.
 - PR reviews now also trace numerical meaning, array ownership, and state
   lifetime so correctness arguments remain understandable from the code.
+- Verification guidance now batches related edits and review feedback, reuses
+  revision-scoped evidence, and runs broad checks when work stabilizes or risk
+  invalidates earlier results rather than at every delivery action.
 - A new `test-r-fixest-fast` task runs a compact edit-time comparison of
   `feols`, `fepois`, and `feglm` with R `fixest`, and `quantreg` with R
   `quantreg`. The existing estimator-specific R suites remain the authoritative

--- a/docs/developer/testing.md
+++ b/docs/developer/testing.md
@@ -17,11 +17,24 @@ selection affect wall time.
 | Merge evidence | Validate the exact PR head in affected environments | May take tens of minutes | canonical R, HAC, no-JIT, docs, plots, Rust, platform CI |
 | Exhaustive or release | Exercise everything available | Potentially substantially longer | `test-all`, CRAN-only dependencies, platform CI, benchmarks |
 
-Run edit checks repeatedly, but do not repeatedly launch `test-r-fixest`,
-`test-r-core`, or `test-all` while iterating. Use a targeted test or
-`test-r-fixest-fast` instead. Once the design is stable, run the selected
-baseline once. A required long check may be deferred to exact-head CI at
-implementation handoff when the report names the check and destination.
+During a related batch of initial edits or review feedback, run the focused
+behavior and caller tests plus lightweight checks that can expose the affected
+seam. Once the batch stabilizes, satisfy its selected requirements with evidence
+that still applies and run missing or invalidated checks. A new edit, commit,
+review comment, agent handoff, push, or PR opening is not by itself a reason to
+repeat a check. Rerun evidence when later work invalidates it, a material risk
+remains unresolved, or an explicit acceptance requirement calls for a newer
+run. Do not repeatedly launch `test-r-fixest`, `test-r-core`, or `test-all`
+while iterating.
+
+Coherent layers that work against their immediate parent need their applicable
+focused checks, not the full acceptance suite after every edit. For a stack or
+other multi-batch change, coordinate one owner for each broad check and normally
+run it once on the stabilized cumulative head against the trunk. Run broad
+checks per layer only when the layers must be independently releasable or an
+acceptance requirement says so. A required long check may be deferred to
+exact-head CI at implementation handoff when the report names the check and
+destination.
 Deferred is never equivalent to passed, and the change is not merge-ready
 until all required merge evidence is green.
 
@@ -87,7 +100,7 @@ This matrix is authoritative for which checks a change requires.
 
 | Change | Required edit or handoff evidence | Merge or long evidence |
 |---|---|---|
-| Public docstrings or API-reference configuration | `git diff --check`; execute changed examples; `docs-build` | affected reference-page render when applicable |
+| Public docstrings or API-reference configuration | `git diff --check`; execute changed examples; `docs-build` once stabilized | affected reference-page render when applicable |
 | Content under `docs/` | `git diff --check`; execute changed examples; render the affected page when practical | `docs-render` only for site-wide configuration, navigation, templates, or cross-page changes |
 | Repository guidance or workflow metadata outside `docs/` | `git diff --check`; targeted skill, template, or configuration validation | affected CI workflow only; no docs build by default |
 | Python API or internals | targeted public tests; changed-file lint/type checks | Python baseline |
@@ -106,8 +119,12 @@ selecting no tests.
 Documentation builds are opt-in. `docs-build` regenerates API-reference inputs;
 it is not a general Markdown validator. Do not run it for changes limited to
 `AGENTS.md`, `.agents/`, `.github/` templates, or contributor workflow metadata.
-For prose under `docs/`, prefer an affected-page render. Reserve the full
-`docs-render` task for changes that can affect the site broadly.
+Do not run it for plain prose or changelog changes either. Where new evidence is
+needed, run it once after a change to public docstrings, API-reference
+configuration, or documentation imports has stabilized. For changed examples or
+prose under `docs/`, execute or render only the affected evidence where useful.
+Reserve the full `docs-render` task for changes that can affect the site broadly,
+and rebuild affected evidence only when a later edit invalidates it.
 
 ## Release contract
 
@@ -166,6 +183,24 @@ as a numerics change. Declare the difference in
 `tests/test_release_contract.py` with a `reason`, add the external comparison
 the "Estimation or inference numerics" row requires, and record it in the
 changelog.
+
+For an invariant internal or backend refactor, satisfy the release-contract
+requirement when the related change batch stabilizes using still-applicable
+evidence. Where a new run is needed, run the full contract normally once on the
+cumulative head. Run it earlier when shared numerical risk is not covered by
+focused tests, or when the contract is needed to investigate the change or
+establish a baseline. It is not an automatic gate for every iteration.
+
+## Evidence records
+
+Keep the verification record compact. Record the revision, environment, scope,
+command, and result for material checks, and name one owner for each coordinated
+broad check. Evidence from an earlier revision may remain relevant when the
+later diff cannot affect it, but do not describe it as exact-head evidence.
+State what changed since the run and rerun only the evidence that change
+invalidated. Changes to dependencies, environments, or test configuration can
+invalidate a result even when the tested source is unchanged. Final merge
+requirements and exact-head CI gates remain unchanged.
 
 ## External numerical references
 

--- a/docs/developer/testing.md
+++ b/docs/developer/testing.md
@@ -17,26 +17,8 @@ selection affect wall time.
 | Merge evidence | Validate the exact PR head in affected environments | May take tens of minutes | canonical R, HAC, no-JIT, docs, plots, Rust, platform CI |
 | Exhaustive or release | Exercise everything available | Potentially substantially longer | `test-all`, CRAN-only dependencies, platform CI, benchmarks |
 
-During a related batch of initial edits or review feedback, run the focused
-behavior and caller tests plus lightweight checks that can expose the affected
-seam. Once the batch stabilizes, satisfy its selected requirements with evidence
-that still applies and run missing or invalidated checks. A new edit, commit,
-review comment, agent handoff, push, or PR opening is not by itself a reason to
-repeat a check. Rerun evidence when later work invalidates it, a material risk
-remains unresolved, or an explicit acceptance requirement calls for a newer
-run. Do not repeatedly launch `test-r-fixest`, `test-r-core`, or `test-all`
-while iterating.
-
-Coherent layers that work against their immediate parent need their applicable
-focused checks, not the full acceptance suite after every edit. For a stack or
-other multi-batch change, coordinate one owner for each broad check and normally
-run it once on the stabilized cumulative head against the trunk. Run broad
-checks per layer only when the layers must be independently releasable or an
-acceptance requirement says so. A required long check may be deferred to
-exact-head CI at implementation handoff when the report names the check and
-destination.
-Deferred is never equivalent to passed, and the change is not merge-ready
-until all required merge evidence is green.
+Which checks to run when, and when to repeat them, is defined in
+`## Verification cadence`.
 
 `test-py` is the broad Python-only regression baseline. It does not compare
 results with R or another external implementation, so it cannot establish
@@ -48,6 +30,42 @@ does not install the CRAN-only packages from `r_test_requirements.R`, so those
 tests can skip. Exhaustive release evidence requires installing those packages,
 running `test-r-extended`, and combining the available suite with the relevant
 platform CI and benchmarks.
+
+## Verification cadence
+
+A **change batch** is a related set of initial edits or review feedback worked
+as a unit; it is **stabilized** once no further edits are planned before handoff
+or acceptance. Evidence is **invalidated** when the later diff — including
+dependency, environment, or test-configuration changes — could affect its tested
+scope. The **broad-check owner** is the single person or agent responsible for
+running a given broad check once on the cumulative head.
+
+While a batch is active, run the focused behavior and caller tests plus the
+lightweight checks that expose the affected seam; do not repeatedly launch
+`test-r-fixest`, `test-r-core`, or `test-all` while iterating.
+
+At stabilization, satisfy the selection matrix with still-valid evidence and run
+what is missing or invalidated. An edit, commit, review comment, agent handoff,
+push, or PR opening is not by itself a rerun trigger; rerun on invalidation,
+unresolved material risk, or an explicit acceptance requirement.
+
+Name one broad-check owner for each broad check. Broad suites run normally once
+on the stabilized cumulative head against the trunk, and per layer only when the
+layers must be independently releasable or an acceptance requirement says so.
+
+The release contract follows this cadence. Run it earlier only when focused
+tests leave shared numerical risk unresolved, or when it is needed to
+investigate the change or establish a baseline.
+
+Keep the record compact: for each material check record revision, environment,
+scope, command, and result. Evidence from an earlier revision may still cover an
+unchanged seam, but is never reported as exact-head evidence; state what changed
+and rerun only what it invalidated.
+
+A required long check may be deferred to exact-head CI at implementation handoff
+when the report names the check and destination. Deferred is never equivalent to
+passed, and the change is not merge-ready until all required merge evidence is
+green.
 
 ## Commands
 
@@ -100,7 +118,7 @@ This matrix is authoritative for which checks a change requires.
 
 | Change | Required edit or handoff evidence | Merge or long evidence |
 |---|---|---|
-| Public docstrings or API-reference configuration | `git diff --check`; execute changed examples; `docs-build` once stabilized | affected reference-page render when applicable |
+| Public docstrings or API-reference configuration | `git diff --check`; execute changed examples; `docs-build` | affected reference-page render when applicable |
 | Content under `docs/` | `git diff --check`; execute changed examples; render the affected page when practical | `docs-render` only for site-wide configuration, navigation, templates, or cross-page changes |
 | Repository guidance or workflow metadata outside `docs/` | `git diff --check`; targeted skill, template, or configuration validation | affected CI workflow only; no docs build by default |
 | Python API or internals | targeted public tests; changed-file lint/type checks | Python baseline |
@@ -118,13 +136,10 @@ selecting no tests.
 
 Documentation builds are opt-in. `docs-build` regenerates API-reference inputs;
 it is not a general Markdown validator. Do not run it for changes limited to
-`AGENTS.md`, `.agents/`, `.github/` templates, or contributor workflow metadata.
-Do not run it for plain prose or changelog changes either. Where new evidence is
-needed, run it once after a change to public docstrings, API-reference
-configuration, or documentation imports has stabilized. For changed examples or
-prose under `docs/`, execute or render only the affected evidence where useful.
-Reserve the full `docs-render` task for changes that can affect the site broadly,
-and rebuild affected evidence only when a later edit invalidates it.
+`AGENTS.md`, `.agents/`, `.github/` templates, or contributor workflow metadata,
+or for plain prose or changelog changes. For changed examples or prose under
+`docs/`, execute or render only the affected evidence. Reserve the full
+`docs-render` task for changes that can affect the site broadly.
 
 ## Release contract
 
@@ -184,23 +199,7 @@ as a numerics change. Declare the difference in
 the "Estimation or inference numerics" row requires, and record it in the
 changelog.
 
-For an invariant internal or backend refactor, satisfy the release-contract
-requirement when the related change batch stabilizes using still-applicable
-evidence. Where a new run is needed, run the full contract normally once on the
-cumulative head. Run it earlier when shared numerical risk is not covered by
-focused tests, or when the contract is needed to investigate the change or
-establish a baseline. It is not an automatic gate for every iteration.
-
-## Evidence records
-
-Keep the verification record compact. Record the revision, environment, scope,
-command, and result for material checks, and name one owner for each coordinated
-broad check. Evidence from an earlier revision may remain relevant when the
-later diff cannot affect it, but do not describe it as exact-head evidence.
-State what changed since the run and rerun only the evidence that change
-invalidated. Changes to dependencies, environments, or test configuration can
-invalidate a result even when the tested source is unchanged. Final merge
-requirements and exact-head CI gates remain unchanged.
+Its timing follows `## Verification cadence`.
 
 ## External numerical references
 


### PR DESCRIPTION
Reworks the contributor verification cadence so checks are batched by risk instead of re-run after every edit, commit, push, or review comment. The policy is stated once, in a new `## Verification cadence` section of `docs/developer/testing.md`; the skills and `AGENTS.md` keep only their role-specific decisions and point to it, per the existing "Where policy lives" rule.

- `testing.md`: defines *change batch*, *stabilized*, *invalidated evidence*, and *broad-check owner*, then states the rules once — focused checks while a batch is active; satisfy the selection matrix at stabilization; an edit/commit/comment/push/PR is not by itself a rerun trigger; one owner runs each broad suite once on the cumulative head (per layer only if layers must be independently releasable); release-contract timing follows the same cadence; evidence records carry revision/environment/scope and earlier-revision evidence is never reported as exact-head; deferral rules unchanged. The selection matrix stays a pure "what".
- `change-verification`: keeps its procedure and report format (now recording revision, environment, and scope); refactor and stack paragraphs reduced to pointers.
- `pr-review`: keeps the review-specific budget rules (inventory exact-head CI first, cheapest check per question, escalation triggers); incremental-review cadence is a one-sentence pointer.
- `pr-handoff`: submission is not a revalidation gate (one clause); when reconstructing a stack, complete and inspect it before publishing by default.
- `implementation-strategy` item 9 and `AGENTS.md`: the release contract is no longer described as "the edit-loop gate"; timing lives in `testing.md`.

The second commit is the consolidation pass over the first (net −29 lines).

## Verification

`git diff --check` clean; `prek` file hooks (trailing-whitespace, end-of-file-fixer, mixed-line-ending, fix-byte-order-marker, check-merge-conflict, check-case-conflict, check-added-large-files) passed on the changed files via `pixi run -e lint prek run <hook> --files …`. No docs build, per the "Repository guidance or workflow metadata" and "Content under `docs/`" matrix rows.