### PR TITLE
fix(estimation): replay estimation options in data-changing refits

### DIFF
--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -72,6 +72,9 @@ fit3 = pf.feols("Y ~ X1 + X2 | f1", data = df)
   non-OLS models instead of mixing scales.
 - Non-Poisson GLMs reject `CRV3` instead of silently refitting through the
   Poisson jackknife. Poisson `CRV3` remains supported.
+- CRV3 jackknife and slow randomization-inference refits now replay the
+  original estimation options (weights, small-sample corrections, singleton
+  handling, solver, demeaner, offset, IRLS tolerances).
 - Randomization inference rejects non-OLS/non-Poisson results, the wild
   bootstrap rejects non-OLS results, and `decompose()` rejects non-OLS results,
   instead of reinterpreting GLM working state or quantile solver outputs as OLS

--- a/docs/developer/architecture.md
+++ b/docs/developer/architecture.md
@@ -278,7 +278,9 @@ configuration; Poisson keeps its longstanding jackknife-refit path.
 Randomization inference rejects non-OLS/non-Poisson results, and the wild
 bootstrap and `decompose()` reject non-OLS results, so none of them
 reinterprets GLM working state or quantile solver outputs as linear-model
-arrays.
+arrays. Poisson CRV3 and slow randomization refits replay the original
+estimation options; prebuilt LSMR preconditioners are rebuilt for each changed
+row sample.
 
 Storage policy follows the full result graph. Multiple-estimation containers
 keep no copy of the input frame under `store_data=False` or `lean=True`,

--- a/pyfixest/estimation/models/feols_.py
+++ b/pyfixest/estimation/models/feols_.py
@@ -961,6 +961,8 @@ class Feols(ResultAccessorMixin):
         if isinstance(demeaner, LsmrDemeaner) and isinstance(
             demeaner.preconditioner, Preconditioner
         ):
+            # A prebuilt factorization belongs to the original FE design. Keep
+            # its algorithmic variant, but rebuild it for the changed row set.
             preconditioner = cast(
                 WithinPreconditionerName,
                 demeaner.preconditioner.variant.lower(),
@@ -981,6 +983,7 @@ class Feols(ResultAccessorMixin):
 
     def _crv3_refit(self, data: pd.DataFrame) -> Feols:
         """Replay OLS for one leave-one-cluster-out sample."""
+        # lazy loading to avoid circular import
         fixest_module = import_module("pyfixest.estimation")
         return fixest_module.feols(
             fml=self._fml,

--- a/pyfixest/estimation/models/feols_.py
+++ b/pyfixest/estimation/models/feols_.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import re
 import warnings
 from collections.abc import Mapping
+from dataclasses import replace
 from importlib import import_module
 from typing import Any, Literal, cast
 
@@ -14,7 +15,7 @@ from scipy.sparse import csc_matrix, diags, spmatrix
 from scipy.sparse.linalg import lsqr
 from scipy.stats import chi2, f, t
 
-from pyfixest.core.demean import Preconditioner
+from pyfixest.core.demean import Preconditioner, WithinPreconditionerName
 from pyfixest.demeaners import AnyDemeaner, LsmrDemeaner, MapDemeaner
 from pyfixest.errors import VcovTypeNotSupportedError
 from pyfixest.estimation.api.utils import _ALL_SAMPLE, _AllSampleSentinel
@@ -949,23 +950,47 @@ class Feols(ResultAccessorMixin):
             cluster_col=cluster_col,
         )
 
+    def _estimation_refit_kwargs(self) -> dict[str, Any]:
+        """Return options needed to replay this estimator on modified data."""
+        demeaner = self._demeaner
+        if isinstance(demeaner, LsmrDemeaner) and isinstance(
+            demeaner.preconditioner, Preconditioner
+        ):
+            preconditioner = cast(
+                WithinPreconditionerName,
+                demeaner.preconditioner.variant.lower(),
+            )
+            demeaner = replace(demeaner, preconditioner=preconditioner)
+
+        return {
+            "weights": self._weights_name,
+            "weights_type": self._weights_type,
+            "ssc": dict(self._ssc_dict),
+            "fixef_rm": "singleton" if self._drop_singletons else "none",
+            "solver": self._solver,
+            "demeaner": demeaner,
+            "drop_intercept": self._drop_intercept,
+            "collin_tol": self._collin_tol,
+            "context": self._context,
+        }
+
+    def _crv3_refit(self, data: pd.DataFrame) -> Feols:
+        """Replay OLS for one leave-one-cluster-out sample."""
+        fixest_module = import_module("pyfixest.estimation")
+        return fixest_module.feols(
+            fml=self._fml,
+            data=data,
+            vcov="iid",
+            **self._estimation_refit_kwargs(),
+        )
+
     def _vcov_crv3_slow(self, clustid, cluster_col):
         beta_jack = np.zeros((len(clustid), self._k))
-
-        # lazy loading to avoid circular import
-        fixest_module = import_module("pyfixest.estimation")
-        fit_ = fixest_module.feols if self._method == "feols" else fixest_module.fepois
 
         for ixg, g in enumerate(clustid):
             # direct leave one cluster out implementation
             data = self._data[~np.equal(g, cluster_col)]
-            fit = fit_(
-                fml=self._fml,
-                data=data,
-                vcov="iid",
-                weights=self._weights_name,
-                weights_type=self._weights_type,
-            )
+            fit = self._crv3_refit(data=data)
             beta_jack[ixg, :] = fit.coef().to_numpy()
 
         # optional: beta_bar in MNW (2022)
@@ -2243,6 +2268,7 @@ class Feols(ResultAccessorMixin):
                 type=type,
                 rng=rng,
                 model=self._method,
+                refit_kwargs=self._estimation_refit_kwargs(),
             )
 
         else:

--- a/pyfixest/estimation/models/fepois_.py
+++ b/pyfixest/estimation/models/fepois_.py
@@ -208,12 +208,6 @@ class Fepois(Feglm):
             y_orig, self._Y_hat_response, poisson_summary_weights
         )
 
-    def _clear_attributes(self) -> None:
-        """Apply GLM cleanup and discard the Poisson null-fit array when lean."""
-        super()._clear_attributes()
-        if self._lean and hasattr(self, "_y_hat_null"):
-            del self._y_hat_null
-
     def _estimation_refit_kwargs(self) -> dict[str, Any]:
         """Return the full Poisson estimation contract for data-changing refits."""
         kwargs = super()._estimation_refit_kwargs()
@@ -233,6 +227,7 @@ class Fepois(Feglm):
 
     def _crv3_refit(self, data: pd.DataFrame) -> Fepois:
         """Replay Poisson estimation for one leave-one-cluster-out sample."""
+        # lazy loading to avoid circular import
         fixest_module = import_module("pyfixest.estimation")
         return fixest_module.fepois(
             fml=self._fml,
@@ -240,6 +235,12 @@ class Fepois(Feglm):
             vcov="iid",
             **self._estimation_refit_kwargs(),
         )
+
+    def _clear_attributes(self) -> None:
+        """Apply GLM cleanup and discard the Poisson null-fit array when lean."""
+        super()._clear_attributes()
+        if self._lean and hasattr(self, "_y_hat_null"):
+            del self._y_hat_null
 
     def predict(
         self,

--- a/pyfixest/estimation/models/fepois_.py
+++ b/pyfixest/estimation/models/fepois_.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from importlib import import_module
 from typing import Any
 
 import numpy as np
@@ -210,6 +211,33 @@ class Fepois(Feglm):
         super()._clear_attributes()
         if self._lean and hasattr(self, "_y_hat_null"):
             del self._y_hat_null
+
+    def _estimation_refit_kwargs(self) -> dict[str, Any]:
+        """Return the full Poisson estimation contract for data-changing refits."""
+        kwargs = super()._estimation_refit_kwargs()
+        kwargs.update(
+            {
+                "offset": self._offset_name,
+                "iwls_tol": self.tol,
+                "iwls_maxiter": self.maxiter,
+                "separation_check": (
+                    None
+                    if self.separation_check is None
+                    else list(self.separation_check)
+                ),
+            }
+        )
+        return kwargs
+
+    def _crv3_refit(self, data: pd.DataFrame) -> Fepois:
+        """Replay Poisson estimation for one leave-one-cluster-out sample."""
+        fixest_module = import_module("pyfixest.estimation")
+        return fixest_module.fepois(
+            fml=self._fml,
+            data=data,
+            vcov="iid",
+            **self._estimation_refit_kwargs(),
+        )
 
     def predict(
         self,

--- a/pyfixest/estimation/post_estimation/ritest.py
+++ b/pyfixest/estimation/post_estimation/ritest.py
@@ -36,6 +36,7 @@ def _get_ritest_stats_slow(
     model: str,
     rng: np.random.Generator,
     vcov: str | dict[str, str],
+    refit_kwargs: dict | None = None,
     clustervar_arr: np.ndarray | None = None,
 ) -> np.ndarray:
     """
@@ -62,6 +63,8 @@ def _get_ritest_stats_slow(
         The random number generator.
     vcov : str or dict[str, str]
         The type of covarianc estimator. See `feols` or `fepois` for details.
+    refit_kwargs : dict, optional
+        Estimator options to replay on each resampled data set.
     clustervar_arr : np.ndarray, optional
         Array containing the cluster variable. Defaults to None.
 
@@ -77,6 +80,7 @@ def _get_ritest_stats_slow(
 
     fixest_module = import_module("pyfixest.estimation")
     fit_ = getattr(fixest_module, model)
+    fit_kwargs = {} if refit_kwargs is None else refit_kwargs
 
     resampvar_arr = data_resampled[resampvar].to_numpy()
 
@@ -92,7 +96,12 @@ def _get_ritest_stats_slow(
 
         data_resampled[f"{resampvar}_resampled"] = D_treat
 
-        fixest_fit = fit_(fml_update, data=data_resampled, vcov=vcov)
+        fixest_fit = fit_(
+            fml_update,
+            data=data_resampled,
+            vcov=vcov,
+            **fit_kwargs,
+        )
         if type == "randomization-c":
             ri_stats[i] = fixest_fit.coef().xs(f"{resampvar}_resampled")
         else:

--- a/pyfixest/estimation/post_estimation/ritest.py
+++ b/pyfixest/estimation/post_estimation/ritest.py
@@ -64,7 +64,8 @@ def _get_ritest_stats_slow(
     vcov : str or dict[str, str]
         The type of covarianc estimator. See `feols` or `fepois` for details.
     refit_kwargs : dict, optional
-        Estimator options to replay on each resampled data set.
+        Estimator options from the original fit that must be replayed on each
+        resampled data set. Defaults to no additional options.
     clustervar_arr : np.ndarray, optional
         Array containing the cluster variable. Defaults to None.
 

--- a/tests/test_ritest.py
+++ b/tests/test_ritest.py
@@ -172,6 +172,58 @@ def test_fepois_ritest():
     assert np.allclose(fit.pvalue().xs("f3"), fit._ritest_pvalue, rtol=0.01, atol=0.01)
 
 
+def test_fepois_slow_ritest_replays_estimation_contract(monkeypatch):
+    import pyfixest.estimation as estimation
+
+    data = pf.get_data(model="Fepois").dropna().iloc[:96].copy()
+    data["treatment"] = (data["X2"] > data["X2"].median()).astype(int)
+    data["exposure"] = np.random.default_rng(20260901).uniform(0.5, 3.0, len(data))
+
+    def shift(values):
+        return values + 0.125
+
+    demeaner = pf.MapDemeaner(fixef_tol=1e-8, fixef_maxiter=20_000)
+    ssc_config = pf.ssc(k_adj=False, G_adj=False)
+    real_fepois = estimation.fepois
+    fit = real_fepois(
+        "Y ~ treatment + shift(X1) | f1",
+        data=data,
+        offset="log(exposure)",
+        ssc=ssc_config,
+        fixef_rm="none",
+        iwls_tol=1e-10,
+        iwls_maxiter=100,
+        collin_tol=1e-8,
+        separation_check=[],
+        solver="np.linalg.lstsq",
+        demeaner=demeaner,
+        drop_intercept=True,
+        context={"shift": shift},
+    )
+    refit_calls = []
+
+    def recording_fepois(fml, *, data, vcov, **kwargs):
+        refit_calls.append((fml, vcov, kwargs))
+        return real_fepois(fml=fml, data=data, vcov=vcov, **kwargs)
+
+    monkeypatch.setattr(estimation, "fepois", recording_fepois)
+    fit.ritest(
+        resampvar="treatment",
+        reps=3,
+        choose_algorithm="slow",
+        rng=np.random.default_rng(1234),
+    )
+
+    assert len(refit_calls) == 3
+    for fml, vcov, kwargs in refit_calls:
+        assert fml == "Y ~ treatment_resampled + shift(X1) | f1"
+        assert vcov == "iid"
+        assert kwargs["ssc"] == ssc_config
+        assert kwargs["demeaner"] is demeaner
+        assert kwargs["offset"] == "log(exposure)"
+        assert kwargs["context"]["shift"] is shift
+
+
 @pytest.fixture
 def data_r_vs_t():
     return pf.get_data(N=5000, seed=2999)

--- a/tests/test_ritest.py
+++ b/tests/test_ritest.py
@@ -173,6 +173,7 @@ def test_fepois_ritest():
 
 
 def test_fepois_slow_ritest_replays_estimation_contract(monkeypatch):
+    """Poisson RI refits must retain offsets, formula context, and fit options."""
     import pyfixest.estimation as estimation
 
     data = pf.get_data(model="Fepois").dropna().iloc[:96].copy()
@@ -200,6 +201,7 @@ def test_fepois_slow_ritest_replays_estimation_contract(monkeypatch):
         drop_intercept=True,
         context={"shift": shift},
     )
+
     refit_calls = []
 
     def recording_fepois(fml, *, data, vcov, **kwargs):
@@ -218,8 +220,17 @@ def test_fepois_slow_ritest_replays_estimation_contract(monkeypatch):
     for fml, vcov, kwargs in refit_calls:
         assert fml == "Y ~ treatment_resampled + shift(X1) | f1"
         assert vcov == "iid"
+        assert kwargs["weights"] is None
+        assert kwargs["weights_type"] == "aweights"
         assert kwargs["ssc"] == ssc_config
+        assert kwargs["fixef_rm"] == "none"
+        assert kwargs["iwls_tol"] == 1e-10
+        assert kwargs["iwls_maxiter"] == 100
+        assert kwargs["collin_tol"] == 1e-8
+        assert kwargs["separation_check"] == []
+        assert kwargs["solver"] == "np.linalg.lstsq"
         assert kwargs["demeaner"] is demeaner
+        assert kwargs["drop_intercept"] is True
         assert kwargs["offset"] == "log(exposure)"
         assert kwargs["context"]["shift"] is shift
 

--- a/tests/test_ses.py
+++ b/tests/test_ses.py
@@ -224,6 +224,7 @@ def run_crv3_poisson():
 
 
 def test_fepois_crv3_replays_estimation_contract(monkeypatch):
+    """Poisson jackknife refits must preserve every coefficient-affecting option."""
     rng = np.random.default_rng(20260901)
     n_clusters = 6
     rows_per_cluster = 12
@@ -233,11 +234,12 @@ def test_fepois_crv3_replays_estimation_contract(monkeypatch):
     x = rng.normal(size=n)
     exposure = rng.uniform(0.5, 3.0, size=n)
     weight = rng.uniform(0.75, 1.5, size=n)
+    fixed_effect_value = np.linspace(-0.25, 0.25, 6)[fixed_effect]
 
     def shift(values):
         return values + 0.125
 
-    eta = 0.35 * shift(x) + np.linspace(-0.25, 0.25, 6)[fixed_effect] + np.log(exposure)
+    eta = 0.35 * shift(x) + fixed_effect_value + np.log(exposure)
     data = pd.DataFrame(
         {
             "y": rng.poisson(np.exp(eta)),
@@ -248,17 +250,21 @@ def test_fepois_crv3_replays_estimation_contract(monkeypatch):
             "cluster": cluster,
         }
     )
+
     demeaner = MapDemeaner(fixef_tol=1e-8, fixef_maxiter=20_000)
     ssc_config = ssc(k_adj=False, G_adj=False)
     real_fepois = estimation.fepois
     refit_calls = []
+    beta_jack = []
 
     def recording_fepois(*, data, **kwargs):
         refit_calls.append((data, kwargs))
-        return real_fepois(data=data, **kwargs)
+        refit = real_fepois(data=data, **kwargs)
+        beta_jack.append(refit.coef().to_numpy())
+        return refit
 
     monkeypatch.setattr(estimation, "fepois", recording_fepois)
-    real_fepois(
+    fit = real_fepois(
         "y ~ shift(x) | fixed_effect",
         data=data,
         vcov={"CRV3": "cluster"},
@@ -280,14 +286,31 @@ def test_fepois_crv3_replays_estimation_contract(monkeypatch):
     assert len(refit_calls) == n_clusters
     for refit_data, kwargs in refit_calls:
         assert refit_data["cluster"].nunique() == n_clusters - 1
+        assert kwargs["fml"] == "y ~ shift(x) | fixed_effect"
+        assert kwargs["vcov"] == "iid"
         assert kwargs["weights"] == "weight"
+        assert kwargs["weights_type"] == "aweights"
         assert kwargs["ssc"] == ssc_config
+        assert kwargs["fixef_rm"] == "none"
+        assert kwargs["iwls_tol"] == 1e-10
+        assert kwargs["iwls_maxiter"] == 100
+        assert kwargs["collin_tol"] == 1e-8
+        assert kwargs["separation_check"] == []
+        assert kwargs["solver"] == "np.linalg.lstsq"
         assert kwargs["demeaner"] is demeaner
+        assert kwargs["drop_intercept"] is True
         assert kwargs["offset"] == "log(exposure)"
         assert kwargs["context"]["shift"] is shift
 
+    expected_vcov = np.zeros_like(fit._vcov)
+    for beta in beta_jack:
+        centered = beta - fit.coef().to_numpy()
+        expected_vcov += np.outer(centered, centered)
+    np.testing.assert_allclose(fit._vcov, expected_vcov, rtol=1e-12, atol=1e-12)
+
 
 def test_crv3_rebuilds_preconditioner_for_each_changed_design():
+    """Leave-cluster-out refits must not reuse a full-sample factorization."""
     rng = np.random.default_rng(20260902)
     n_groups = 6
     rows_per_group = 6
@@ -307,7 +330,10 @@ def test_crv3_rebuilds_preconditioner_for_each_changed_design():
         demeaner=LsmrDemeaner(backend="within"),
     )
     assert base.preconditioner is not None
-    reused = LsmrDemeaner(backend="within", preconditioner=base.preconditioner)
+    reused = LsmrDemeaner(
+        backend="within",
+        preconditioner=base.preconditioner,
+    )
 
     fit = feols(
         "y ~ x | group + time",
@@ -315,6 +341,7 @@ def test_crv3_rebuilds_preconditioner_for_each_changed_design():
         vcov={"CRV3": "group"},
         demeaner=reused,
     )
+
     assert np.isfinite(fit._vcov).all()
 
 

--- a/tests/test_ses.py
+++ b/tests/test_ses.py
@@ -1,6 +1,9 @@
 import numpy as np
+import pandas as pd
 import pytest
 
+import pyfixest.estimation as estimation
+from pyfixest.demeaners import LsmrDemeaner, MapDemeaner
 from pyfixest.estimation import feols, fepois
 from pyfixest.utils.utils import get_data, ssc
 
@@ -218,6 +221,101 @@ def run_crv3_poisson():
         vcov={"CRV3": "f1"},
         ssc=ssc(k_adj=False, G_adj=False),
     )
+
+
+def test_fepois_crv3_replays_estimation_contract(monkeypatch):
+    rng = np.random.default_rng(20260901)
+    n_clusters = 6
+    rows_per_cluster = 12
+    n = n_clusters * rows_per_cluster
+    cluster = np.repeat(np.arange(n_clusters), rows_per_cluster)
+    fixed_effect = np.tile(np.arange(6), n // 6)
+    x = rng.normal(size=n)
+    exposure = rng.uniform(0.5, 3.0, size=n)
+    weight = rng.uniform(0.75, 1.5, size=n)
+
+    def shift(values):
+        return values + 0.125
+
+    eta = 0.35 * shift(x) + np.linspace(-0.25, 0.25, 6)[fixed_effect] + np.log(exposure)
+    data = pd.DataFrame(
+        {
+            "y": rng.poisson(np.exp(eta)),
+            "x": x,
+            "exposure": exposure,
+            "weight": weight,
+            "fixed_effect": fixed_effect,
+            "cluster": cluster,
+        }
+    )
+    demeaner = MapDemeaner(fixef_tol=1e-8, fixef_maxiter=20_000)
+    ssc_config = ssc(k_adj=False, G_adj=False)
+    real_fepois = estimation.fepois
+    refit_calls = []
+
+    def recording_fepois(*, data, **kwargs):
+        refit_calls.append((data, kwargs))
+        return real_fepois(data=data, **kwargs)
+
+    monkeypatch.setattr(estimation, "fepois", recording_fepois)
+    real_fepois(
+        "y ~ shift(x) | fixed_effect",
+        data=data,
+        vcov={"CRV3": "cluster"},
+        weights="weight",
+        weights_type="aweights",
+        offset="log(exposure)",
+        ssc=ssc_config,
+        fixef_rm="none",
+        iwls_tol=1e-10,
+        iwls_maxiter=100,
+        collin_tol=1e-8,
+        separation_check=[],
+        solver="np.linalg.lstsq",
+        demeaner=demeaner,
+        drop_intercept=True,
+        context={"shift": shift},
+    )
+
+    assert len(refit_calls) == n_clusters
+    for refit_data, kwargs in refit_calls:
+        assert refit_data["cluster"].nunique() == n_clusters - 1
+        assert kwargs["weights"] == "weight"
+        assert kwargs["ssc"] == ssc_config
+        assert kwargs["demeaner"] is demeaner
+        assert kwargs["offset"] == "log(exposure)"
+        assert kwargs["context"]["shift"] is shift
+
+
+def test_crv3_rebuilds_preconditioner_for_each_changed_design():
+    rng = np.random.default_rng(20260902)
+    n_groups = 6
+    rows_per_group = 6
+    n = n_groups * rows_per_group
+    data = pd.DataFrame(
+        {
+            "y": rng.normal(size=n),
+            "x": rng.normal(size=n),
+            "group": np.repeat(np.arange(n_groups), rows_per_group),
+            "time": np.tile(np.arange(rows_per_group), n_groups),
+        }
+    )
+    base = feols(
+        "y ~ x | group + time",
+        data=data,
+        vcov="iid",
+        demeaner=LsmrDemeaner(backend="within"),
+    )
+    assert base.preconditioner is not None
+    reused = LsmrDemeaner(backend="within", preconditioner=base.preconditioner)
+
+    fit = feols(
+        "y ~ x | group + time",
+        data=data,
+        vcov={"CRV3": "group"},
+        demeaner=reused,
+    )
+    assert np.isfinite(fit._vcov).all()
 
 
 @pytest.mark.parametrize("vcov", ["NW", "DK"])


### PR DESCRIPTION
## Summary

Poisson CRV3 jackknife refits and slow randomization-inference refits now replay the original estimation options: weights, small-sample corrections, singleton handling, solver, demeaner, offset, and IRLS tolerances. A prebuilt LSMR preconditioner is the one deliberate exception: its factorization belongs to one fixed-effect design, so a refit keeps the variant but rebuilds it for the changed row set.

Review question: **Does a refit replay the original specification?**

Layer 8 of 9 replacing #1500/#1501; depends on #1523 (`fix/retained-estimation-storage`). The original PRs stay open until the replacement stack is validated.

## Verification

- Release contract: 1,355 passed.
- Refit-contract tests: `tests/test_ses.py` and `tests/test_ritest.py -k "replay or refit or estimation_contract or preconditioner"` 3 passed; `tests/test_estimator_state_lifecycle.py` 55 passed.
- Changed-file Ruff and mypy passed; whole-tree `ruff-check`/`ruff-format` hooks passed at this tip.

Exact targeted command: `pixi run -e py312-r pytest tests/test_ses.py tests/test_ritest.py -q --no-cov -k "replay or refit or estimation_contract or preconditioner"`.

The repository's Python/R/docs workflow only runs for PRs targeting `master`; this stacked PR receives pre-commit CI only. Broad cumulative checks ran locally on the final replacement head (layer 9). Human review is required; no automatic merge.
