### PR TITLE
fix(estimation): enforce retained estimation storage contracts

### DIFF
--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -226,6 +226,13 @@ We also removed:
 
 ### Bug Fixes
 
+- `lean=True` results keep the formula specification and evaluation context, so
+  `predict(newdata=...)` keeps working for models without fixed effects; methods
+  that need discarded state now raise an informative `RuntimeError` instead of
+  `AttributeError`.
+- `store_data=False` and `lean=True` now apply to retained IV first stages and
+  multiple-estimation containers; lean fits also discard demeaning caches, GLM
+  working state, and quantile solver outputs.
 - Fitted models and non-plotting DiD and reporting paths no longer import
   plotting dependencies eagerly. `ritest()` loads its numerical helpers on use,
   while Matplotlib, Seaborn, and Lets-Plot load only when plotting.

--- a/docs/developer/architecture.md
+++ b/docs/developer/architecture.md
@@ -280,6 +280,15 @@ bootstrap and `decompose()` reject non-OLS results, so none of them
 reinterprets GLM working state or quantile solver outputs as linear-model
 arrays.
 
+Storage policy follows the full result graph. Multiple-estimation containers
+keep no copy of the input frame under `store_data=False` or `lean=True`,
+retained IV first stages honor `store_data=False`, and lean results discard
+within state, GLM working state, demeaning caches, quantile solver outputs, and
+large first-stage arrays. Lean results keep the formula specification and
+evaluation context so `predict(newdata=...)` remains available for models
+without fixed effects. Methods that need discarded state raise an informative
+error naming the storage option and remedy.
+
 Every estimator or inference feature specifies behavior for weights, fixed
 effects, IV, multiple estimation, `lean=True`, and `store_data=False`.
 Unsupported combinations fail explicitly. Silent fallback is never acceptable.

--- a/pyfixest/estimation/FixestMulti_.py
+++ b/pyfixest/estimation/FixestMulti_.py
@@ -67,10 +67,11 @@ class FixestMulti(TidyColumnAccessors):
         context : Mapping[str, Any]
             Captured evaluation scope (from `capture_context`).
         """
-        self._config = config
         self._parsed = parsed
-        self._data = data
-        self._context = context
+        if config.store_data and not config.lean:
+            self._config = config
+            self._data = data
+            self._context = context
 
         self.all_fitted_models: dict[str, Feols | Fepois | Feiv] = {}
 

--- a/pyfixest/estimation/models/_result_accessor_mixin.py
+++ b/pyfixest/estimation/models/_result_accessor_mixin.py
@@ -10,10 +10,7 @@ from pyfixest.errors import EmptyVcovError
 
 if TYPE_CHECKING:
     from pyfixest.estimation.internals.families import InferenceDist
-    from pyfixest.estimation.internals.model_state import (
-        ObservationWeights,
-        WithinLinearData,
-    )
+    from pyfixest.estimation.internals.model_state import ObservationWeights
 from pyfixest.estimation.internals.literals import (
     InferenceType,
     _validate_literal_argument,
@@ -133,7 +130,6 @@ class ResultAccessorMixin(TidyColumnAccessors):
     _conf_int: np.ndarray
     _u_hat: np.ndarray
     _observation_weights: "ObservationWeights"
-    _within_data: "WithinLinearData"
     _response: np.ndarray
     _coefnames: list[str]
     _method: str
@@ -158,6 +154,16 @@ class ResultAccessorMixin(TidyColumnAccessors):
     @property
     def _Y(self) -> np.ndarray:
         """Estimator-specific within-response view."""
+        raise NotImplementedError
+
+    def _require_fit_arrays(
+        self,
+        method: str,
+        *,
+        arrays: str,
+        remedy: str = "Refit with lean=False.",
+    ) -> None:
+        """Reject a call whose input arrays ``lean=True`` discarded."""
         raise NotImplementedError
 
     def _bind_report_methods(self):
@@ -314,6 +320,9 @@ class ResultAccessorMixin(TidyColumnAccessors):
         fit._r2, fit._adj_r2, fit._r2_within
         ```
         """
+        self._require_fit_arrays(
+            "get_performance", arrays="the response and within arrays"
+        )
         # `_Y` is the unpremultiplied within response for linear models and the
         # unpremultiplied final working response for Gaussian GLMs.
         Y_within = self._Y.flatten()
@@ -611,4 +620,5 @@ class ResultAccessorMixin(TidyColumnAccessors):
         fit.resid()[:5]
         ```
         """
+        self._require_fit_arrays("resid", arrays="the residual arrays")
         return self._u_hat.flatten()

--- a/pyfixest/estimation/models/_result_accessor_mixin.py
+++ b/pyfixest/estimation/models/_result_accessor_mixin.py
@@ -143,7 +143,6 @@ class ResultAccessorMixin(TidyColumnAccessors):
     _k: int
     _df_t: int
     _inference_dist: "InferenceDist"
-
     _rmse: float
     _r2: float
     _adj_r2: float
@@ -163,7 +162,10 @@ class ResultAccessorMixin(TidyColumnAccessors):
         arrays: str,
         remedy: str = "Refit with lean=False.",
     ) -> None:
-        """Reject a call whose input arrays ``lean=True`` discarded."""
+        """Reject a call whose input arrays `lean=True` discarded.
+
+        Implemented by the host class.
+        """
         raise NotImplementedError
 
     def _bind_report_methods(self):
@@ -323,12 +325,14 @@ class ResultAccessorMixin(TidyColumnAccessors):
         self._require_fit_arrays(
             "get_performance", arrays="the response and within arrays"
         )
-        # `_Y` is the unpremultiplied within response for linear models and the
-        # unpremultiplied final working response for Gaussian GLMs.
+        # Shared result code must use the estimator's within-response view:
+        # linear models expose WithinLinearData, while Gaussian GLMs expose the
+        # final unpremultiplied IRLS working response through the same alias.
+        # For Gaussian GLMs this is within(y - offset); the global denominator
+        # below deliberately remains centered on the raw response y.
         Y_within = self._Y.flatten()
         Y = self._response
         observation_weights = self._observation_weights.values
-        residuals = self._u_hat
 
         has_intercept = not self._drop_intercept
 
@@ -340,12 +344,12 @@ class ResultAccessorMixin(TidyColumnAccessors):
             adj_factor = (self._N - has_intercept) / (self._N - self._k)
 
         if observation_weights is None:
-            ssu = np.sum(residuals**2)
+            ssu = np.sum(self._u_hat**2)
             y_center = np.mean(Y)
             ssy = np.sum((Y - y_center) ** 2)
         else:
             weights = observation_weights
-            ssu = np.sum(weights.flatten() * residuals**2)
+            ssu = np.sum(weights * self._u_hat**2)
             y_center = np.average(Y, weights=weights)
             ssy = np.sum(weights * (Y - y_center) ** 2)
         self._rmse = np.sqrt(ssu / self._N)

--- a/pyfixest/estimation/models/feglm_.py
+++ b/pyfixest/estimation/models/feglm_.py
@@ -262,6 +262,19 @@ class Feglm(Feols):
         """Linear predictor as a column vector."""
         return self._working_state.eta.reshape((-1, 1))
 
+    def _clear_attributes(self) -> None:
+        """Apply base cleanup and discard large GLM fit arrays when lean."""
+        super()._clear_attributes()
+        if self._lean:
+            for attr in (
+                "_working_state",
+                "_u_hat_response",
+                "_u_hat_working",
+                "_offset",
+            ):
+                if hasattr(self, attr):
+                    delattr(self, attr)
+
     def _normal_equation_weights(self) -> np.ndarray:
         """Return final IRLS weights used by the normal equations."""
         return self._working_state.working_weights
@@ -292,11 +305,16 @@ class Feglm(Feols):
         np.ndarray
             A flat array with the requested residuals.
         """
+        if type not in ("response", "working"):
+            raise ValueError("type must be one of 'response' or 'working'.")
+        self._require_fit_arrays(
+            "resid",
+            arrays="the response and working residual arrays",
+            remedy="Refit with lean=False to access residuals.",
+        )
         if type == "response":
             return self._u_hat_response.flatten()
-        if type == "working":
-            return self._u_hat_working.flatten()
-        raise ValueError("type must be one of 'response' or 'working'.")
+        return self._u_hat_working.flatten()
 
     def residualize(
         self,
@@ -307,6 +325,7 @@ class Feglm(Feols):
         tol: float,
     ) -> tuple[np.ndarray, np.ndarray]:
         "Residualize v and X by flist using weights."
+        self._require_fit_arrays("residualize", arrays="the demeaning caches")
         if flist is None:
             return v, X
 

--- a/pyfixest/estimation/models/feglm_.py
+++ b/pyfixest/estimation/models/feglm_.py
@@ -235,7 +235,6 @@ class Feglm(Feols):
         self._tZXinv = np.linalg.inv(self._tZX)
 
         self._hessian = self._tZX.copy()
-
         self.deviance = fit.deviance
         self.convergence = fit.converged
         if self.convergence:
@@ -273,6 +272,8 @@ class Feglm(Feols):
         """Apply base cleanup and discard large GLM fit arrays when lean."""
         super()._clear_attributes()
         if self._lean:
+            # The IRLS aliases are read-only views, so the working state
+            # backing them is what has to go.
             for attr in (
                 "_working_state",
                 "_u_hat_response",

--- a/pyfixest/estimation/models/feiv_.py
+++ b/pyfixest/estimation/models/feiv_.py
@@ -299,6 +299,7 @@ class Feiv(Feols):
 
     def first_stage(self) -> None:
         """Implement First stage regression."""
+        self._require_estimation_data("first_stage")
         # Store names of instruments from Z matrix
         self._non_exo_instruments = list(set(self._coefnames_z) - set(self._coefnames))
 
@@ -335,6 +336,7 @@ class Feiv(Feols):
             collin_tol=self._collin_tol,
             solver=self._solver,
             demeaner=demeaner,
+            store_data=self._store_data,
         )
 
         # Ensure model1 is of type Feols
@@ -361,6 +363,22 @@ class Feiv(Feols):
     def _finalize_fit(self) -> None:
         """Fit and retain the first-stage model after second-stage inference."""
         self.first_stage()
+
+    def _require_first_stage_state(self, method: str) -> None:
+        """Reject a first-stage diagnostic once lean storage discarded the fit."""
+        if not hasattr(self, "_model_1st_stage"):
+            raise RuntimeError(
+                f"{method}() is unavailable when lean=True because the retained "
+                "first-stage fit state was discarded."
+            )
+
+    def _clear_attributes(self) -> None:
+        """Apply base cleanup and drop the retained first-stage fit when lean."""
+        super()._clear_attributes()
+        if self._lean:
+            for attr in ("_model_1st_stage", "_X_hat", "_v_hat"):
+                if hasattr(self, attr):
+                    delattr(self, attr)
 
     def IV_Diag(self, statistics: list[str] | None = None):
         """Implement IV diagnostic tests.
@@ -442,6 +460,8 @@ class Feiv(Feols):
 
             ```
         """
+        self._require_first_stage_state("IV_Diag")
+
         # Set default statistics
         iv_diag_stat = ["f_stat", "effective_f"]
 
@@ -488,6 +508,8 @@ class Feiv(Feols):
         """
         iv_diag_statistics = iv_diag_statistics or []
 
+        self._require_first_stage_state("IV_weakness_test")
+
         if "f_stat" in iv_diag_statistics:
             self._p_iv = len(self._non_exo_instruments)
 
@@ -520,6 +542,7 @@ class Feiv(Feols):
 
     def eff_F(self) -> None:
         """Compute Effective F stat (Olea and Pflueger 2013)."""
+        self._require_first_stage_state("eff_F")
         # If vcov is iid, redo first stage regression
 
         if self._vcov_type_detail == "iid":

--- a/pyfixest/estimation/models/feiv_.py
+++ b/pyfixest/estimation/models/feiv_.py
@@ -127,8 +127,8 @@ class Feiv(Feols):
     _eff_F : scalar
         Effective F-statistics of first stage regression as in Olea and Pflueger 2013
     _data: pd.DataFrame
-        The data frame used in the estimation. None if arguments `lean = True` or
-        `store_data = False`.
+        The data frame used in the estimation. Deleted if arguments `lean = True`
+        or `store_data = False`.
 
 
     Raises
@@ -215,22 +215,22 @@ class Feiv(Feols):
         self._support_decomposition = False
 
     def _prepare_within_data(self) -> WithinLinearData:
-        """Return second-stage and full instrument arrays on within scale."""
+        """Return second-stage and instrument arrays on within scale."""
         linear_data = super()._prepare_within_data()
         endogenous_frame = self._model_matrix.endogenous
         instrument_frame = self._model_matrix.instruments
         assert endogenous_frame is not None
         assert instrument_frame is not None
+
         endogenous = endogenous_frame.to_numpy(dtype=np.float64)
         instruments = instrument_frame.to_numpy(dtype=np.float64)
-        fixed_effects = self._model_matrix.fixed_effects
-        if fixed_effects is not None:
+        if self._model_matrix.fixed_effects is not None:
             endogenous, instruments, _ = self._demean_cache.demean_yx(
                 endogenous,
                 instruments,
-                y_names=tuple(endogenous_frame.columns),
-                x_names=tuple(instrument_frame.columns),
-                fe=fixed_effects.to_numpy(),
+                y_names=endogenous_frame.columns,
+                x_names=instrument_frame.columns,
+                fe=self._model_matrix.fixed_effects.to_numpy(),
                 weights=self._observation_weights.values,
                 na_index=self._na_index,
                 demeaner=self._demeaner,
@@ -279,6 +279,7 @@ class Feiv(Feols):
         within_data = self._drop_multicollinear_within_data(self._prepare_within_data())
         self._set_within_data(within_data)
         assert within_data.instruments is not None
+
         fit = fit_iv(
             X=within_data.design,
             Z=within_data.instruments,
@@ -300,6 +301,7 @@ class Feiv(Feols):
     def first_stage(self) -> None:
         """Implement First stage regression."""
         self._require_estimation_data("first_stage")
+
         # Store names of instruments from Z matrix
         self._non_exo_instruments = list(set(self._coefnames_z) - set(self._coefnames))
 
@@ -543,6 +545,7 @@ class Feiv(Feols):
     def eff_F(self) -> None:
         """Compute Effective F stat (Olea and Pflueger 2013)."""
         self._require_first_stage_state("eff_F")
+
         # If vcov is iid, redo first stage regression
 
         if self._vcov_type_detail == "iid":

--- a/pyfixest/estimation/models/feols_.py
+++ b/pyfixest/estimation/models/feols_.py
@@ -229,8 +229,8 @@ class Feols(ResultAccessorMixin):
         "scipy.sparse.linalg.lsqr"],
         default is "scipy.linalg.solve". Solver to use for the estimation.
     _data: pd.DataFrame
-        The data frame used in the estimation. None if arguments `lean = True` or
-        `store_data = False`.
+        The data frame used in the estimation. Deleted if arguments `lean = True`
+        or `store_data = False`.
     _model_name: str
         The name of the model. Usually just the formula string. If split estimation is used,
         the model name will include the split variable and value.
@@ -321,6 +321,9 @@ class Feols(ResultAccessorMixin):
         self._store_data = store_data
         self._copy_data = copy_data
         self._lean = lean
+        # Storage cleanup runs at the very end of the fit, so `lean` alone does
+        # not say whether the fit arrays are still there. Estimation itself goes
+        # through the same guarded methods.
         self._fit_state_discarded = False
         self._context = capture_context(context)
 
@@ -646,7 +649,7 @@ class Feols(ResultAccessorMixin):
         arrays: str,
         remedy: str = "Refit with lean=False.",
     ) -> None:
-        """Reject a call whose input arrays ``lean=True`` discarded."""
+        """Reject a call whose input arrays `lean=True` discarded."""
         if self._lean and self._fit_state_discarded:
             raise RuntimeError(
                 f"{method}() is unavailable after fitting with lean=True because "
@@ -659,7 +662,7 @@ class Feols(ResultAccessorMixin):
         *,
         remedy: str = "Refit with store_data=True.",
     ) -> None:
-        """Reject a call whose estimation data were discarded."""
+        """Reject a call whose estimation data the storage options discarded."""
         if not hasattr(self, "_data"):
             raise RuntimeError(
                 f"{method}() is unavailable when store_data=False or lean=True "
@@ -1006,8 +1009,8 @@ class Feols(ResultAccessorMixin):
                 "_tXZ",
                 "_tZy",
                 "_tZX",
-                "_scores",
                 "_tZZinv",
+                "_scores",
                 "_u_hat",
                 "_Y_hat_link",
                 "_Y_hat_response",
@@ -1678,11 +1681,6 @@ class Feols(ResultAccessorMixin):
         res = fit.decompose(decomp_var="x1", combine_covariates={"g1": re.compile("x2[1-2]"), "g2": re.compile("x23")})
         ```
         """
-        if not self._support_decomposition:
-            raise NotImplementedError(
-                "Decomposition is currently only supported for OLS models."
-            )
-
         has_param = param is not None
         has_decomp = decomp_var is not None
 
@@ -1716,7 +1714,14 @@ class Feols(ResultAccessorMixin):
             only_coef=only_coef,
         )
 
+        if not self._support_decomposition:
+            raise NotImplementedError(
+                "Decomposition is currently only supported for OLS models."
+            )
+
         self._require_fit_arrays("decompose", arrays="the fitted arrays")
+        # A cluster variable or an absorbed fixed effect is read back from the
+        # estimation sample; the plain covariate case works on arrays alone.
         if cluster is not None or self._is_clustered or self._has_fixef:
             self._require_estimation_data("decompose")
 
@@ -2006,6 +2011,7 @@ class Feols(ResultAccessorMixin):
             # matching how unseen fixed-effect levels are handled below.
             valid_idx = valid_idx[~unseen[valid_idx]]
             if self._has_fixef:
+                # Fixed-effect levels are recovered from the estimation sample.
                 self._require_fit_arrays(
                     "predict", arrays="the fitted design and residual arrays"
                 )
@@ -2404,19 +2410,20 @@ class Feols(ResultAccessorMixin):
             raise NotImplementedError(
                 "The update() method is currently not supported for models with weights."
             )
-        self._require_fit_arrays("update", arrays="the fitted design arrays")
         if inplace:
             raise NotImplementedError(
                 "update(..., inplace=True) is not supported because appending design "
                 "rows cannot safely update the complete fitted-result state; use the "
                 "returned coefficients instead."
             )
+        self._require_fit_arrays("update", arrays="the fitted design arrays")
         if not np.all(X_new[:, 0] == 1):
             X_new = np.column_stack((np.ones(len(X_new)), X_new))
         X_n_plus_1 = np.vstack((self._X, X_new))
         epsi_n_plus_1 = y_new - X_new @ self._beta_hat
         gamma_n_plus_1 = np.linalg.inv(X_n_plus_1.T @ X_n_plus_1) @ X_new.T
         beta_n_plus_1 = self._beta_hat + gamma_n_plus_1 @ epsi_n_plus_1
+
         return beta_n_plus_1
 
 

--- a/pyfixest/estimation/models/feols_.py
+++ b/pyfixest/estimation/models/feols_.py
@@ -321,6 +321,7 @@ class Feols(ResultAccessorMixin):
         self._store_data = store_data
         self._copy_data = copy_data
         self._lean = lean
+        self._fit_state_discarded = False
         self._context = capture_context(context)
 
         self._support_crv3_inference = True
@@ -519,6 +520,7 @@ class Feols(ResultAccessorMixin):
         ``LsmrDemeaner(backend='within', preconditioner=...)`` to skip the
         setup phase on a later fit over the same design.
         """
+        self._require_fit_arrays("preconditioner", arrays="the demeaning caches")
         return self._demean_cache.lookup_preconditioner.get(self._na_index)
 
     def _drop_multicollinear_within_data(
@@ -635,6 +637,33 @@ class Feols(ResultAccessorMixin):
         """Yield this fitted result to the result container."""
         return (self,)
 
+    def _require_fit_arrays(
+        self,
+        method: str,
+        *,
+        arrays: str,
+        remedy: str = "Refit with lean=False.",
+    ) -> None:
+        """Reject a call whose input arrays ``lean=True`` discarded."""
+        if self._lean and self._fit_state_discarded:
+            raise RuntimeError(
+                f"{method}() is unavailable after fitting with lean=True because "
+                f"{arrays} were discarded. {remedy}"
+            )
+
+    def _require_estimation_data(
+        self,
+        method: str,
+        *,
+        remedy: str = "Refit with store_data=True.",
+    ) -> None:
+        """Reject a call whose estimation data were discarded."""
+        if not hasattr(self, "_data"):
+            raise RuntimeError(
+                f"{method}() is unavailable when store_data=False or lean=True "
+                f"because the estimation data were discarded. {remedy}"
+            )
+
     def vcov(
         self,
         vcov: str | dict[str, str],
@@ -686,20 +715,25 @@ class Feols(ResultAccessorMixin):
         See [On Small Sample Corrections](/explanation/ssc.qmd) for how the
         `ssc` adjustments interact with each estimator.
         """
-        # Assuming `data` is the DataFrame in question
+        self._require_fit_arrays(
+            "vcov",
+            arrays="the required estimation arrays",
+            remedy="Set vcov at estimation time or refit with lean=False.",
+        )
 
-        data_to_check = data if data is not None else self._data
-        try:
-            data_to_check = _narwhals_to_pandas(data_to_check)
-        except TypeError as e:
-            raise TypeError(
-                f"The data set must be a DataFrame type. Received: {type(data)}"
-            ) from e
+        data_to_check = getattr(self, "_data", None) if data is None else data
+        if data_to_check is not None:
+            try:
+                data_to_check = _narwhals_to_pandas(data_to_check)
+            except TypeError as e:
+                raise TypeError(
+                    f"The data set must be a DataFrame type. Received: {type(data)}"
+                ) from e
 
         # assign estimated fixed effects, and fixed effects nested within cluster.
 
         # deparse vcov input
-        _check_vcov_input(vcov=vcov, vcov_kwargs=vcov_kwargs, data=self._data)
+        _check_vcov_input(vcov=vcov, vcov_kwargs=vcov_kwargs, data=data_to_check)
 
         (
             self._vcov_type,
@@ -707,6 +741,12 @@ class Feols(ResultAccessorMixin):
             self._is_clustered,
             self._clustervar,
         ) = _deparse_vcov_input(vcov, self._has_fixef, self._is_iv)
+
+        if self._vcov_type in {"HAC", "CRV"} and data_to_check is None:
+            self._require_estimation_data(
+                "vcov",
+                remedy="Pass the estimation sample via data= or refit with store_data=True.",
+            )
 
         self._bread = _compute_bread(
             self._is_iv, self._tXZ, self._tZZinv, self._tZX, self._hessian
@@ -726,6 +766,7 @@ class Feols(ResultAccessorMixin):
             self._vcov = self._ssc * self._vcov_hetero()
 
         elif self._vcov_type == "HAC":
+            assert data_to_check is not None
             kw = vcov_kwargs or {}
             self._lag = kw.get("lag")
             self._time_id = kw.get("time_id")
@@ -733,7 +774,7 @@ class Feols(ResultAccessorMixin):
             self._ssc, self._df_k, self._df_t = get_ssc(
                 **self._make_ssc_kwargs(
                     vcov_type="HAC",
-                    G=np.unique(self._data[self._time_id]).shape[0],
+                    G=np.unique(data_to_check[self._time_id]).shape[0],
                 )  # number of unique time periods T used
             )
             self._vcov = self._ssc * self._vcov_hac()
@@ -745,8 +786,9 @@ class Feols(ResultAccessorMixin):
             self._vcov = self._ssc * self._vcov_nid()
 
         elif self._vcov_type == "CRV":
+            assert data_to_check is not None
             prep = prepare_cluster_state(
-                data=data if data is not None else self._data,
+                data=data_to_check,
                 clustervar=self._clustervar,
                 ssc_dict=self._ssc_dict,
                 fixef=self._fixef,
@@ -952,8 +994,12 @@ class Feols(ResultAccessorMixin):
             # backing them are what has to go.
             attributes += [
                 "_data",
+                "_model_matrix",
                 "_within_data",
                 "_observation_weights",
+                "_demean_cache",
+                "_fe",
+                "_response",
                 "_cluster_df",
                 "_tXZ",
                 "_tZy",
@@ -963,13 +1009,14 @@ class Feols(ResultAccessorMixin):
                 "_u_hat",
                 "_Y_hat_link",
                 "_Y_hat_response",
-                "_response",
-                "_model_matrix",
             ]
 
         for attr in attributes:
             if hasattr(self, attr):
                 delattr(self, attr)
+
+        if self._lean:
+            self._fit_state_discarded = True
 
     def wald_test(self, R=None, q=None, distribution="F"):
         """
@@ -1186,6 +1233,9 @@ class Feols(ResultAccessorMixin):
                 "Wild cluster bootstrap is only supported for unweighted OLS models."
             )
 
+        self._require_fit_arrays("wildboottest", arrays="the fitted arrays")
+        self._require_estimation_data("wildboottest")
+
         cluster_list = []
 
         if cluster is not None and isinstance(cluster, str):
@@ -1379,6 +1429,9 @@ class Feols(ResultAccessorMixin):
             raise ValueError(
                 f"Variable {treatment} not found in the model's coefficients."
             )
+
+        self._require_fit_arrays("ccv", arrays="the fitted arrays")
+        self._require_estimation_data("ccv")
 
         if cluster is None:
             if self._clustervar is None:
@@ -1661,6 +1714,10 @@ class Feols(ResultAccessorMixin):
             only_coef=only_coef,
         )
 
+        self._require_fit_arrays("decompose", arrays="the fitted arrays")
+        if cluster is not None or self._is_clustered or self._has_fixef:
+            self._require_estimation_data("decompose")
+
         nthreads_int = -1 if nthreads is None else nthreads
 
         rng = (
@@ -1759,6 +1816,9 @@ class Feols(ResultAccessorMixin):
             raise NotImplementedError(
                 "The fixef() method is currently not supported for IV models."
             )
+
+        self._require_fit_arrays("fixef", arrays="the fitted arrays")
+        self._require_estimation_data("fixef")
 
         Y, X = self._model_spec[_ModelMatrixKey.main].get_model_matrix(
             self._data,
@@ -1913,6 +1973,11 @@ class Feols(ResultAccessorMixin):
         if interval is not None:
             _validate_literal_argument(interval, PredictionErrorOptions)
 
+        if newdata is None or se_fit or interval == "prediction":
+            self._require_fit_arrays(
+                "predict", arrays="the fitted design and residual arrays"
+            )
+
         if newdata is None:
             # note: no need to worry about fixed effects, as not supported with
             # prediction errors; will throw error later;
@@ -1940,6 +2005,10 @@ class Feols(ResultAccessorMixin):
             # matching how unseen fixed-effect levels are handled below.
             valid_idx = valid_idx[~unseen[valid_idx]]
             if self._has_fixef:
+                self._require_fit_arrays(
+                    "predict", arrays="the fitted design and residual arrays"
+                )
+                self._require_estimation_data("predict")
                 fe_spec = self._model_spec[_ModelMatrixKey.fixed_effects]
                 check_fe_dtype_compatibility(fe_spec, newdata)
                 # na_action="ignore" keeps unseen-level rows as NaN codes
@@ -2097,6 +2166,9 @@ class Feols(ResultAccessorMixin):
         # check that resampvar in _coefnames
         if resampvar_ not in self._coefnames:
             raise ValueError(f"{resampvar_} not found in the model's coefficients.")
+
+        self._require_fit_arrays("ritest", arrays="the fitted arrays")
+        self._require_estimation_data("ritest")
 
         if cluster is not None and cluster not in self._data:
             raise ValueError(f"The variable {cluster} is not found in the data.")
@@ -2331,6 +2403,7 @@ class Feols(ResultAccessorMixin):
             raise NotImplementedError(
                 "The update() method is currently not supported for models with weights."
             )
+        self._require_fit_arrays("update", arrays="the fitted design arrays")
         if inplace:
             raise NotImplementedError(
                 "update(..., inplace=True) is not supported because appending design "
@@ -2349,7 +2422,7 @@ class Feols(ResultAccessorMixin):
 def _check_vcov_input(
     vcov: str | dict[str, str],
     vcov_kwargs: dict[str, Any] | None,
-    data: pd.DataFrame,
+    data: pd.DataFrame | None,
 ):
     """
     Check the input for the vcov argument in the Feols class.
@@ -2360,8 +2433,8 @@ def _check_vcov_input(
         The vcov argument passed to the Feols class.
     vcov_kwargs : Optional[dict[str, Any]]
         The vcov_kwargs argument passed to the Feols class.
-    data : pd.DataFrame
-        The data passed to the Feols class.
+    data : pd.DataFrame or None
+        The estimation sample, or None when the fitted model retains none.
 
     Returns
     -------
@@ -2381,6 +2454,11 @@ def _check_vcov_input(
 
     if isinstance(vcov, list):
         assert all(isinstance(v, str) for v in vcov), "vcov list must contain strings"
+        if data is None:
+            raise RuntimeError(
+                "A vcov column list requires estimation data. Pass data= or fit "
+                "with store_data=True."
+            )
         assert all(v in data.columns for v in vcov), (
             "vcov list must contain columns in the data"
         )

--- a/pyfixest/estimation/models/fepois_.py
+++ b/pyfixest/estimation/models/fepois_.py
@@ -205,6 +205,12 @@ class Fepois(Feglm):
             y_orig, self._Y_hat_response, user_weights
         )
 
+    def _clear_attributes(self) -> None:
+        """Apply GLM cleanup and discard the Poisson null-fit array when lean."""
+        super()._clear_attributes()
+        if self._lean and hasattr(self, "_y_hat_null"):
+            del self._y_hat_null
+
     def predict(
         self,
         newdata: DataFrameType | None = None,

--- a/pyfixest/estimation/models/fepois_.py
+++ b/pyfixest/estimation/models/fepois_.py
@@ -79,8 +79,8 @@ class Fepois(Feglm):
     weights_type : Optional[str]
         Type of weights variable.
     _data: pd.DataFrame
-        The data frame used in the estimation. None if arguments `lean = True` or
-        `store_data = False`.
+        The data frame used in the estimation. Deleted if arguments `lean = True`
+        or `store_data = False`.
 
     Examples
     --------

--- a/pyfixest/estimation/quantreg/quantreg_.py
+++ b/pyfixest/estimation/quantreg/quantreg_.py
@@ -220,6 +220,20 @@ class Quantreg(Feols):
         self._hessian = self._X.T @ self._X
         self._bread = np.linalg.inv(self._hessian)
 
+    def _clear_attributes(self) -> None:
+        """Apply base cleanup and discard quantile solver arrays when lean."""
+        super()._clear_attributes()
+        if self._lean:
+            for attr in (
+                "_x_final",
+                "_s_final",
+                "_z_final",
+                "_w_final",
+                "_y_final",
+            ):
+                if hasattr(self, attr):
+                    delattr(self, attr)
+
     def fit_qreg_fn(
         self,
         X: np.ndarray,
@@ -452,6 +466,7 @@ class Quantreg(Feols):
     @property
     def objective_value(self):
         "Compute the total loss of the quantile regression model."
+        self._require_fit_arrays("objective_value", arrays="the residual arrays")
         return np.sum(np.abs(self._u_hat) * (self._quantile - (self._u_hat < 0)))
 
     def get_performance(self):

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -56,12 +56,22 @@ def test_cluster_na():
         feols(fml="Y ~ X1", data=data, vcov={"CRV1": "f3"})
 
 
-def test_cluster_but_no_data():
-    """Test if AttributeError if self._data is not stored."""
+def test_cluster_vcov_without_stored_or_explicit_data_is_informative():
+    """Data-dependent vcov updates explain how to supply stripped data."""
     data = get_data()
     fit = feols("Y ~ X1", data=data, store_data=False)
-    with pytest.raises(AttributeError):
+    with pytest.raises(RuntimeError, match=r"store_data=False.*Pass.*data="):
         fit.vcov({"CRV1": "f2"})
+
+
+def test_vcov_column_list_without_data_is_informative():
+    """A column-list vcov cannot be validated without the estimation sample."""
+    data = get_data()
+    fit = feols("Y ~ X1", data=data, store_data=False)
+    with pytest.raises(
+        RuntimeError, match=r"vcov column list requires estimation data"
+    ):
+        fit.vcov(["f2"])
 
 
 def test_error_hc23_fe():

--- a/tests/test_estimator_state_lifecycle.py
+++ b/tests/test_estimator_state_lifecycle.py
@@ -7,6 +7,7 @@ import pandas as pd
 import pytest
 
 import pyfixest as pf
+from pyfixest.estimation.FixestMulti_ import FixestMulti
 from pyfixest.estimation.formula.model_matrix import ModelMatrix
 from pyfixest.estimation.internals.model_state import (
     GlmWorkingState,
@@ -132,6 +133,313 @@ def test_quantreg_multi_retains_default_post_estimation_state() -> None:
     first_quantile = multi.fetch_model(0, print_fml=False)
     np.testing.assert_allclose(first_quantile.predict(), single.predict())
     np.testing.assert_allclose(first_quantile.se(), single.se())
+
+
+@pytest.mark.parametrize("fit_kwargs", [{"store_data": False}, {"lean": True}])
+def test_multiple_estimation_respects_storage_options(
+    lifecycle_data: pd.DataFrame,
+    fit_kwargs: dict[str, bool],
+) -> None:
+    fit = pf.feols(
+        "y ~ sw(x, x2) | fe", data=lifecycle_data, vcov="iid", **fit_kwargs
+    )
+
+    assert isinstance(fit, FixestMulti)
+    assert not hasattr(fit, "_data")
+    assert not hasattr(fit, "_config")
+    assert not hasattr(fit, "_context")
+    assert all(not hasattr(model, "_data") for model in fit.to_list())
+
+
+def test_store_data_false_allows_array_only_vcov_updates(
+    lifecycle_data: pd.DataFrame,
+) -> None:
+    stripped = pf.feols("y ~ x", data=lifecycle_data, vcov="iid", store_data=False)
+    expected = pf.feols("y ~ x", data=lifecycle_data, vcov="HC1")
+
+    stripped.vcov("HC1")
+
+    np.testing.assert_allclose(stripped._vcov, expected._vcov)
+    assert not hasattr(stripped, "_data")
+
+
+def test_lean_vcov_fails_with_storage_guidance(
+    lifecycle_data: pd.DataFrame,
+) -> None:
+    fit = pf.feols("y ~ x", data=lifecycle_data, vcov="iid", lean=True)
+
+    with pytest.raises(RuntimeError, match=r"vcov\(\).*lean=True.*discarded"):
+        fit.vcov("HC1")
+
+
+def test_glm_lean_discards_formula_and_working_state() -> None:
+    data = pd.DataFrame({"y": [0, 1, 0, 1, 1, 0], "x": np.arange(6.0)})
+    fit = pf.feglm("y ~ x", data=data, family="logit", lean=True, vcov="iid")
+
+    discarded = (
+        "_model_matrix",
+        "_observation_weights",
+        "_demean_cache",
+        "_working_state",
+        "_u_hat_response",
+        "_u_hat_working",
+        "_offset",
+    )
+    assert all(not hasattr(fit, attr) for attr in discarded)
+    assert not hasattr(fit, "_irls_weights")
+    assert not hasattr(fit, "_Xbeta")
+    assert np.isfinite(fit.coef()).all()
+
+
+def test_quantreg_lean_discards_solver_arrays() -> None:
+    data = pd.DataFrame({"y": [0.2, 1.1, 1.8, 3.2, 3.9, 5.1], "x": np.arange(6.0)})
+    with pytest.warns(FutureWarning, match="experimental"):
+        fit = pf.quantreg("y ~ x", data=data, lean=True, vcov="iid", maxiter=100)
+
+    solver_arrays = ("_x_final", "_s_final", "_z_final", "_w_final", "_y_final")
+    assert all(not hasattr(fit, attr) for attr in solver_arrays)
+    assert np.isfinite(fit.coef()).all()
+
+
+@pytest.mark.parametrize("method", ["IV_Diag", "IV_weakness_test", "eff_F"])
+def test_lean_iv_rejects_first_stage_diagnostics(
+    lifecycle_data: pd.DataFrame,
+    method: str,
+) -> None:
+    fit = pf.feols(
+        "y ~ x + [endog ~ z] | fe",
+        data=lifecycle_data,
+        vcov="hetero",
+        lean=True,
+    )
+
+    assert not hasattr(fit, "_model_1st_stage")
+    with pytest.raises(RuntimeError, match=rf"{method}\(\).*lean=True"):
+        getattr(fit, method)()
+
+
+def test_iv_first_stage_respects_store_data_false(
+    lifecycle_data: pd.DataFrame,
+) -> None:
+    fit = pf.feols(
+        "y ~ x + [endog ~ z] | fe",
+        data=lifecycle_data,
+        vcov="hetero",
+        store_data=False,
+    )
+
+    first_stage = fit._model_1st_stage
+    assert not hasattr(first_stage, "_data")
+    assert not hasattr(first_stage, "_model_matrix")
+    assert hasattr(first_stage, "_within_data")
+    fit.IV_Diag()
+    assert np.isfinite(fit._eff_F)
+    with pytest.raises(RuntimeError, match=r"first_stage\(\).*store_data=False"):
+        fit.first_stage()
+
+
+def test_iv_effective_f_uses_retained_arrays_without_stored_data(
+    lifecycle_data: pd.DataFrame,
+) -> None:
+    stripped = pf.feols(
+        "y ~ x + [endog ~ z] | fe",
+        data=lifecycle_data,
+        vcov="iid",
+        store_data=False,
+    )
+    retained = pf.feols(
+        "y ~ x + [endog ~ z] | fe", data=lifecycle_data, vcov="iid"
+    )
+
+    stripped.IV_Diag()
+    retained.IV_Diag()
+
+    np.testing.assert_allclose(stripped._eff_F, retained._eff_F)
+    assert not hasattr(stripped._model_1st_stage, "_data")
+
+
+LEAN_REJECTION_CASES = [
+    ("resid", "y ~ x | fe", lambda fit: fit.resid()),
+    ("get_performance", "y ~ x | fe", lambda fit: fit.get_performance()),
+    ("predict", "y ~ x | fe", lambda fit: fit.predict()),
+    ("fixef", "y ~ x | fe", lambda fit: fit.fixef()),
+    ("preconditioner", "y ~ x | fe", lambda fit: fit.preconditioner),
+    ("ccv", "y ~ x", lambda fit: fit.ccv(treatment="x")),
+    (
+        "decompose",
+        "y ~ x + x2",
+        lambda fit: fit.decompose(decomp_var="x", only_coef=True),
+    ),
+    (
+        "wildboottest",
+        "y ~ x + x2",
+        lambda fit: fit.wildboottest(param="x", reps=11),
+    ),
+    ("ritest", "y ~ x + x2", lambda fit: fit.ritest(resampvar="x", reps=11)),
+    (
+        "update",
+        "y ~ x + x2",
+        lambda fit: fit.update(np.ones((1, 3)), np.zeros(1)),
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ("method", "fml", "call"),
+    LEAN_REJECTION_CASES,
+    ids=[case[0] for case in LEAN_REJECTION_CASES],
+)
+def test_lean_results_reject_state_dependent_methods(
+    lifecycle_data: pd.DataFrame,
+    method: str,
+    fml: str,
+    call,
+) -> None:
+    fit = pf.feols(fml, data=lifecycle_data, vcov="iid", lean=True)
+
+    with pytest.raises(RuntimeError, match=rf"{method}\(\).*lean=True.*discarded"):
+        call(fit)
+
+
+STORE_DATA_REJECTION_CASES = [
+    ("fixef", "y ~ x | fe", lambda fit, data: fit.fixef()),
+    ("predict", "y ~ x | fe", lambda fit, data: fit.predict(newdata=data)),
+    ("ccv", "y ~ x", lambda fit, data: fit.ccv(treatment="x")),
+    (
+        "decompose",
+        "y ~ x + x2 | fe",
+        lambda fit, data: fit.decompose(decomp_var="x", only_coef=True),
+    ),
+    (
+        "wildboottest",
+        "y ~ x + x2",
+        lambda fit, data: fit.wildboottest(param="x", reps=11),
+    ),
+    (
+        "ritest",
+        "y ~ x + x2",
+        lambda fit, data: fit.ritest(resampvar="x", reps=11),
+    ),
+    (
+        "first_stage",
+        "y ~ x + [endog ~ z] | fe",
+        lambda fit, data: fit.first_stage(),
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ("method", "fml", "call"),
+    STORE_DATA_REJECTION_CASES,
+    ids=[case[0] for case in STORE_DATA_REJECTION_CASES],
+)
+def test_store_data_false_results_reject_data_dependent_methods(
+    lifecycle_data: pd.DataFrame,
+    method: str,
+    fml: str,
+    call,
+) -> None:
+    fit = pf.feols(fml, data=lifecycle_data, vcov="iid", store_data=False)
+
+    with pytest.raises(RuntimeError, match=rf"{method}\(\).*store_data=False"):
+        call(fit, lifecycle_data)
+
+
+def test_lean_results_predict_new_data_without_fixed_effects(
+    lifecycle_data: pd.DataFrame,
+) -> None:
+    lean_fit = pf.feols("y ~ x + x2", data=lifecycle_data, vcov="iid", lean=True)
+    retained_fit = pf.feols("y ~ x + x2", data=lifecycle_data, vcov="iid")
+
+    np.testing.assert_allclose(
+        lean_fit.predict(newdata=lifecycle_data),
+        retained_fit.predict(newdata=lifecycle_data),
+    )
+
+
+def test_lean_glm_rejects_residualize_and_residuals() -> None:
+    data = pd.DataFrame({"y": [0, 1, 0, 1, 1, 0], "x": np.arange(6.0)})
+    fit = pf.feglm("y ~ x", data=data, family="logit", vcov="iid", lean=True)
+
+    with pytest.raises(RuntimeError, match=r"resid\(\).*lean=True.*discarded"):
+        fit.resid("response")
+    with pytest.raises(RuntimeError, match=r"residualize\(\).*lean=True.*discarded"):
+        fit.residualize(
+            v=np.zeros((6, 1)),
+            X=np.ones((6, 1)),
+            flist=None,
+            weights=np.ones((6, 1)),
+            tol=1e-06,
+        )
+
+
+def test_lean_quantreg_rejects_objective_value() -> None:
+    data = pd.DataFrame({"y": [0.2, 1.1, 1.8, 3.2, 3.9, 5.1], "x": np.arange(6.0)})
+    with pytest.warns(FutureWarning, match="experimental"):
+        fit = pf.quantreg("y ~ x", data=data, lean=True, vcov="iid", maxiter=100)
+
+    with pytest.raises(RuntimeError, match=r"objective_value\(\).*lean=True"):
+        _ = fit.objective_value
+
+
+STORAGE_STATE_FIELDS = frozenset(
+    {
+        "_data",
+        "_model_matrix",
+        "_within_data",
+        "_observation_weights",
+        "_demean_cache",
+        "_fe",
+        "_response",
+        "_X",
+        "_Y",
+        "_Z",
+        "_weights",
+        "_scores",
+        "_u_hat",
+    }
+)
+
+
+@pytest.mark.parametrize(
+    ("fit_kwargs", "missing_fields"),
+    [
+        ({}, frozenset()),
+        ({"store_data": False}, frozenset({"_data", "_model_matrix"})),
+        ({"lean": True}, STORAGE_STATE_FIELDS),
+    ],
+    ids=["retained", "store_data_false", "lean"],
+)
+def test_storage_options_delete_expected_state(
+    lifecycle_data: pd.DataFrame,
+    fit_kwargs: dict[str, bool],
+    missing_fields: frozenset[str],
+) -> None:
+    fit = pf.feols("y ~ x | fe", data=lifecycle_data, vcov="iid", **fit_kwargs)
+
+    observed_fields = frozenset(
+        field for field in STORAGE_STATE_FIELDS if hasattr(fit, field)
+    )
+    assert observed_fields == STORAGE_STATE_FIELDS - missing_fields
+    if fit_kwargs.get("lean"):
+        for field in ("_model_spec", "_context", "_na_index"):
+            assert hasattr(fit, field)
+    assert np.isfinite(fit.coef()).all()
+
+
+def test_poisson_lean_discards_offset_and_null_fit_arrays() -> None:
+    data = pd.DataFrame(
+        {
+            "y": [0, 1, 2, 1, 3, 2],
+            "x": np.arange(6.0),
+            "offset": np.linspace(0.1, 0.6, 6),
+        }
+    )
+    fit = pf.fepois("y ~ x", data=data, offset="offset", lean=True, vcov="iid")
+
+    assert not hasattr(fit, "_offset")
+    assert not hasattr(fit, "_y_hat_null")
+    assert np.isfinite(fit.coef()).all()
 
 
 def test_feglm_keeps_observation_and_working_weights_distinct() -> None:


### PR DESCRIPTION
## Summary

`store_data=False` and `lean=True` now apply to retained IV first stages and multiple-estimation containers, and lean fits discard demeaning caches, GLM working state, and quantile solver outputs while keeping the formula specification and evaluation context, so `predict(newdata=...)` still works for models without fixed effects. Every method that needs discarded state raises an informative `RuntimeError` naming the storage option and its remedy instead of an `AttributeError`; array-only covariance updates stay available without stored data.

Review question: **What remains usable after `lean` or `store_data=False`?**

Layer 7 of 9 replacing #1500/#1501; depends on #1522 (`refactor/estimator-state-aliases`). The original PRs stay open until the replacement stack is validated.

## Verification

- Release contract: 1,355 passed.
- Storage and error-path tests: `tests/test_estimator_state_lifecycle.py` and `tests/test_errors.py` 144 passed, 1 skipped.
- Changed-file Ruff and mypy passed; whole-tree `ruff-check`/`ruff-format` hooks passed at this tip.

Exact targeted command: `pixi run -e py312-r pytest tests/test_estimator_state_lifecycle.py tests/test_errors.py -q --no-cov`.

The repository's Python/R/docs workflow only runs for PRs targeting `master`; this stacked PR receives pre-commit CI only. Broad cumulative checks ran locally on the final replacement head (layer 9). Human review is required; no automatic merge.
