### PR TITLE
fix(inference): publish covariance updates atomically

### DIFF
--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -46,24 +46,18 @@ fit3 = pf.feols("Y ~ X1 + X2 | f1", data = df)
   result expansion through a structural lifecycle protocol. This keeps formula
   roles stable while the later within- and weight-scale cleanup proceeds
   independently.
-
-- Standalone OLS and IV fit primitives now accept user-scale observation
-  weights, apply square-root weighting only to solver-local arrays, and return
-  residuals and scores in their documented supplied-array and estimating-equation
-  domains.
-- The shared demeaning cache now stores read-only named arrays, preserves
-  requested column order on complete and partial hits, and avoids allocating a
-  concatenated request matrix when every requested column is already cached.
-- Linear estimators now retain formula tables, unpremultiplied within arrays,
-  and user-scale observation weights as separate state. Weighted OLS and IV
-  scores, covariance leverage, residuals, diagnostics, and recovered fixed
-  effects use those explicit domains.
-- GLM estimators now retain final within-scale IRLS working state separately
-  from immutable user-scale observation weights. Working weights already
-  include observation weights in scores, Hessians, leverage, and weighted
-  fixed-effect recovery; frequency-weight effective counts survive separation.
+- Estimator internals now keep formula tables, unpremultiplied within arrays,
+  and user-scale observation weights in separate typed domains.
+  Square-root-weighted arrays are local solver temporaries, and linear
+  residuals remain in response units. GLM IRLS working state (working response,
+  design, and weights) is kept separate from observation weights.
 - Legacy estimator attributes such as `_X`, `_Y`, `_Z`, and `_weights` are now
   read-only views over the typed state objects.
+- Internal demeaning and covariance code now names column-order, normal-equation,
+  and frequency-replication invariants explicitly alongside their formulas.
+- Post-fit covariance updates now prepare covariance metadata and derived
+  inference before publishing them. Multiple-estimation and quantile-process
+  updates likewise prepare every child before changing any child.
 
 ### Inference Types
 
@@ -119,6 +113,9 @@ fit.confint(inference_type="savi", mixture_precision=mixture_precision)
 
 ### GLM API and Behavior
 
+- Poisson and GLM frequency weights now work, including post-separation sample
+  sizes; the 0.60.0 path raised a shape error. Probability weights remain
+  unsupported.
 - Poisson offsets now accept Formulaic transformations such as
   `offset="log(exposure)"` when the expression evaluates to one numeric column.
 - `feglm()` now accepts `weights`, `weights_type`, and `offset`, and supports
@@ -232,13 +229,24 @@ We also removed:
 - `lean=True` results keep the formula specification and evaluation context, so
   `predict(newdata=...)` keeps working for models without fixed effects; methods
   that need discarded state now raise an informative `RuntimeError` instead of
-  `AttributeError`.
-- `store_data=False` and `lean=True` now apply to retained IV first stages and
-  multiple-estimation containers; lean fits also discard demeaning caches, GLM
-  working state, and quantile solver outputs.
+  `AttributeError`. `vcov(..., data=...)` now validates that the explicit sample
+  matches the fitted rows.
+- `store_data=False` and `lean=True` now apply to retained IV first stages; lean
+  fits also discard demeaning caches, GLM working state, and quantile solver
+  outputs.
+- `store_data=False` and `lean=True` now apply to multiple-estimation
+  containers; `FixestMulti.vcov()` accepts a common explicit estimation sample;
+  default multi-quantile results retain the arrays needed for prediction and
+  covariance updates.
 - Fitted models and non-plotting DiD and reporting paths no longer import
   plotting dependencies eagerly. `ritest()` loads its numerical helpers on use,
   while Matplotlib, Seaborn, and Lets-Plot load only when plotting.
+- Weighted fixed-effect contributions (`_sumFE`) are now stored in response
+  units.
+- Gaussian GLM performance measures now use the estimator's unpremultiplied
+  within response and observation weights, including weighted fixed-effect fits.
+- `IV_Diag()` no longer relabels the main model's covariance type when computing
+  the effective F statistic.
 - CCV auxiliary fits now retain the original demeaner configuration.
 - IR separation checks now use the configured demeaner backend.
 - Fixes `confint()` when `keep` or `drop` requests coefficients in an order

--- a/docs/developer/architecture.md
+++ b/docs/developer/architecture.md
@@ -60,13 +60,11 @@ shared estimator API
   -> prepare_model_matrix
   -> estimator-specific get_fit
        -> feols / feiv
-            -> demean
-            -> to_array
-            -> drop_multicol_vars
-            -> wls_transform
-            -> solve OLS / 2SLS
+            -> construct within-scale arrays
+            -> drop collinear columns
+            -> solve OLS / 2SLS with local weight transforms
        -> fepois / feglm
-            -> IRLS with weighted demeaning and solving inside each iteration
+            -> IRLS with explicit observation and working weights
        -> quantreg
             -> Frisch-Newton solve (absorbed fixed effects are unsupported)
   -> vcov
@@ -77,12 +75,13 @@ shared estimator API
 `FixestMulti` is a container for fitted results. Numerical behavior belongs in
 the individual models and shared primitives, not in the container.
 
-## Current estimator-state lifecycle
+## Historical estimator-state lifecycle (pre-refactor)
 
-The fitted-model classes currently use themselves as both a work area and a
-result object. Several private attributes therefore change representation and
-numerical scale while a model is fitted. This section records that status quo;
-it is not a contract for new code.
+Before the immutable-state refactor, fitted-model classes used themselves as
+both a work area and a result object. Several private attributes therefore
+changed representation and numerical scale while a model was fitted. This
+section preserves that baseline as migration history; it is not the current
+contract for new code.
 
 For linear models, the transformations are:
 
@@ -192,10 +191,9 @@ constructors only assemble configuration and child objects; for example,
 `QuantregMulti` prepares its children in `prepare_model_matrix`, not during
 construction.
 
-This is the representation foundation, not the final within/weight cleanup.
-The compatibility fields documented above still move through their established
-DataFrame, within-array, and solver-array states until the numerical primitives
-and inference consumers move to explicit within-scale inputs.
+This established the representation foundation. The within/weight cleanup
+described below completes that layer by moving numerical primitives and
+inference consumers to explicit within-scale inputs.
 
 ## Estimation-state vocabulary
 
@@ -218,26 +216,91 @@ not replace canonical within data. A fitted result may still expose explicitly
 in-place post-estimation operations, but those operations must not repurpose
 estimation fields.
 
-## Implemented linear array and weight domains
+## Implemented array and weight domains
 
-Linear estimators retain formula tables, user-scale `ObservationWeights`, and
-unpremultiplied `WithinLinearData` as distinct state. For IV models, `design`
-is the full structural regressor matrix and `instruments` is the full
-instrument matrix, including exogenous regressors that instrument themselves.
-OLS and IV primitives create square-root-weighted arrays only as solver-local
-temporaries; persisted residuals remain in response units, while scores and
-cross-products contain the full observation weights required by their
-estimating equations.
+The shared linear and GLM paths now implement the vocabulary above with frozen,
+slotted state values. Frozen state prevents field rebinding, but contained NumPy
+arrays remain mutable unless they are explicitly marked read-only:
 
-Frozen state objects prevent field rebinding, but their NumPy arrays remain
-element-mutable unless separately marked read-only. The shared demeaning cache
-does mark published buffers read-only because they are shared across fits.
+| State | Persisted contract |
+|---|---|
+| `ModelMatrix` | Formula-materialized pandas tables remain on formula scale and keep dependent, independent, fixed-effect, IV, weight, and offset roles separate. |
+| `ObservationWeights` | Canonical user-scale weights and their `aweights` or `fweights` semantics. `values=None` is the allocation-free unweighted path. |
+| `WithinLinearData` | Unpremultiplied within-scale arrays, with response, design, instruments, and endogenous variables in named roles. |
+| `GlmWorkingState` | Final within-scale working response and design, IRLS working weights, predictors, means, and response- and working-residual domains. |
+| `DemeanedData` | Array-native cache entries whose ordered column names are metadata rather than DataFrame conversions around each reuse. |
 
-GLMs keep observation weights and final IRLS working weights separate. The
-working weights already incorporate observation weights and are paired with
-the unpremultiplied working response, design, and residuals in
-`GlmWorkingState`; applying observation weights to them again would double
-count those weights.
+Analytic weights keep the retained row count as the effective sample size;
+frequency weights use the sum of their user-scale values. Probability weights
+(`pweights`) remain unsupported. Fixed-effect projection may use observation or
+IRLS weights, but the returned arrays remain within scale. OLS, IV, and IRLS
+fit primitives create square-root-weighted design and response arrays only as
+local solver temporaries. They persist response-unit residuals and weighted
+scores or cross-products, not solver-scale copies of canonical data.
+Singleton fixed-effect detection counts physical rows even under frequency
+weights, so an aggregate row alone in its level is dropped although its literal
+expansion would not be; this deliberate deviation is documented in
+`tests/test_wls_types.py`.
+
+GLMs keep two weight concepts deliberately separate. `ObservationWeights`
+never changes after formula preparation, while each IRLS iteration computes
+working weights and the final values live in `GlmWorkingState`. Response
+residuals and working residuals likewise have separate fields.
+
+The compatibility aliases are still available, but they are read-only
+properties over the typed state rather than cross-type workspaces: the state
+objects are the single writable representation, and assigning or deleting an
+alias raises. For linear and IV fits, `_Y`, `_X`, and `_Z` view within-scale
+arrays; for GLMs they view the final within-scale working response and design.
+`_weights` always means observation weights, never square-root solver weights
+or GLM working weights, and an unweighted fit materializes its ones column on
+access instead of keeping one alive for the lifetime of the result. New code
+should consume the typed state values rather than infer semantics from these
+aliases.
+
+`ccv()` explicitly rejects weighted models. `update()` can compute and return
+coefficient-only Sherman-Morrison updates for unweighted, non-IV OLS without
+fixed effects, but rejects `inplace=True`: design rows alone cannot reconstruct
+the complete formula, prediction, inference, and performance state of a fitted
+result.
+
+Post-estimation paths reject the estimators they cannot represent instead of
+reading their arrays as OLS state. Non-Poisson GLMs reject `CRV3` until their
+leave-cluster-out refits can retain the original family and solver
+configuration; Poisson keeps its longstanding jackknife-refit path.
+Randomization inference rejects non-OLS/non-Poisson results, and the wild
+bootstrap and `decompose()` reject non-OLS results, so none of them
+reinterprets GLM working state or quantile solver outputs as linear-model
+arrays. Poisson CRV3 and slow randomization refits replay the original
+estimation options. A prebuilt LSMR preconditioner is the sole exception: its
+factorization belongs to one fixed-effect design, so refits keep its variant
+but rebuild it for the changed row set. Weighted `fixef()` stores `_sumFE` in
+response units, and `IV_Diag()` leaves the outer model's covariance label
+untouched.
+
+Storage policy follows the full result graph. Multiple-estimation containers
+keep no copy of the input frame under `store_data=False` or `lean=True`,
+retained IV first stages honor `store_data=False`, and lean results discard
+within state, GLM working state, demeaning caches, quantile solver outputs, and
+large first-stage arrays. Lean results do keep the formula specification and
+evaluation context, so `predict(newdata=...)` still works for models without
+fixed effects. Array-only covariance updates remain available after
+`store_data=False`; cluster and HAC updates require the estimation sample
+through the documented `vcov(data=...)` argument. Explicit covariance data must
+already be filtered to the fitted row sample and retain its estimation order. A
+row-count check rejects length mismatches but cannot establish row identity or
+ordering. Single-model covariance updates compute covariance metadata and
+derived inference on a detached candidate before publishing any fields.
+`FixestMulti.vcov(data=...)` validates one common sample, and both multiple-
+estimation containers prepare every child before publishing any child, while
+preserving the child objects themselves. Lean results reject post-fit covariance
+updates because their numerical arrays have been discarded. Every other method
+that needs discarded state raises an informative error naming the storage option
+and its remedy.
+
+Keeping canonical arrays unpremultiplied favors readability without moving
+weight work out of the numerical hot path: each solver still performs the same
+vectorized square-root transform locally.
 
 ## Repository map and extension seams
 
@@ -264,32 +327,6 @@ A model method validates inputs, unpacks model state, calls a module-level
 function with keyword arguments, and stores or returns the result. Numerical
 functions operate on arrays and return small typed dataclasses whose docstrings
 state array shapes.
-
-`ccv()` explicitly rejects weighted models. `update()` can compute and return
-coefficient-only Sherman-Morrison updates for unweighted, non-IV OLS without
-fixed effects, but rejects `inplace=True`: design rows alone cannot reconstruct
-the complete formula, prediction, inference, and performance state of a fitted
-result.
-
-Post-estimation paths reject the estimators they cannot represent instead of
-reading their arrays as OLS state. Non-Poisson GLMs reject `CRV3` until their
-leave-cluster-out refits can retain the original family and solver
-configuration; Poisson keeps its longstanding jackknife-refit path.
-Randomization inference rejects non-OLS/non-Poisson results, and the wild
-bootstrap and `decompose()` reject non-OLS results, so none of them
-reinterprets GLM working state or quantile solver outputs as linear-model
-arrays. Poisson CRV3 and slow randomization refits replay the original
-estimation options; prebuilt LSMR preconditioners are rebuilt for each changed
-row sample.
-
-Storage policy follows the full result graph. Multiple-estimation containers
-keep no copy of the input frame under `store_data=False` or `lean=True`,
-retained IV first stages honor `store_data=False`, and lean results discard
-within state, GLM working state, demeaning caches, quantile solver outputs, and
-large first-stage arrays. Lean results keep the formula specification and
-evaluation context so `predict(newdata=...)` remains available for models
-without fixed effects. Methods that need discarded state raise an informative
-error naming the storage option and remedy.
 
 Every estimator or inference feature specifies behavior for weights, fixed
 effects, IV, multiple estimation, `lean=True`, and `store_data=False`.

--- a/pyfixest/estimation/FixestMulti_.py
+++ b/pyfixest/estimation/FixestMulti_.py
@@ -13,6 +13,7 @@ from pyfixest.estimation.models.feiv_ import Feiv
 from pyfixest.estimation.models.feols_ import Feols
 from pyfixest.estimation.models.fepois_ import Fepois
 from pyfixest.estimation.plan_ import ParsedFormula
+from pyfixest.utils.dev_utils import DataFrameType, _narwhals_to_pandas
 
 
 class FixestMulti(TidyColumnAccessors):
@@ -120,7 +121,8 @@ class FixestMulti(TidyColumnAccessors):
         self,
         vcov: str | dict[str, str],
         vcov_kwargs: dict[str, str | int] | None = None,
-    ):
+        data: DataFrameType | None = None,
+    ) -> FixestMulti:
         """
         Update regression inference "on the fly".
 
@@ -138,13 +140,63 @@ class FixestMulti(TidyColumnAccessors):
             for CRV1 inference or {"CRV3": "clustervar"} for CRV3 inference.
         vcov_kwargs : Optional[dict[str, any]]
              Additional keyword arguments for the variance-covariance matrix.
+        data : DataFrameType, optional
+            The common, already-filtered estimation sample in its original order.
+            Required for data-dependent covariance updates when the fitted models
+            were created with `store_data=False`. Defaults to None.
 
         Returns
         -------
-            An instance of the "Fixest" class with updated inference.
+        FixestMulti
+            This result container with updated inference.
         """
-        for fxst in self.all_fitted_models.values():
-            fxst.vcov(vcov=vcov, vcov_kwargs=vcov_kwargs)
+        data_to_forward = data
+        if data is not None:
+            try:
+                data_to_forward = _narwhals_to_pandas(data)
+            except TypeError as exc:
+                raise TypeError(
+                    f"The data set must be a DataFrame type. Received: {type(data)}"
+                ) from exc
+
+            models = list(self.all_fitted_models.values())
+            expected_rows = sorted({model._N_rows for model in models})
+            received_rows = len(data_to_forward)
+            if any(n_rows != received_rows for n_rows in expected_rows):
+                raise ValueError(
+                    "`data` passed to FixestMulti.vcov() must contain the common, "
+                    "already-filtered estimation sample in its original order for "
+                    "every child model; expected child row counts "
+                    f"{expected_rows}, received {received_rows}. Fetch each child "
+                    "model and call vcov(..., data=...) separately when estimation "
+                    "samples differ."
+                )
+
+            reference = models[0] if models else None
+            if reference is not None and any(
+                model._sample_split_var != reference._sample_split_var
+                or model._sample_split_value != reference._sample_split_value
+                or model._na_index != reference._na_index
+                for model in models[1:]
+            ):
+                raise ValueError(
+                    "`data` cannot be forwarded by FixestMulti.vcov() because its "
+                    "child models use different estimation samples. Fetch each "
+                    "child model and call vcov(..., data=...) with that model's "
+                    "already-filtered estimation sample instead."
+                )
+
+        models = list(self.all_fitted_models.values())
+        candidates = [
+            model._prepare_vcov_update(
+                vcov=vcov,
+                vcov_kwargs=vcov_kwargs,
+                data=data_to_forward,
+            )
+            for model in models
+        ]
+        for model, candidate in zip(models, candidates, strict=True):
+            model._publish_vcov_update(candidate)
         return self
 
     def tidy(self) -> pd.DataFrame:

--- a/pyfixest/estimation/models/feols_.py
+++ b/pyfixest/estimation/models/feols_.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import re
 import warnings
 from collections.abc import Mapping
+from copy import copy as shallow_copy
 from dataclasses import replace
+from functools import partial
 from importlib import import_module
 from typing import Any, Literal, cast
 
@@ -31,6 +33,7 @@ from pyfixest.estimation.internals.demean_ import DemeanCache, DemeanedData
 from pyfixest.estimation.internals.families import T_DIST, InferenceDist
 from pyfixest.estimation.internals.fit_ import fit_ols
 from pyfixest.estimation.internals.literals import (
+    HacVcovTypeOptions,
     PredictionErrorOptions,
     PredictionType,
     SolverOptions,
@@ -230,8 +233,8 @@ class Feols(ResultAccessorMixin):
         "scipy.sparse.linalg.lsqr"],
         default is "scipy.linalg.solve". Solver to use for the estimation.
     _data: pd.DataFrame
-        The data frame used in the estimation. None if arguments `lean = True` or
-        `store_data = False`.
+        The data frame used in the estimation. Deleted if arguments `lean = True`
+        or `store_data = False`.
     _model_name: str
         The name of the model. Usually just the formula string. If split estimation is used,
         the model name will include the split variable and value.
@@ -322,6 +325,9 @@ class Feols(ResultAccessorMixin):
         self._store_data = store_data
         self._copy_data = copy_data
         self._lean = lean
+        # Storage cleanup runs at the very end of the fit, so `lean` alone does
+        # not say whether the fit arrays are still there. Estimation itself goes
+        # through the same guarded methods.
         self._fit_state_discarded = False
         self._context = capture_context(context)
 
@@ -485,9 +491,10 @@ class Feols(ResultAccessorMixin):
             return ObservationWeights.unweighted(n_rows=n_rows)
 
         assert self._weights_type in ("aweights", "fweights")
+        weights_kind = cast(WeightsTypeOptions, self._weights_type)
         return ObservationWeights.from_values(
             self._model_matrix.weights.to_numpy().reshape(-1),
-            kind=cast(WeightsTypeOptions, self._weights_type),
+            kind=weights_kind,
         )
 
     def _prepare_within_data(self) -> WithinLinearData:
@@ -496,18 +503,19 @@ class Feols(ResultAccessorMixin):
         design_frame = self._model_matrix.independent
         response = response_frame.to_numpy(dtype=np.float64)
         design = design_frame.to_numpy(dtype=np.float64)
-        fixed_effects = self._model_matrix.fixed_effects
-        if fixed_effects is not None:
+
+        if self._model_matrix.fixed_effects is not None:
             response, design, _ = self._demean_cache.demean_yx(
                 response,
                 design,
-                y_names=tuple(response_frame.columns),
-                x_names=tuple(design_frame.columns),
-                fe=fixed_effects.to_numpy(),
+                y_names=response_frame.columns,
+                x_names=design_frame.columns,
+                fe=self._model_matrix.fixed_effects.to_numpy(),
                 weights=self._observation_weights.values,
                 na_index=self._na_index,
                 demeaner=self._demeaner,
             )
+
         return WithinLinearData(response=response, design=design)
 
     @property
@@ -645,7 +653,7 @@ class Feols(ResultAccessorMixin):
         arrays: str,
         remedy: str = "Refit with lean=False.",
     ) -> None:
-        """Reject a call whose input arrays ``lean=True`` discarded."""
+        """Reject a call whose input arrays `lean=True` discarded."""
         if self._lean and self._fit_state_discarded:
             raise RuntimeError(
                 f"{method}() is unavailable after fitting with lean=True because "
@@ -658,7 +666,7 @@ class Feols(ResultAccessorMixin):
         *,
         remedy: str = "Refit with store_data=True.",
     ) -> None:
-        """Reject a call whose estimation data were discarded."""
+        """Reject a call whose estimation data the storage options discarded."""
         if not hasattr(self, "_data"):
             raise RuntimeError(
                 f"{method}() is unavailable when store_data=False or lean=True "
@@ -687,8 +695,10 @@ class Feols(ResultAccessorMixin):
         vcov_kwargs : Optional[dict[str, any]]
              Additional keyword arguments for the variance-covariance matrix.
         data: Optional[DataFrameType], optional
-            The data used for estimation. If None, tries to fetch the data from the
-            model object. Defaults to None.
+            The already-filtered estimation sample in its original estimation
+            order. This is required for data-dependent covariance updates when
+            the fitted model does not retain its input data. If None, tries to
+            fetch the data from the model object. Defaults to None.
 
 
         Returns
@@ -716,38 +726,114 @@ class Feols(ResultAccessorMixin):
         See [On Small Sample Corrections](/explanation/ssc.qmd) for how the
         `ssc` adjustments interact with each estimator.
         """
+        candidate = self._prepare_vcov_update(
+            vcov=vcov,
+            vcov_kwargs=vcov_kwargs,
+            data=data,
+        )
+        self._publish_vcov_update(candidate)
+        return self
+
+    def _prepare_vcov_update(
+        self,
+        *,
+        vcov: str | dict[str, str],
+        vcov_kwargs: dict[str, str | int] | None,
+        data: DataFrameType | None,
+    ) -> Feols:
+        """Compute a covariance update without changing this fitted result.
+
+        The candidate shares fitted input arrays with this result. Covariance
+        callbacks treat those arrays as inputs and allocate their outputs, so
+        only the candidate's inference fields change during computation.
+        """
+        candidate = shallow_copy(self)
+        candidate._compute_vcov_update(
+            vcov=vcov,
+            vcov_kwargs=vcov_kwargs,
+            data=data,
+        )
+        return candidate
+
+    def _publish_vcov_update(self, candidate: Feols) -> None:
+        """Publish a completely computed covariance and inference state."""
+        inference_attributes = (
+            "_vcov_type",
+            "_vcov_type_detail",
+            "_is_clustered",
+            "_clustervar",
+            "_bread",
+            "_ssc",
+            "_df_k",
+            "_df_t",
+            "_vcov",
+            "_lag",
+            "_time_id",
+            "_panel_id",
+            "_cluster_df",
+            "_G",
+            "_se",
+            "_tstat",
+            "_pvalue",
+            "_conf_int",
+        )
+        for attribute in inference_attributes:
+            if hasattr(candidate, attribute):
+                setattr(self, attribute, getattr(candidate, attribute))
+            elif hasattr(self, attribute):
+                delattr(self, attribute)
+
+    def _compute_vcov_update(
+        self,
+        *,
+        vcov: str | dict[str, str],
+        vcov_kwargs: dict[str, str | int] | None,
+        data: DataFrameType | None,
+    ) -> None:
+        """Compute covariance and derived inference on this candidate."""
         self._require_fit_arrays(
             "vcov",
             arrays="the required estimation arrays",
             remedy="Set vcov at estimation time or refit with lean=False.",
         )
 
-        data_to_check = getattr(self, "_data", None) if data is None else data
-        if data_to_check is not None:
+        estimation_data: pd.DataFrame | None
+        if data is None:
+            estimation_data = getattr(self, "_data", None)
+        else:
             try:
-                data_to_check = _narwhals_to_pandas(data_to_check)
+                estimation_data = _narwhals_to_pandas(data)
             except TypeError as e:
                 raise TypeError(
                     f"The data set must be a DataFrame type. Received: {type(data)}"
                 ) from e
+            if len(estimation_data) != self._N_rows:
+                raise ValueError(
+                    "`data` passed to vcov() must contain exactly the already-filtered "
+                    "estimation sample in its original estimation order; expected "
+                    f"{self._N_rows} rows, received {len(estimation_data)}."
+                )
 
         # assign estimated fixed effects, and fixed effects nested within cluster.
 
         # deparse vcov input
-        _check_vcov_input(vcov=vcov, vcov_kwargs=vcov_kwargs, data=data_to_check)
+        _check_vcov_input(vcov=vcov, vcov_kwargs=vcov_kwargs, data=estimation_data)
 
-        (
-            self._vcov_type,
-            self._vcov_type_detail,
-            self._is_clustered,
-            self._clustervar,
-        ) = _deparse_vcov_input(vcov, self._has_fixef, self._is_iv)
+        vcov_type, vcov_type_detail, is_clustered, clustervar = _deparse_vcov_input(
+            vcov, self._has_fixef, self._is_iv
+        )
 
-        if self._vcov_type in {"HAC", "CRV"} and data_to_check is None:
+        # Cluster and HAC estimators need columns from the estimation sample.
+        if vcov_type in {"HAC", "CRV"} and estimation_data is None:
             self._require_estimation_data(
                 "vcov",
                 remedy="Pass the estimation sample via data= or refit with store_data=True.",
             )
+
+        self._vcov_type = vcov_type
+        self._vcov_type_detail = vcov_type_detail
+        self._is_clustered = is_clustered
+        self._clustervar = clustervar
 
         self._bread = _compute_bread(
             self._is_iv, self._tXZ, self._tZZinv, self._tZX, self._hessian
@@ -767,7 +853,7 @@ class Feols(ResultAccessorMixin):
             self._vcov = self._ssc * self._vcov_hetero()
 
         elif self._vcov_type == "HAC":
-            assert data_to_check is not None
+            assert estimation_data is not None
             kw = vcov_kwargs or {}
             self._lag = kw.get("lag")
             self._time_id = kw.get("time_id")
@@ -775,10 +861,10 @@ class Feols(ResultAccessorMixin):
             self._ssc, self._df_k, self._df_t = get_ssc(
                 **self._make_ssc_kwargs(
                     vcov_type="HAC",
-                    G=np.unique(data_to_check[self._time_id]).shape[0],
+                    G=np.unique(estimation_data[self._time_id]).shape[0],
                 )  # number of unique time periods T used
             )
-            self._vcov = self._ssc * self._vcov_hac()
+            self._vcov = self._ssc * self._vcov_hac(data=estimation_data)
 
         elif self._vcov_type == "nid":
             self._ssc, self._df_k, self._df_t = get_ssc(
@@ -787,9 +873,9 @@ class Feols(ResultAccessorMixin):
             self._vcov = self._ssc * self._vcov_nid()
 
         elif self._vcov_type == "CRV":
-            assert data_to_check is not None
+            assert estimation_data is not None
             prep = prepare_cluster_state(
-                data=data_to_check,
+                data=estimation_data,
                 clustervar=self._clustervar,
                 ssc_dict=self._ssc_dict,
                 fixef=self._fixef,
@@ -802,12 +888,10 @@ class Feols(ResultAccessorMixin):
                 prep=prep,
                 k=self._k,
                 make_ssc_kwargs=self._make_ssc_kwargs,
-                cluster_vcov=self._vcov_crv_cluster,
+                cluster_vcov=partial(self._vcov_crv_cluster, data=estimation_data),
             )
         # update p-value, t-stat, standard error, confint
         self.get_inference()
-
-        return self
 
     def _make_ssc_kwargs(
         self,
@@ -833,7 +917,11 @@ class Feols(ResultAccessorMixin):
         }
 
     def _vcov_crv_cluster(
-        self, clustid: np.ndarray, cluster_col: np.ndarray
+        self,
+        clustid: np.ndarray,
+        cluster_col: np.ndarray,
+        *,
+        data: pd.DataFrame,
     ) -> np.ndarray:
         "Pick CRV1 / CRV3-fast / CRV3-slow for one cluster column."
         if self._vcov_type_detail == "CRV1":
@@ -844,8 +932,13 @@ class Feols(ResultAccessorMixin):
                 f"CRV3 inference is not for models of type '{self._method}'."
             )
         use_fast = not self._has_fixef and self._method == "feols" and not self._is_iv
-        crv3 = self._vcov_crv3_fast if use_fast else self._vcov_crv3_slow
-        return crv3(clustid=clustid, cluster_col=cluster_col)
+        if use_fast:
+            return self._vcov_crv3_fast(clustid=clustid, cluster_col=cluster_col)
+        return self._vcov_crv3_slow(
+            clustid=clustid,
+            cluster_col=cluster_col,
+            data=data,
+        )
 
     def _vcov_iid(self):
         return vcov_iid_ols(
@@ -882,10 +975,9 @@ class Feols(ResultAccessorMixin):
             tZZinv=self._tZZinv,
         )
 
-    def _vcov_hac(self):
+    def _vcov_hac(self, *, data: pd.DataFrame):
         _time_id = self._time_id
         _panel_id = self._panel_id
-        _data = self._data
 
         if not self._support_hac_inference:
             raise NotImplementedError(
@@ -900,22 +992,22 @@ class Feols(ResultAccessorMixin):
 
         # some data checks on input pandas df
         # time needs to be numeric or date else we cannot sort by time
-        if not np.issubdtype(_data[_time_id], np.number) and not np.issubdtype(
-            _data[_time_id], np.datetime64
+        if not np.issubdtype(data[_time_id], np.number) and not np.issubdtype(
+            data[_time_id], np.datetime64
         ):
             raise ValueError(
                 "The time variable must be numeric or date, else we cannot sort by time."
             )
 
-        _time_arr = _data[_time_id].to_numpy()
-        _panel_arr = _data[_panel_id].to_numpy() if _panel_id is not None else None
+        _time_arr = data[_time_id].to_numpy()
+        _panel_arr = data[_panel_id].to_numpy() if _panel_id is not None else None
 
         return vcov_hac(
             scores=self._scores,
             time_arr=_time_arr,
             panel_arr=_panel_arr,
-            lag=self._lag,
-            vcov_type_detail=self._vcov_type_detail,
+            lag=cast(int | None, self._lag),
+            vcov_type_detail=cast(HacVcovTypeOptions, self._vcov_type_detail),
             bread=self._bread,
             is_iv=self._is_iv,
             tXZ=self._tXZ,
@@ -956,6 +1048,8 @@ class Feols(ResultAccessorMixin):
         if isinstance(demeaner, LsmrDemeaner) and isinstance(
             demeaner.preconditioner, Preconditioner
         ):
+            # A prebuilt factorization belongs to the original FE design. Keep
+            # its algorithmic variant, but rebuild it for the changed row set.
             preconditioner = cast(
                 WithinPreconditionerName,
                 demeaner.preconditioner.variant.lower(),
@@ -976,6 +1070,7 @@ class Feols(ResultAccessorMixin):
 
     def _crv3_refit(self, data: pd.DataFrame) -> Feols:
         """Replay OLS for one leave-one-cluster-out sample."""
+        # lazy loading to avoid circular import
         fixest_module = import_module("pyfixest.estimation")
         return fixest_module.feols(
             fml=self._fml,
@@ -984,13 +1079,19 @@ class Feols(ResultAccessorMixin):
             **self._estimation_refit_kwargs(),
         )
 
-    def _vcov_crv3_slow(self, clustid, cluster_col):
+    def _vcov_crv3_slow(
+        self,
+        clustid: np.ndarray,
+        cluster_col: np.ndarray,
+        *,
+        data: pd.DataFrame,
+    ) -> np.ndarray:
         beta_jack = np.zeros((len(clustid), self._k))
 
         for ixg, g in enumerate(clustid):
             # direct leave one cluster out implementation
-            data = self._data[~np.equal(g, cluster_col)]
-            fit = self._crv3_refit(data=data)
+            refit_data = data[~np.equal(g, cluster_col)]
+            fit = self._crv3_refit(data=refit_data)
             beta_jack[ixg, :] = fit.coef().to_numpy()
 
         # optional: beta_bar in MNW (2022)
@@ -1029,8 +1130,8 @@ class Feols(ResultAccessorMixin):
                 "_tXZ",
                 "_tZy",
                 "_tZX",
-                "_scores",
                 "_tZZinv",
+                "_scores",
                 "_u_hat",
                 "_Y_hat_link",
                 "_Y_hat_response",
@@ -1701,11 +1802,6 @@ class Feols(ResultAccessorMixin):
         res = fit.decompose(decomp_var="x1", combine_covariates={"g1": re.compile("x2[1-2]"), "g2": re.compile("x23")})
         ```
         """
-        if not self._support_decomposition:
-            raise NotImplementedError(
-                "Decomposition is currently only supported for OLS models."
-            )
-
         has_param = param is not None
         has_decomp = decomp_var is not None
 
@@ -1739,7 +1835,14 @@ class Feols(ResultAccessorMixin):
             only_coef=only_coef,
         )
 
+        if not self._support_decomposition:
+            raise NotImplementedError(
+                "Decomposition is currently only supported for OLS models."
+            )
+
         self._require_fit_arrays("decompose", arrays="the fitted arrays")
+        # A cluster variable or an absorbed fixed effect is read back from the
+        # estimation sample; the plain covariate case works on arrays alone.
         if cluster is not None or self._is_clustered or self._has_fixef:
             self._require_estimation_data("decompose")
 
@@ -1845,6 +1948,8 @@ class Feols(ResultAccessorMixin):
         self._require_fit_arrays("fixef", arrays="the fitted arrays")
         self._require_estimation_data("fixef")
 
+        fixef_recovery_weights = self._fixef_recovery_weights()
+
         Y, X = self._model_spec[_ModelMatrixKey.main].get_model_matrix(
             self._data,
             output="pandas",
@@ -1882,7 +1987,6 @@ class Feols(ResultAccessorMixin):
         )
         fixed_effect_design = contrast_coding.matrix
         fixed_effect_design_for_recovery = fixed_effect_design
-        fixef_recovery_weights = self._fixef_recovery_weights()
         if fixef_recovery_weights is not None:
             weights_sqrt = np.sqrt(fixef_recovery_weights).flatten()
             uhat *= weights_sqrt
@@ -1899,8 +2003,6 @@ class Feols(ResultAccessorMixin):
             ].transform_state,
         )
         self._alpha = alpha
-        # Weighting changes the recovery metric; fitted FE contributions remain
-        # D alpha in response units (up to solver and convergence tolerance).
         self._sumFE = fixed_effect_design.dot(alpha)
 
         return fixed_effects_to_frame(self._fixef_coefficients)
@@ -2030,6 +2132,7 @@ class Feols(ResultAccessorMixin):
             # matching how unseen fixed-effect levels are handled below.
             valid_idx = valid_idx[~unseen[valid_idx]]
             if self._has_fixef:
+                # Fixed-effect levels are recovered from the estimation sample.
                 self._require_fit_arrays(
                     "predict", arrays="the fitted design and residual arrays"
                 )
@@ -2429,19 +2532,20 @@ class Feols(ResultAccessorMixin):
             raise NotImplementedError(
                 "The update() method is currently not supported for models with weights."
             )
-        self._require_fit_arrays("update", arrays="the fitted design arrays")
         if inplace:
             raise NotImplementedError(
                 "update(..., inplace=True) is not supported because appending design "
                 "rows cannot safely update the complete fitted-result state; use the "
                 "returned coefficients instead."
             )
+        self._require_fit_arrays("update", arrays="the fitted design arrays")
         if not np.all(X_new[:, 0] == 1):
             X_new = np.column_stack((np.ones(len(X_new)), X_new))
         X_n_plus_1 = np.vstack((self._X, X_new))
         epsi_n_plus_1 = y_new - X_new @ self._beta_hat
         gamma_n_plus_1 = np.linalg.inv(X_n_plus_1.T @ X_n_plus_1) @ X_new.T
         beta_n_plus_1 = self._beta_hat + gamma_n_plus_1 @ epsi_n_plus_1
+
         return beta_n_plus_1
 
 

--- a/pyfixest/estimation/quantreg/QuantregMulti.py
+++ b/pyfixest/estimation/quantreg/QuantregMulti.py
@@ -209,8 +209,17 @@ class QuantregMulti:
         data: DataFrameType | None = None,
     ) -> dict[float, Quantreg]:
         "Compute variance-covariance matrices for all models in the quantile regression process."
-        for quantreg in self.all_quantregs.values():
-            quantreg.vcov(vcov=vcov, vcov_kwargs=vcov_kwargs, data=data)
+        quantregs = list(self.all_quantregs.values())
+        candidates = [
+            quantreg._prepare_vcov_update(
+                vcov=vcov,
+                vcov_kwargs=vcov_kwargs,
+                data=data,
+            )
+            for quantreg in quantregs
+        ]
+        for quantreg, candidate in zip(quantregs, candidates, strict=True):
+            quantreg._publish_vcov_update(candidate)
 
         return self.all_quantregs
 
@@ -235,5 +244,4 @@ class QuantregMulti:
         "Clear all large non-necessary attributes to free memory."
         for quantreg in self.all_quantregs.values():
             quantreg._clear_attributes()
-
         gc.collect()

--- a/tests/test_estimator_state_lifecycle.py
+++ b/tests/test_estimator_state_lifecycle.py
@@ -1,5 +1,13 @@
-"""Protect formula, within-array, and observation-weight state boundaries."""
+"""Protect the estimator-state lifecycle boundaries of formula data.
 
+These tests deliberately inspect private state: public numerical behavior is
+covered by the release snapshots and live-R suites, while the representation
+and row-sample seams locked here are not observable from those suites.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
 from dataclasses import FrozenInstanceError
 
 import numpy as np
@@ -8,16 +16,73 @@ import pytest
 
 import pyfixest as pf
 from pyfixest.estimation.FixestMulti_ import FixestMulti
-from pyfixest.estimation.formula.model_matrix import ModelMatrix
+from pyfixest.estimation.formula.model_matrix import ModelMatrix, create_model_matrix
+from pyfixest.estimation.formula.parse import Formula
+from pyfixest.estimation.internals.demean_ import DemeanedData
 from pyfixest.estimation.internals.model_state import (
     GlmWorkingState,
     ObservationWeights,
     WithinLinearData,
 )
+from pyfixest.estimation.quantreg.QuantregMulti import QuantregMulti
+
+INFERENCE_STATE_ATTRIBUTES = (
+    "_vcov_type",
+    "_vcov_type_detail",
+    "_is_clustered",
+    "_clustervar",
+    "_bread",
+    "_ssc",
+    "_df_k",
+    "_df_t",
+    "_vcov",
+    "_lag",
+    "_time_id",
+    "_panel_id",
+    "_cluster_df",
+    "_G",
+    "_se",
+    "_tstat",
+    "_pvalue",
+    "_conf_int",
+)
+
+
+def _inference_snapshot(model) -> dict[str, tuple[bool, object | None]]:
+    return {
+        attribute: (
+            hasattr(model, attribute),
+            deepcopy(getattr(model, attribute)) if hasattr(model, attribute) else None,
+        )
+        for attribute in INFERENCE_STATE_ATTRIBUTES
+    }
+
+
+def _assert_inference_unchanged(
+    model, expected: dict[str, tuple[bool, object | None]]
+) -> None:
+    for attribute, (was_present, value) in expected.items():
+        assert hasattr(model, attribute) is was_present, (
+            f"failed covariance update changed presence of {attribute}"
+        )
+        if not was_present:
+            continue
+        observed = getattr(model, attribute)
+        if isinstance(value, np.ndarray):
+            np.testing.assert_array_equal(
+                observed,
+                value,
+                err_msg=f"failed covariance update changed {attribute}",
+            )
+        elif isinstance(value, pd.DataFrame):
+            pd.testing.assert_frame_equal(observed, value)
+        else:
+            assert observed == value, f"failed covariance update changed {attribute}"
 
 
 @pytest.fixture
 def lifecycle_data() -> pd.DataFrame:
+    """Return a small full-rank weighted FE/IV data set."""
     rng = np.random.default_rng(20260831)
     n_obs = 24
     fixed_effect = np.repeat(["a", "b", "c", "d"], n_obs // 4)
@@ -35,6 +100,7 @@ def lifecycle_data() -> pd.DataFrame:
         + group_effect.to_numpy()
         + rng.normal(scale=0.3, size=n_obs)
     )
+
     return pd.DataFrame(
         {
             "y": response,
@@ -49,11 +115,15 @@ def lifecycle_data() -> pd.DataFrame:
 
 
 @pytest.mark.parametrize(
-    ("weights_type", "expected_n"), [("aweights", 24), ("fweights", 52)]
+    ("weights_type", "expected_n"),
+    [("aweights", 24), ("fweights", 52)],
 )
 def test_feols_keeps_formula_within_and_weight_domains_distinct(
-    lifecycle_data: pd.DataFrame, weights_type: str, expected_n: int
+    lifecycle_data: pd.DataFrame,
+    weights_type: str,
+    expected_n: int,
 ) -> None:
+    """A weighted FE fit retains within arrays and response-scale residuals."""
     fit = pf.feols(
         "y ~ x | fe",
         data=lifecycle_data,
@@ -61,7 +131,9 @@ def test_feols_keeps_formula_within_and_weight_domains_distinct(
         weights_type=weights_type,
         vcov="iid",
     )
+
     assert isinstance(fit._model_matrix, ModelMatrix)
+    assert isinstance(fit._model_matrix.dependent, pd.DataFrame)
     assert isinstance(fit._observation_weights, ObservationWeights)
     assert isinstance(fit._within_data, WithinLinearData)
     assert fit._Y is fit._within_data.response
@@ -69,11 +141,13 @@ def test_feols_keeps_formula_within_and_weight_domains_distinct(
     assert fit._Z is fit._within_data.design
     assert not hasattr(fit, "_Yd")
     assert not hasattr(fit, "_Xd")
+
     weights = lifecycle_data["weight"].to_numpy(dtype=np.float64)
     np.testing.assert_array_equal(fit._observation_weights.values, weights)
     np.testing.assert_array_equal(fit._weights.flatten(), weights)
     assert fit._observation_weights.kind == weights_type
     assert expected_n == fit._N
+
     weighted_group_mean = (lifecycle_data["y"] * lifecycle_data["weight"]).groupby(
         lifecycle_data["fe"]
     ).transform("sum") / lifecycle_data["weight"].groupby(
@@ -81,11 +155,20 @@ def test_feols_keeps_formula_within_and_weight_domains_distinct(
     ).transform("sum")
     expected_y_within = lifecycle_data["y"] - weighted_group_mean
     np.testing.assert_allclose(fit._within_data.response.flatten(), expected_y_within)
+    assert not np.allclose(
+        fit._within_data.response.flatten(),
+        expected_y_within * np.sqrt(weights),
+    )
+
     residuals = fit._within_data.response.flatten() - fit._X @ fit._beta_hat
     np.testing.assert_allclose(fit._u_hat, residuals)
     np.testing.assert_allclose(fit.resid(), residuals)
-    np.testing.assert_allclose(fit._scores, fit._X * (weights * residuals)[:, None])
+    np.testing.assert_allclose(
+        fit._scores,
+        fit._X * (weights * residuals)[:, None],
+    )
     np.testing.assert_allclose(fit._hessian, fit._X.T @ (weights[:, None] * fit._X))
+
     with pytest.raises(FrozenInstanceError):
         fit._within_data.response = fit._within_data.design  # type: ignore[misc]
 
@@ -115,147 +198,209 @@ def test_unweighted_weight_alias_is_materialized_on_access(
     assert fit._weights is not fit._weights
 
 
-def test_quantreg_multi_retains_default_post_estimation_state() -> None:
-    """Default multi-quantile results support prediction and vcov updates."""
-    rng = np.random.default_rng(20260901)
-    x = rng.normal(size=200)
-    data = pd.DataFrame({"y": 1 + 2 * x + rng.normal(size=200), "x": x})
-    with pytest.warns(FutureWarning, match="experimental"):
-        multi = pf.quantreg("y ~ x", data=data, quantile=[0.25, 0.75], vcov="iid")
-        single = pf.quantreg("y ~ x", data=data, quantile=0.25, vcov="hetero")
-
-    multi.vcov("hetero")
-
-    for model in multi.to_list():
-        assert np.isfinite(model.predict()).all()
-        assert np.isfinite(model.se()).all()
-
-    first_quantile = multi.fetch_model(0, print_fml=False)
-    np.testing.assert_allclose(first_quantile.predict(), single.predict())
-    np.testing.assert_allclose(first_quantile.se(), single.se())
-
-
-@pytest.mark.parametrize("fit_kwargs", [{"store_data": False}, {"lean": True}])
-def test_multiple_estimation_respects_storage_options(
+def test_weighted_iv_keeps_each_econometric_role_on_within_scale(
     lifecycle_data: pd.DataFrame,
-    fit_kwargs: dict[str, bool],
 ) -> None:
+    """IV state names response, design, endogenous, and instrument roles."""
     fit = pf.feols(
-        "y ~ sw(x, x2) | fe", data=lifecycle_data, vcov="iid", **fit_kwargs
+        "y ~ x + [endog ~ z] | fe",
+        data=lifecycle_data,
+        weights="weight",
+        weights_type="aweights",
+        vcov="iid",
+    )
+
+    within = fit._within_data
+    assert isinstance(within, WithinLinearData)
+    assert within.instruments is not None
+    assert within.endogenous is not None
+    assert fit._Y is within.response
+    assert fit._X is within.design
+    assert fit._Z is within.instruments
+    assert fit._endogvar is within.endogenous
+    assert not hasattr(fit, "_Yd")
+    assert not hasattr(fit, "_Xd")
+    assert not hasattr(fit, "_Zd")
+    assert not hasattr(fit, "_endogvard")
+
+    weights = lifecycle_data["weight"].to_numpy(dtype=np.float64)
+    weighted_design = weights[:, None] * within.design
+    weighted_response = weights[:, None] * within.response
+    np.testing.assert_allclose(fit._tZX, within.instruments.T @ weighted_design)
+    np.testing.assert_allclose(fit._tZy, within.instruments.T @ weighted_response)
+    np.testing.assert_allclose(
+        fit._scores,
+        within.instruments * (weights * fit._u_hat)[:, None],
+    )
+    np.testing.assert_allclose(fit.resid(), fit._u_hat)
+
+
+def test_formula_data_remains_canonical_after_linear_fit(
+    lifecycle_data: pd.DataFrame,
+) -> None:
+    """Formula roles remain tabular while compatibility aliases are transformed."""
+    fit = pf.feols(
+        "y ~ x + [endog ~ z] | fe",
+        data=lifecycle_data,
+        weights="weight",
+        vcov="iid",
+    )
+
+    model_matrix = fit._model_matrix
+    assert isinstance(model_matrix, ModelMatrix)
+
+    assert isinstance(model_matrix.dependent, pd.DataFrame)
+    assert isinstance(model_matrix.independent, pd.DataFrame)
+    assert isinstance(model_matrix.fixed_effects, pd.DataFrame)
+    assert isinstance(model_matrix.instruments, pd.DataFrame)
+    assert isinstance(model_matrix.weights, pd.DataFrame)
+    assert isinstance(fit._Y, np.ndarray)
+    assert isinstance(fit._X, np.ndarray)
+    assert isinstance(fit._Z, np.ndarray)
+    pd.testing.assert_frame_equal(
+        model_matrix.dependent,
+        lifecycle_data.loc[:, ["y"]],
+    )
+    pd.testing.assert_frame_equal(
+        model_matrix.weights,
+        lifecycle_data.loc[:, ["weight"]],
+    )
+    assert fit._model_spec is model_matrix.model_spec
+
+
+def test_unweighted_effective_n_remains_integer_for_prediction_errors(
+    lifecycle_data: pd.DataFrame,
+) -> None:
+    """An integer physical row count remains usable by prediction allocation."""
+    fit = pf.feols("y ~ x", data=lifecycle_data, vcov="iid")
+
+    assert isinstance(fit._N, int)
+    assert isinstance(fit._observation_weights.n_effective, int)
+    assert fit.predict(se_fit=True).shape == (len(lifecycle_data),)
+
+
+def test_glm_separation_replaces_formula_data_with_filtered_state() -> None:
+    """Canonical GLM formula data describes the post-separation sample."""
+    data = pd.DataFrame(
+        {
+            "y": [0, 0, 0, 1, 2, 3],
+            "fe": ["a", "a", "b", "b", "b", "c"],
+            "x": [-1.0, 0.5, 0.25, 1.0, -0.5, 1.5],
+        }
+    )
+
+    with pytest.warns(
+        UserWarning, match="2 observations removed because of separation"
+    ):
+        fit = pf.fepois(
+            "y ~ x | fe",
+            data=data,
+            vcov="hetero",
+            separation_check=["fe"],
+        )
+
+    model_matrix = fit._model_matrix
+    assert model_matrix.dependent.index.equals(fit._data.index)
+    assert model_matrix.independent.index.equals(fit._data.index)
+    assert model_matrix.fixed_effects is not None
+    assert model_matrix.fixed_effects.index.equals(fit._data.index)
+    # Row 5 is a formula-stage singleton; rows 0 and 1 are separated.
+    assert model_matrix.na_index == frozenset({0, 1, 5})
+    assert len(model_matrix.dependent) == fit._N_rows
+    assert fit.n_separation_na == 2
+
+
+def test_model_matrix_without_rows_returns_filtered_copy(
+    lifecycle_data: pd.DataFrame,
+) -> None:
+    """Estimator-level row filters yield a new ModelMatrix and keep the source."""
+    model_matrix = create_model_matrix(
+        formula=Formula.parse("y ~ x | fe")[0],
+        data=lifecycle_data.copy(),
+        weights="weight",
+    )
+    kept_index = model_matrix.dependent.index.drop([0, 5])
+
+    filtered = model_matrix.without_rows([0, 5])
+
+    assert model_matrix.without_rows([]) is model_matrix
+    assert filtered is not model_matrix
+    assert filtered.na_index == model_matrix.na_index | {0, 5}
+    assert filtered.model_spec is model_matrix.model_spec
+    for role in ("dependent", "independent", "fixed_effects", "weights"):
+        assert getattr(filtered, role).index.equals(kept_index)
+    assert filtered.endogenous is None
+    assert filtered.instruments is None
+    assert filtered.offset is None
+    assert len(model_matrix.dependent) == len(lifecycle_data)
+
+
+def test_multiple_estimation_shares_array_native_demean_cache(
+    lifecycle_data: pd.DataFrame,
+) -> None:
+    """Multiple fits share one ordered array cache without DataFrame round trips."""
+    fit = pf.feols(
+        "y ~ sw(x, x2) | fe",
+        data=lifecycle_data,
+        weights="weight",
+        vcov="iid",
     )
 
     assert isinstance(fit, FixestMulti)
-    assert not hasattr(fit, "_data")
-    assert not hasattr(fit, "_config")
-    assert not hasattr(fit, "_context")
-    assert all(not hasattr(model, "_data") for model in fit.to_list())
+    models = list(fit.all_fitted_models.values())
+    assert len(models) == 2
+
+    demeaned_caches = [model._demean_cache.lookup_demeaned_data for model in models]
+    preconditioner_caches = [
+        model._demean_cache.lookup_preconditioner for model in models
+    ]
+    assert demeaned_caches[0] is demeaned_caches[1]
+    assert preconditioner_caches[0] is preconditioner_caches[1]
+    assert demeaned_caches[0]
+    assert all(isinstance(value, DemeanedData) for value in demeaned_caches[0].values())
+    assert all(isinstance(model._within_data, WithinLinearData) for model in models)
+    assert all(model._Y is model._within_data.response for model in models)
+    assert all(model._X is model._within_data.design for model in models)
 
 
-def test_store_data_false_allows_array_only_vcov_updates(
-    lifecycle_data: pd.DataFrame,
-) -> None:
-    stripped = pf.feols("y ~ x", data=lifecycle_data, vcov="iid", store_data=False)
-    expected = pf.feols("y ~ x", data=lifecycle_data, vcov="HC1")
-
-    stripped.vcov("HC1")
-
-    np.testing.assert_allclose(stripped._vcov, expected._vcov)
-    assert not hasattr(stripped, "_data")
-
-
-def test_lean_vcov_fails_with_storage_guidance(
-    lifecycle_data: pd.DataFrame,
-) -> None:
-    fit = pf.feols("y ~ x", data=lifecycle_data, vcov="iid", lean=True)
-
-    with pytest.raises(RuntimeError, match=r"vcov\(\).*lean=True.*discarded"):
-        fit.vcov("HC1")
-
-
-def test_glm_lean_discards_formula_and_working_state() -> None:
-    data = pd.DataFrame({"y": [0, 1, 0, 1, 1, 0], "x": np.arange(6.0)})
-    fit = pf.feglm("y ~ x", data=data, family="logit", lean=True, vcov="iid")
-
-    discarded = (
-        "_model_matrix",
-        "_observation_weights",
-        "_demean_cache",
-        "_working_state",
-        "_u_hat_response",
-        "_u_hat_working",
-        "_offset",
-    )
-    assert all(not hasattr(fit, attr) for attr in discarded)
-    assert not hasattr(fit, "_irls_weights")
-    assert not hasattr(fit, "_Xbeta")
-    assert np.isfinite(fit.coef()).all()
-
-
-def test_quantreg_lean_discards_solver_arrays() -> None:
-    data = pd.DataFrame({"y": [0.2, 1.1, 1.8, 3.2, 3.9, 5.1], "x": np.arange(6.0)})
-    with pytest.warns(FutureWarning, match="experimental"):
-        fit = pf.quantreg("y ~ x", data=data, lean=True, vcov="iid", maxiter=100)
-
-    solver_arrays = ("_x_final", "_s_final", "_z_final", "_w_final", "_y_final")
-    assert all(not hasattr(fit, attr) for attr in solver_arrays)
-    assert np.isfinite(fit.coef()).all()
-
-
-@pytest.mark.parametrize("method", ["IV_Diag", "IV_weakness_test", "eff_F"])
-def test_lean_iv_rejects_first_stage_diagnostics(
-    lifecycle_data: pd.DataFrame,
-    method: str,
-) -> None:
-    fit = pf.feols(
-        "y ~ x + [endog ~ z] | fe",
-        data=lifecycle_data,
-        vcov="hetero",
-        lean=True,
+def test_feglm_keeps_observation_and_working_weights_distinct() -> None:
+    """The stable observation-weight alias is never replaced by IRLS weights."""
+    rng = np.random.default_rng(8675309)
+    n_obs = 160
+    covariate = rng.normal(size=n_obs)
+    probability = 1 / (1 + np.exp(-(-0.2 + 0.8 * covariate)))
+    observation_weights = np.linspace(0.5, 2.0, n_obs)
+    data = pd.DataFrame(
+        {
+            "y": rng.binomial(1, probability),
+            "x": covariate,
+            "observation_weight": observation_weights,
+        }
     )
 
-    assert not hasattr(fit, "_model_1st_stage")
-    with pytest.raises(RuntimeError, match=rf"{method}\(\).*lean=True"):
-        getattr(fit, method)()
-
-
-def test_iv_first_stage_respects_store_data_false(
-    lifecycle_data: pd.DataFrame,
-) -> None:
-    fit = pf.feols(
-        "y ~ x + [endog ~ z] | fe",
-        data=lifecycle_data,
-        vcov="hetero",
-        store_data=False,
-    )
-
-    first_stage = fit._model_1st_stage
-    assert not hasattr(first_stage, "_data")
-    assert not hasattr(first_stage, "_model_matrix")
-    assert hasattr(first_stage, "_within_data")
-    fit.IV_Diag()
-    assert np.isfinite(fit._eff_F)
-    with pytest.raises(RuntimeError, match=r"first_stage\(\).*store_data=False"):
-        fit.first_stage()
-
-
-def test_iv_effective_f_uses_retained_arrays_without_stored_data(
-    lifecycle_data: pd.DataFrame,
-) -> None:
-    stripped = pf.feols(
-        "y ~ x + [endog ~ z] | fe",
-        data=lifecycle_data,
+    fit = pf.feglm(
+        "y ~ x",
+        data=data,
+        family="logit",
+        weights="observation_weight",
         vcov="iid",
-        store_data=False,
-    )
-    retained = pf.feols(
-        "y ~ x + [endog ~ z] | fe", data=lifecycle_data, vcov="iid"
+        iwls_tol=1e-10,
     )
 
-    stripped.IV_Diag()
-    retained.IV_Diag()
-
-    np.testing.assert_allclose(stripped._eff_F, retained._eff_F)
-    assert not hasattr(stripped._model_1st_stage, "_data")
+    working = fit._working_state
+    assert isinstance(working, GlmWorkingState)
+    np.testing.assert_allclose(fit._weights.flatten(), observation_weights)
+    np.testing.assert_allclose(fit._observation_weights.values, observation_weights)
+    np.testing.assert_allclose(fit._irls_weights, working.working_weights)
+    assert not np.allclose(working.working_weights, observation_weights)
+    assert fit._X is working.design_within
+    assert fit._Y is working.working_response_within
+    np.testing.assert_allclose(fit.resid("response"), working.response_residuals)
+    np.testing.assert_allclose(fit.resid("working"), working.working_residuals)
+    np.testing.assert_allclose(
+        fit._scores,
+        fit._X * (working.working_weights * working.working_residuals)[:, None],
+    )
 
 
 LEAN_REJECTION_CASES = [
@@ -270,11 +415,7 @@ LEAN_REJECTION_CASES = [
         "y ~ x + x2",
         lambda fit: fit.decompose(decomp_var="x", only_coef=True),
     ),
-    (
-        "wildboottest",
-        "y ~ x + x2",
-        lambda fit: fit.wildboottest(param="x", reps=11),
-    ),
+    ("wildboottest", "y ~ x + x2", lambda fit: fit.wildboottest(param="x", reps=11)),
     ("ritest", "y ~ x + x2", lambda fit: fit.ritest(resampvar="x", reps=11)),
     (
         "update",
@@ -295,6 +436,7 @@ def test_lean_results_reject_state_dependent_methods(
     fml: str,
     call,
 ) -> None:
+    """Discarded fit arrays produce a remedy, not an AttributeError."""
     fit = pf.feols(fml, data=lifecycle_data, vcov="iid", lean=True)
 
     with pytest.raises(RuntimeError, match=rf"{method}\(\).*lean=True.*discarded"):
@@ -315,11 +457,7 @@ STORE_DATA_REJECTION_CASES = [
         "y ~ x + x2",
         lambda fit, data: fit.wildboottest(param="x", reps=11),
     ),
-    (
-        "ritest",
-        "y ~ x + x2",
-        lambda fit, data: fit.ritest(resampvar="x", reps=11),
-    ),
+    ("ritest", "y ~ x + x2", lambda fit, data: fit.ritest(resampvar="x", reps=11)),
     (
         "first_stage",
         "y ~ x + [endog ~ z] | fe",
@@ -339,29 +477,21 @@ def test_store_data_false_results_reject_data_dependent_methods(
     fml: str,
     call,
 ) -> None:
+    """Methods that read the estimation sample say how to supply it again."""
     fit = pf.feols(fml, data=lifecycle_data, vcov="iid", store_data=False)
 
     with pytest.raises(RuntimeError, match=rf"{method}\(\).*store_data=False"):
         call(fit, lifecycle_data)
 
 
-def test_lean_results_predict_new_data_without_fixed_effects(
-    lifecycle_data: pd.DataFrame,
-) -> None:
-    lean_fit = pf.feols("y ~ x + x2", data=lifecycle_data, vcov="iid", lean=True)
-    retained_fit = pf.feols("y ~ x + x2", data=lifecycle_data, vcov="iid")
-
-    np.testing.assert_allclose(
-        lean_fit.predict(newdata=lifecycle_data),
-        retained_fit.predict(newdata=lifecycle_data),
-    )
-
-
 def test_lean_glm_rejects_residualize_and_residuals() -> None:
+    """A lean GLM keeps neither its IRLS residuals nor its demeaning caches."""
     data = pd.DataFrame({"y": [0, 1, 0, 1, 1, 0], "x": np.arange(6.0)})
     fit = pf.feglm("y ~ x", data=data, family="logit", vcov="iid", lean=True)
 
-    with pytest.raises(RuntimeError, match=r"resid\(\).*lean=True.*discarded"):
+    with pytest.raises(
+        RuntimeError, match=r"resid\(\).*lean=True.*residual arrays were discarded"
+    ):
         fit.resid("response")
     with pytest.raises(RuntimeError, match=r"residualize\(\).*lean=True.*discarded"):
         fit.residualize(
@@ -374,12 +504,441 @@ def test_lean_glm_rejects_residualize_and_residuals() -> None:
 
 
 def test_lean_quantreg_rejects_objective_value() -> None:
+    """The quantile loss needs residuals that lean storage discarded."""
     data = pd.DataFrame({"y": [0.2, 1.1, 1.8, 3.2, 3.9, 5.1], "x": np.arange(6.0)})
     with pytest.warns(FutureWarning, match="experimental"):
         fit = pf.quantreg("y ~ x", data=data, lean=True, vcov="iid", maxiter=100)
 
     with pytest.raises(RuntimeError, match=r"objective_value\(\).*lean=True"):
         _ = fit.objective_value
+
+
+@pytest.mark.parametrize("method", ["IV_Diag", "IV_weakness_test", "eff_F"])
+def test_lean_iv_rejects_first_stage_diagnostics(
+    lifecycle_data: pd.DataFrame,
+    method: str,
+) -> None:
+    """First-stage diagnostics need the retained first-stage fit."""
+    fit = pf.feols(
+        "y ~ x + [endog ~ z] | fe",
+        data=lifecycle_data,
+        vcov="hetero",
+        lean=True,
+    )
+
+    assert not hasattr(fit, "_model_1st_stage")
+    assert np.isfinite(fit._f_stat_1st_stage)
+    with pytest.raises(RuntimeError, match=rf"{method}\(\).*lean=True"):
+        getattr(fit, method)()
+
+
+@pytest.mark.parametrize("fit_kwargs", [{"store_data": False}, {"lean": True}])
+def test_multiple_estimation_respects_storage_options(
+    lifecycle_data: pd.DataFrame,
+    fit_kwargs: dict[str, bool],
+) -> None:
+    """The result container must not retain data cleared from all child fits."""
+    fit = pf.feols(
+        "y ~ sw(x, x2) | fe",
+        data=lifecycle_data,
+        vcov="iid",
+        **fit_kwargs,
+    )
+
+    assert isinstance(fit, FixestMulti)
+    assert not hasattr(fit, "_data")
+    assert not hasattr(fit, "_config")
+    assert not hasattr(fit, "_context")
+    assert all(not hasattr(model, "_data") for model in fit.to_list())
+
+
+def test_lean_results_predict_new_data_without_fixed_effects(
+    lifecycle_data: pd.DataFrame,
+) -> None:
+    """Lean results keep the formula spec and context needed for prediction."""
+    lean_fit = pf.feols("y ~ x + x2", data=lifecycle_data, vcov="iid", lean=True)
+    retained_fit = pf.feols("y ~ x + x2", data=lifecycle_data, vcov="iid")
+
+    np.testing.assert_allclose(
+        lean_fit.predict(newdata=lifecycle_data),
+        retained_fit.predict(newdata=lifecycle_data),
+    )
+
+
+def test_store_data_false_allows_array_only_vcov_updates(
+    lifecycle_data: pd.DataFrame,
+) -> None:
+    """Array-only covariance updates do not require retained formula data."""
+    stripped = pf.feols("y ~ x", data=lifecycle_data, vcov="iid", store_data=False)
+    expected = pf.feols("y ~ x", data=lifecycle_data, vcov="HC1")
+
+    stripped.vcov("HC1")
+
+    np.testing.assert_allclose(stripped._vcov, expected._vcov)
+    assert not hasattr(stripped, "_data")
+
+
+def test_store_data_false_vcov_uses_explicit_estimation_sample(
+    lifecycle_data: pd.DataFrame,
+) -> None:
+    """Data-dependent covariance updates use the documented data argument."""
+    stripped = pf.feols("y ~ x | fe", data=lifecycle_data, vcov="iid", store_data=False)
+    expected = pf.feols("y ~ x | fe", data=lifecycle_data, vcov={"CRV1": "fe"})
+
+    metadata_before = deepcopy(
+        (
+            stripped._vcov_type,
+            stripped._vcov_type_detail,
+            stripped._is_clustered,
+            stripped._clustervar,
+            stripped._G,
+            stripped._df_k,
+            stripped._df_t,
+        )
+    )
+    arrays_before = {
+        attr: getattr(stripped, attr).copy()
+        for attr in (
+            "_bread",
+            "_ssc",
+            "_vcov",
+            "_se",
+            "_tstat",
+            "_pvalue",
+            "_conf_int",
+        )
+    }
+
+    with pytest.raises(RuntimeError, match=r"store_data=False.*Pass.*data="):
+        stripped.vcov({"CRV1": "fe"})
+
+    assert (
+        stripped._vcov_type,
+        stripped._vcov_type_detail,
+        stripped._is_clustered,
+        stripped._clustervar,
+        stripped._G,
+        stripped._df_k,
+        stripped._df_t,
+    ) == metadata_before
+    for attr, value in arrays_before.items():
+        np.testing.assert_array_equal(getattr(stripped, attr), value)
+
+    stripped.vcov({"CRV1": "fe"}, data=lifecycle_data)
+
+    np.testing.assert_allclose(stripped._vcov, expected._vcov)
+    assert not hasattr(stripped, "_data")
+
+
+def test_failed_vcov_update_preserves_complete_inference_state(
+    lifecycle_data: pd.DataFrame,
+) -> None:
+    """A failure during covariance computation publishes no partial state."""
+    fit = pf.feols("y ~ x | fe", data=lifecycle_data, vcov="iid")
+    inference_before = _inference_snapshot(fit)
+
+    with pytest.raises(KeyError, match="fe"):
+        fit.vcov({"CRV1": "fe"}, data=lifecycle_data.drop(columns="fe"))
+
+    _assert_inference_unchanged(fit, inference_before)
+
+
+def test_failed_inference_finalization_preserves_complete_inference_state(
+    lifecycle_data: pd.DataFrame,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Derived inference is prepared before covariance state is published."""
+    fit = pf.feols("y ~ x | fe", data=lifecycle_data, vcov="iid")
+    inference_before = _inference_snapshot(fit)
+
+    def fail_inference(_self) -> None:
+        raise RuntimeError("inference finalization failed")
+
+    monkeypatch.setattr(type(fit), "get_inference", fail_inference)
+    with pytest.raises(RuntimeError, match="inference finalization failed"):
+        fit.vcov("hetero")
+
+    _assert_inference_unchanged(fit, inference_before)
+
+
+def test_fixest_multi_forwards_explicit_vcov_data(
+    lifecycle_data: pd.DataFrame,
+) -> None:
+    """Multiple-estimation covariance updates forward an explicit sample."""
+    stripped = pf.feols(
+        "y ~ sw(x, x2) | fe",
+        data=lifecycle_data,
+        vcov="iid",
+        store_data=False,
+    )
+    expected = pf.feols(
+        "y ~ sw(x, x2) | fe",
+        data=lifecycle_data,
+        vcov={"CRV1": "fe"},
+    )
+    child_ids = [id(child) for child in stripped.to_list()]
+
+    stripped.vcov({"CRV1": "fe"}, data=lifecycle_data)
+
+    assert [id(child) for child in stripped.to_list()] == child_ids
+    for stripped_model, expected_model in zip(
+        stripped.to_list(), expected.to_list(), strict=True
+    ):
+        np.testing.assert_allclose(stripped_model._vcov, expected_model._vcov)
+        assert not hasattr(stripped_model, "_data")
+
+
+def test_fixest_multi_vcov_is_atomic_after_later_child_failure(
+    lifecycle_data: pd.DataFrame,
+) -> None:
+    """Every child covariance is prepared before any child is updated."""
+    data = lifecycle_data.assign(time=np.arange(len(lifecycle_data)))
+    fit = pf.feols("y ~ sw(x, x2)", data=data, vcov="iid")
+    children = fit.to_list()
+    child_ids = [id(child) for child in children]
+    inference_before = [_inference_snapshot(child) for child in children]
+    children[1]._support_hac_inference = False
+
+    with pytest.raises(NotImplementedError, match="HAC inference is not supported"):
+        fit.vcov("NW", vcov_kwargs={"time_id": "time", "lag": 1})
+
+    assert [id(child) for child in fit.to_list()] == child_ids
+    for child, expected in zip(children, inference_before, strict=True):
+        _assert_inference_unchanged(child, expected)
+
+
+def test_quantreg_multi_vcov_is_atomic_after_later_child_failure(
+    lifecycle_data: pd.DataFrame,
+) -> None:
+    """Quantile-process inference also commits only after all children succeed."""
+    fit = pf.quantreg(
+        "y ~ x",
+        data=lifecycle_data,
+        quantile=[0.25, 0.75],
+        vcov="iid",
+        seed=1324,
+    )
+    children = fit.to_list()
+    quantreg_multi = QuantregMulti.__new__(QuantregMulti)
+    quantreg_multi.all_quantregs = dict(zip((0.25, 0.75), children, strict=True))
+    child_ids = [id(child) for child in children]
+    inference_before = [_inference_snapshot(child) for child in children]
+    children[1]._lean = True
+    children[1]._fit_state_discarded = True
+
+    with pytest.raises(RuntimeError, match=r"vcov\(\).*lean=True"):
+        quantreg_multi.vcov("hetero")
+
+    assert [id(child) for child in quantreg_multi.all_quantregs.values()] == child_ids
+    for child, expected in zip(children, inference_before, strict=True):
+        _assert_inference_unchanged(child, expected)
+
+
+@pytest.mark.parametrize(
+    ("fml", "weights", "weights_type"),
+    [
+        ("y ~ x", None, "aweights"),
+        ("y ~ x | fe", "weight", "aweights"),
+        ("y ~ x | fe", "weight", "fweights"),
+    ],
+)
+def test_gaussian_glm_performance_uses_explicit_response_domains(
+    lifecycle_data: pd.DataFrame,
+    fml: str,
+    weights: str | None,
+    weights_type: str,
+) -> None:
+    """Gaussian performance uses raw totals and unpremultiplied within arrays."""
+    fit = pf.feglm(
+        fml,
+        data=lifecycle_data,
+        family="gaussian",
+        weights=weights,
+        weights_type=weights_type,
+        vcov="iid",
+        iwls_tol=1e-10,
+    )
+
+    fit.get_performance()
+
+    observation_weights = fit._observation_weights.values
+    if observation_weights is None:
+        ssu = np.sum(fit._u_hat**2)
+        response_center = np.mean(fit._response)
+        ssy = np.sum((fit._response - response_center) ** 2)
+    else:
+        ssu = np.sum(observation_weights * fit._u_hat**2)
+        response_center = np.average(fit._response, weights=observation_weights)
+        ssy = np.sum(observation_weights * (fit._response - response_center) ** 2)
+
+    np.testing.assert_allclose(
+        fit._rmse,
+        np.sqrt(ssu / fit._N),
+        err_msg="Gaussian GLM RMSE used the wrong residual domain",
+    )
+    np.testing.assert_allclose(
+        fit._r2,
+        1 - ssu / ssy,
+        err_msg="Gaussian GLM R-squared used the wrong response domain",
+    )
+    if fit._has_fixef:
+        data = lifecycle_data
+        assert observation_weights is not None
+        weighted_response = data["weight"] * data["y"]
+        weighted_group_mean = weighted_response.groupby(data["fe"], observed=True).sum()
+        weighted_group_mean /= data["weight"].groupby(data["fe"], observed=True).sum()
+        response_within = (
+            data["y"].to_numpy() - data["fe"].map(weighted_group_mean).to_numpy()
+        )
+        ssy_within = np.sum(observation_weights * response_within**2)
+        np.testing.assert_allclose(
+            fit._r2_within,
+            1 - ssu / ssy_within,
+            err_msg="Gaussian GLM within R-squared used the wrong within response",
+        )
+
+
+def test_lean_gaussian_glm_rejects_performance_update(
+    lifecycle_data: pd.DataFrame,
+) -> None:
+    fit = pf.feglm(
+        "y ~ x | fe",
+        data=lifecycle_data,
+        family="gaussian",
+        vcov="iid",
+        lean=True,
+    )
+
+    with pytest.raises(RuntimeError, match=r"get_performance\(\).*lean=True"):
+        fit.get_performance()
+
+
+def test_fixest_multi_vcov_preflights_different_estimation_samples(
+    lifecycle_data: pd.DataFrame,
+) -> None:
+    """A common-sample mismatch leaves every child model unchanged."""
+    data = lifecycle_data.copy()
+    data.loc[data.index[:3], "x2"] = np.nan
+    fit = pf.feols(
+        "y ~ sw(x, x2) | fe",
+        data=data,
+        vcov="iid",
+        store_data=False,
+    )
+    children = fit.to_list()
+    inference_before = [
+        (child._vcov_type_detail, child._vcov.copy()) for child in children
+    ]
+
+    with pytest.raises(
+        ValueError,
+        match=r"common, already-filtered estimation sample.*\[21, 24\], received 24",
+    ):
+        fit.vcov({"CRV1": "fe"}, data=data)
+
+    for child, (vcov_type_detail, vcov) in zip(children, inference_before, strict=True):
+        assert child._vcov_type_detail == vcov_type_detail
+        np.testing.assert_array_equal(child._vcov, vcov)
+
+
+def test_fixest_multi_vcov_rejects_equal_size_split_samples(
+    lifecycle_data: pd.DataFrame,
+) -> None:
+    """Equal row counts do not make distinct split samples interchangeable."""
+    data = lifecycle_data.assign(sample=np.tile(["left", "right"], 12))
+    fit = pf.feols(
+        "y ~ x | fe",
+        data=data,
+        split="sample",
+        vcov="iid",
+        store_data=False,
+    )
+    children = fit.to_list()
+    inference_before = [
+        (child._vcov_type_detail, child._vcov.copy()) for child in children
+    ]
+    left_sample = data.loc[data["sample"] == "left"]
+
+    with pytest.raises(
+        ValueError,
+        match=r"child models use different estimation samples.*Fetch each child",
+    ):
+        fit.vcov({"CRV1": "fe"}, data=left_sample)
+
+    for child, (vcov_type_detail, vcov) in zip(children, inference_before, strict=True):
+        assert child._vcov_type_detail == vcov_type_detail
+        np.testing.assert_array_equal(child._vcov, vcov)
+
+
+def test_fixest_multi_vcov_rejects_equal_size_distinct_na_masks(
+    lifecycle_data: pd.DataFrame,
+) -> None:
+    """Equal-sized formula expansions must retain the same source rows."""
+    data = lifecycle_data.copy()
+    data.loc[data.index[0], "x"] = np.nan
+    data.loc[data.index[1], "x2"] = np.nan
+    fit = pf.feols(
+        "y ~ sw(x, x2) | fe",
+        data=data,
+        vcov="iid",
+        store_data=False,
+    )
+    children = fit.to_list()
+    inference_before = [
+        (child._vcov_type_detail, child._vcov.copy()) for child in children
+    ]
+
+    with pytest.raises(
+        ValueError,
+        match=r"child models use different estimation samples.*Fetch each child",
+    ):
+        fit.vcov({"CRV1": "fe"}, data=data.drop(index=0))
+
+    for child, (vcov_type_detail, vcov) in zip(children, inference_before, strict=True):
+        assert child._vcov_type_detail == vcov_type_detail
+        np.testing.assert_array_equal(child._vcov, vcov)
+
+
+def test_vcov_rejects_unfiltered_explicit_data(
+    lifecycle_data: pd.DataFrame,
+) -> None:
+    """An explicit covariance sample must align with the fitted row arrays."""
+    data = lifecycle_data.copy()
+    data.loc[data.index[0], "y"] = np.nan
+    estimation_sample = data.dropna(subset=["y", "x", "fe"])
+    stripped = pf.feols(
+        "y ~ x | fe",
+        data=data,
+        vcov="iid",
+        store_data=False,
+    )
+    expected = pf.feols(
+        "y ~ x | fe",
+        data=estimation_sample,
+        vcov={"CRV1": "fe"},
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"already-filtered estimation sample.*original estimation order; "
+            r"expected 23 rows, received 24"
+        ),
+    ):
+        stripped.vcov({"CRV1": "fe"}, data=data)
+
+    stripped.vcov({"CRV1": "fe"}, data=estimation_sample)
+    np.testing.assert_allclose(stripped._vcov, expected._vcov)
+
+
+def test_lean_vcov_fails_with_storage_guidance(
+    lifecycle_data: pd.DataFrame,
+) -> None:
+    """Lean results explain that covariance inputs were intentionally discarded."""
+    fit = pf.feols("y ~ x", data=lifecycle_data, vcov="iid", lean=True)
+
+    with pytest.raises(RuntimeError, match=r"vcov\(\).*lean=True.*discarded"):
+        fit.vcov("HC1")
 
 
 STORAGE_STATE_FIELDS = frozenset(
@@ -415,6 +974,7 @@ def test_storage_options_delete_expected_state(
     fit_kwargs: dict[str, bool],
     missing_fields: frozenset[str],
 ) -> None:
+    """Distinguish data-only cleanup from lean fit-state cleanup."""
     fit = pf.feols("y ~ x | fe", data=lifecycle_data, vcov="iid", **fit_kwargs)
 
     observed_fields = frozenset(
@@ -422,12 +982,102 @@ def test_storage_options_delete_expected_state(
     )
     assert observed_fields == STORAGE_STATE_FIELDS - missing_fields
     if fit_kwargs.get("lean"):
+        # Retained so that predict(newdata=...) keeps working without fixed
+        # effects, and so that row alignment stays checkable.
         for field in ("_model_spec", "_context", "_na_index"):
             assert hasattr(fit, field)
     assert np.isfinite(fit.coef()).all()
 
 
+def test_iv_first_stage_respects_store_data_false(
+    lifecycle_data: pd.DataFrame,
+) -> None:
+    """A retained IV first stage must not hide a copy of stripped input data."""
+    fit = pf.feols(
+        "y ~ x + [endog ~ z] | fe",
+        data=lifecycle_data,
+        vcov="hetero",
+        store_data=False,
+    )
+
+    first_stage = fit._model_1st_stage
+    assert not hasattr(first_stage, "_data")
+    assert not hasattr(first_stage, "_model_matrix")
+    assert hasattr(first_stage, "_within_data")
+    assert hasattr(first_stage, "_X")
+    fit.IV_Diag()
+    assert np.isfinite(fit._eff_F)
+    with pytest.raises(RuntimeError, match=r"first_stage\(\).*store_data=False"):
+        fit.first_stage()
+
+
+def test_iv_effective_f_uses_retained_arrays_without_stored_data(
+    lifecycle_data: pd.DataFrame,
+) -> None:
+    """IID first-stage diagnostics need retained arrays, not formula data."""
+    stripped = pf.feols(
+        "y ~ x + [endog ~ z] | fe",
+        data=lifecycle_data,
+        vcov="iid",
+        store_data=False,
+    )
+    retained = pf.feols(
+        "y ~ x + [endog ~ z] | fe",
+        data=lifecycle_data,
+        vcov="iid",
+    )
+
+    stripped.IV_Diag()
+    retained.IV_Diag()
+
+    np.testing.assert_allclose(stripped._eff_F, retained._eff_F)
+    assert not hasattr(stripped._model_1st_stage, "_data")
+
+
+def test_lean_iv_discards_retained_first_stage_arrays(
+    lifecycle_data: pd.DataFrame,
+) -> None:
+    """Lean IV results retain diagnostics but no nested fitted-data graph."""
+    fit = pf.feols(
+        "y ~ x + [endog ~ z] | fe",
+        data=lifecycle_data,
+        vcov="hetero",
+        lean=True,
+    )
+
+    assert not hasattr(fit, "_model_1st_stage")
+    assert not hasattr(fit, "_X_hat")
+    assert not hasattr(fit, "_v_hat")
+    # `_endogvar` is a read-only view on the discarded within data.
+    assert not hasattr(fit, "_endogvar")
+    assert np.isfinite(fit._f_stat_1st_stage)
+    with pytest.raises(RuntimeError, match=r"IV_Diag\(\).*lean=True"):
+        fit.IV_Diag()
+
+
+def test_glm_lean_discards_formula_and_working_state() -> None:
+    """Lean GLM results discard both canonical input and working fit arrays."""
+    data = pd.DataFrame({"y": [0, 1, 0, 1, 1, 0], "x": np.arange(6.0)})
+    fit = pf.feglm("y ~ x", data=data, family="logit", lean=True, vcov="iid")
+
+    discarded = (
+        "_model_matrix",
+        "_observation_weights",
+        "_demean_cache",
+        "_working_state",
+        "_u_hat_response",
+        "_u_hat_working",
+        "_offset",
+    )
+    assert all(not hasattr(fit, attr) for attr in discarded)
+    # The IRLS aliases are read-only views on the discarded working state.
+    assert not hasattr(fit, "_irls_weights")
+    assert not hasattr(fit, "_Xbeta")
+    assert np.isfinite(fit.coef()).all()
+
+
 def test_poisson_lean_discards_offset_and_null_fit_arrays() -> None:
+    """Lean Poisson results do not retain offset or null-fit row arrays."""
     data = pd.DataFrame(
         {
             "y": [0, 1, 2, 1, 3, 2],
@@ -442,131 +1092,32 @@ def test_poisson_lean_discards_offset_and_null_fit_arrays() -> None:
     assert np.isfinite(fit.coef()).all()
 
 
-def test_feglm_keeps_observation_and_working_weights_distinct() -> None:
-    rng = np.random.default_rng(8675309)
-    n_obs = 160
-    covariate = rng.normal(size=n_obs)
-    probability = 1 / (1 + np.exp(-(-0.2 + 0.8 * covariate)))
-    observation_weights = np.linspace(0.5, 2.0, n_obs)
-    data = pd.DataFrame(
-        {
-            "y": rng.binomial(1, probability),
-            "x": covariate,
-            "observation_weight": observation_weights,
-        }
-    )
-    fit = pf.feglm(
-        "y ~ x",
-        data=data,
-        family="logit",
-        weights="observation_weight",
-        vcov="iid",
-        iwls_tol=1e-10,
-    )
-    working = fit._working_state
-    assert isinstance(working, GlmWorkingState)
-    np.testing.assert_allclose(fit._weights.flatten(), observation_weights)
-    np.testing.assert_allclose(fit._irls_weights, working.working_weights)
-    assert not np.allclose(working.working_weights, observation_weights)
-    assert fit._X is working.design_within
-    assert fit._Y is working.working_response_within
+def test_quantreg_lean_discards_solver_arrays() -> None:
+    """Lean quantile results do not retain row-sized solver outputs."""
+    data = pd.DataFrame({"y": [0.2, 1.1, 1.8, 3.2, 3.9, 5.1], "x": np.arange(6.0)})
+    with pytest.warns(FutureWarning, match="experimental"):
+        fit = pf.quantreg("y ~ x", data=data, lean=True, vcov="iid", maxiter=100)
+
+    solver_arrays = ("_x_final", "_s_final", "_z_final", "_w_final", "_y_final")
+    assert all(not hasattr(fit, attr) for attr in solver_arrays)
+    assert np.isfinite(fit.coef()).all()
 
 
-def test_weighted_iv_keeps_each_econometric_role_on_within_scale(
-    lifecycle_data: pd.DataFrame,
-) -> None:
-    fit = pf.feols(
-        "y ~ x + [endog ~ z] | fe",
-        data=lifecycle_data,
-        weights="weight",
-        weights_type="aweights",
-        vcov="iid",
-    )
-    within = fit._within_data
-    assert isinstance(within, WithinLinearData)
-    assert within.instruments is not None
-    assert within.endogenous is not None
-    assert fit._Y is within.response
-    assert fit._X is within.design
-    assert fit._Z is within.instruments
-    assert fit._endogvar is within.endogenous
-    weights = lifecycle_data["weight"].to_numpy(dtype=np.float64)
-    np.testing.assert_allclose(
-        fit._tZX, within.instruments.T @ (weights[:, None] * within.design)
-    )
-    np.testing.assert_allclose(
-        fit._scores, within.instruments * (weights * fit._u_hat)[:, None]
-    )
+def test_quantreg_multi_retains_default_post_estimation_state() -> None:
+    """Default multi-quantile results support prediction and vcov updates."""
+    rng = np.random.default_rng(20260901)
+    x = rng.normal(size=200)
+    data = pd.DataFrame({"y": 1 + 2 * x + rng.normal(size=200), "x": x})
+    with pytest.warns(FutureWarning, match="experimental"):
+        multi = pf.quantreg("y ~ x", data=data, quantile=[0.25, 0.75], vcov="iid")
+        single = pf.quantreg("y ~ x", data=data, quantile=0.25, vcov="hetero")
 
+    multi.vcov("hetero")
 
-def test_formula_data_remains_canonical_after_linear_fit(
-    lifecycle_data: pd.DataFrame,
-) -> None:
-    fit = pf.feols(
-        "y ~ x + [endog ~ z] | fe", data=lifecycle_data, weights="weight", vcov="iid"
-    )
-    model_matrix = fit._model_matrix
-    assert isinstance(model_matrix, ModelMatrix)
-    assert isinstance(model_matrix.dependent, pd.DataFrame)
-    assert isinstance(model_matrix.independent, pd.DataFrame)
-    assert isinstance(model_matrix.instruments, pd.DataFrame)
-    assert isinstance(fit._Y, np.ndarray)
-    assert isinstance(fit._X, np.ndarray)
-    assert isinstance(fit._Z, np.ndarray)
+    for model in multi.to_list():
+        assert np.isfinite(model.predict()).all()
+        assert np.isfinite(model.se()).all()
 
-
-def test_unweighted_effective_n_remains_integer_for_prediction_errors(
-    lifecycle_data: pd.DataFrame,
-) -> None:
-    fit = pf.feols("y ~ x", data=lifecycle_data, vcov="iid")
-    assert isinstance(fit._N, int)
-    assert isinstance(fit._observation_weights.n_effective, int)
-    assert fit.predict(se_fit=True).shape == (len(lifecycle_data),)
-
-
-@pytest.mark.parametrize(
-    ("fml", "weights", "weights_type"),
-    [
-        ("y ~ x", None, "aweights"),
-        ("y ~ x | fe", "weight", "aweights"),
-        ("y ~ x | fe", "weight", "fweights"),
-    ],
-)
-def test_gaussian_glm_performance_uses_explicit_response_domains(
-    lifecycle_data: pd.DataFrame,
-    fml: str,
-    weights: str | None,
-    weights_type: str,
-) -> None:
-    fit = pf.feglm(
-        fml,
-        data=lifecycle_data,
-        family="gaussian",
-        weights=weights,
-        weights_type=weights_type,
-        vcov="iid",
-        iwls_tol=1e-10,
-    )
-    fit.get_performance()
-    response = lifecycle_data["y"].to_numpy()
-    observation_weights = fit._observation_weights.values
-    residuals = fit._u_hat_response
-    if observation_weights is None:
-        ssu = np.sum(residuals**2)
-        ssy = np.sum((response - np.mean(response)) ** 2)
-    else:
-        ssu = np.sum(observation_weights * residuals**2)
-        center = np.average(response, weights=observation_weights)
-        ssy = np.sum(observation_weights * (response - center) ** 2)
-    np.testing.assert_allclose(fit._rmse, np.sqrt(ssu / fit._N))
-    np.testing.assert_allclose(fit._r2, 1 - ssu / ssy)
-    if fit._has_fixef:
-        assert observation_weights is not None
-        weighted_y = lifecycle_data["weight"] * lifecycle_data["y"]
-        group_mean = weighted_y.groupby(lifecycle_data["fe"]).transform("sum")
-        group_mean /= (
-            lifecycle_data["weight"].groupby(lifecycle_data["fe"]).transform("sum")
-        )
-        response_within = response - group_mean.to_numpy()
-        ssy_within = np.sum(observation_weights * response_within**2)
-        np.testing.assert_allclose(fit._r2_within, 1 - ssu / ssy_within)
+    first_quantile = multi.fetch_model(0, print_fml=False)
+    np.testing.assert_allclose(first_quantile.predict(), single.predict())
+    np.testing.assert_allclose(first_quantile.se(), single.se())


### PR DESCRIPTION
## Summary

Post-fit covariance updates compute the covariance metadata and derived inference on a detached candidate and publish only on success, so a failed update leaves every inference field exactly as it was. Explicit estimation data is routed through `vcov(data=...)` with a row-count check, `FixestMulti.vcov()` accepts one common explicit sample, and both multi-model containers prepare every child before publishing any child while preserving the child objects.

Review question: **Does success update everything, while failure changes nothing?**

Layer 9 of 9 replacing #1500/#1501; depends on #1524 (`fix/faithful-estimation-refits`). The tracked-file contents of this head are identical to the reviewed head `03f284bf` of #1501. The original PRs stay open until the replacement stack is validated.

## Verification

- Release contract: 1,355 passed.
- Transaction and container tests: `tests/test_estimator_state_lifecycle.py`, `tests/test_errors.py`, `tests/test_wls_types.py` 165 passed, 1 skipped.
- Fast live R suite (`test-r-fixest-fast`): 22 passed.
- Broad Python baseline (`test-py` selection, run locally on this head): 7,741 passed, 1,878 skipped, 276 failed. All 276 failures are the known `torch_mps` demeaner-backend failures on this Mac (pre-existing on `master`; not reproduced in CI); there are no other failures.
- Changed-file Ruff and mypy passed; whole-tree `ruff-check`/`ruff-format` hooks passed at this tip.

The quantile-convergence failure seen in CI on the original stack is not addressed here and is reported separately; no tolerances were changed.

The repository's Python/R/docs workflow only runs for PRs targeting `master`; this stacked PR receives pre-commit CI only. Human review is required; no automatic merge.
