### PR TITLE
Refactor Wald test into post-estimation module

### DIFF
--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -51,6 +51,9 @@ fit3 = pf.feols("Y ~ X1 + X2 | f1", data = df)
 
 ### Inference Types
 
+- Wald-test computation now lives in the standalone post-estimation module,
+  while fitted-model methods retain the existing public interface.
+
 - `tidy()`, `confint()`, and `summary()` gain an `inference_type` argument.
   `confint()` takes `"regular"` (pointwise, the default), `"simult"`
   (simultaneous / joint intervals), or `"savi"`; `tidy()` and `summary()` take

--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -51,9 +51,6 @@ fit3 = pf.feols("Y ~ X1 + X2 | f1", data = df)
 
 ### Inference Types
 
-- Wald-test computation now lives in the standalone post-estimation module,
-  while fitted-model methods retain the existing public interface.
-
 - `tidy()`, `confint()`, and `summary()` gain an `inference_type` argument.
   `confint()` takes `"regular"` (pointwise, the default), `"simult"`
   (simultaneous / joint intervals), or `"savi"`; `tidy()` and `summary()` take

--- a/pyfixest/estimation/models/feols_.py
+++ b/pyfixest/estimation/models/feols_.py
@@ -11,7 +11,7 @@ import numpy as np
 import pandas as pd
 from scipy.sparse import csc_matrix, diags, spmatrix
 from scipy.sparse.linalg import lsqr
-from scipy.stats import chi2, f, t
+from scipy.stats import t
 
 from pyfixest.core.demean import Preconditioner
 from pyfixest.demeaners import AnyDemeaner, LsmrDemeaner, MapDemeaner
@@ -61,7 +61,7 @@ from pyfixest.estimation.post_estimation.fixed_effects import (
     warn_on_unseen_fixed_effect_levels,
 )
 from pyfixest.estimation.post_estimation.prediction import _compute_prediction_error
-from pyfixest.estimation.post_estimation.wald import _wald_statistic
+from pyfixest.estimation.post_estimation.wald import wald_test
 from pyfixest.utils.dev_utils import (
     DataFrameType,
     _narwhals_to_pandas,
@@ -248,6 +248,12 @@ class Feols(ResultAccessorMixin):
     iplot_aggregate: Callable[..., Any]
 
     """
+
+    _dfd: Any
+    _dfn: Any
+    _wald_statistic: Any
+    _f_statistic: Any
+    _p_value: Any
 
     def __init__(
         self,
@@ -992,49 +998,7 @@ class Feols(ResultAccessorMixin):
         print(f"Python p_stat: {p_stat}")
         ```
         """
-        k_fe = np.sum(self._k_fe.values) if self._has_fixef else 0
-
-        # If R is None, default to the identity matrix
-        R = np.eye(self._k) if R is None else np.atleast_2d(np.asarray(R, dtype=float))
-
-        W, self._dfn = _wald_statistic(
-            beta_hat=self._beta_hat,
-            vcov=self._vcov,
-            R=R,
-            q=q,
-        )
-
-        if self._is_clustered:
-            self._dfd = np.min(np.array(self._G)) - 1
-        else:
-            self._dfd = self._N - self._k - k_fe
-
-        self._wald_statistic = W
-
-        # The F distribution is only used for the joint test that all
-        # coefficients are zero (R identity, q zero).
-        if distribution == "F" and (
-            not np.array_equal(R, np.eye(self._k)) or (q is not None and np.any(q))
-        ):
-            warnings.warn(
-                "Distribution changed to chi2, as R is not an identity matrix and q is not a zero vector."
-            )
-            distribution = "chi2"
-
-        if distribution == "F":
-            self._f_statistic = W / self._dfn
-            self._p_value = 1 - f.cdf(self._f_statistic, dfn=self._dfn, dfd=self._dfd)
-            res = pd.Series({"statistic": self._f_statistic, "pvalue": self._p_value})
-        elif distribution == "chi2":
-            self._f_statistic = W / self._dfn
-            self._p_value = chi2.sf(self._wald_statistic, self._dfn)
-            res = pd.Series(
-                {"statistic": self._wald_statistic, "pvalue": self._p_value}
-            )
-        else:
-            raise ValueError("Distribution must be F or chi2")
-
-        return res
+        return wald_test(self, R=R, q=q, distribution=distribution)
 
     def wildboottest(
         self,

--- a/pyfixest/estimation/models/feols_.py
+++ b/pyfixest/estimation/models/feols_.py
@@ -998,7 +998,26 @@ class Feols(ResultAccessorMixin):
         print(f"Python p_stat: {p_stat}")
         ```
         """
-        return wald_test(self, R=R, q=q, distribution=distribution)
+        k_fe = np.sum(np.asarray(self._k_fe.values)) if self._has_fixef else 0
+        df_denom = (
+            np.min(np.array(self._G)) - 1
+            if self._is_clustered
+            else self._N - self._k - k_fe
+        )
+        result = wald_test(
+            beta_hat=self._beta_hat,
+            vcov=self._vcov,
+            df_denom=df_denom,
+            R=R,
+            q=q,
+            distribution=distribution,
+        )
+        self._dfd = df_denom
+        self._dfn = result.dfn
+        self._wald_statistic = result.wald_statistic
+        self._f_statistic = result.f_statistic
+        self._p_value = result.pvalue
+        return pd.Series({"statistic": result.statistic, "pvalue": result.pvalue})
 
     def wildboottest(
         self,

--- a/pyfixest/estimation/post_estimation/wald.py
+++ b/pyfixest/estimation/post_estimation/wald.py
@@ -2,7 +2,66 @@
 
 from __future__ import annotations
 
+import warnings
+from typing import TYPE_CHECKING
+
 import numpy as np
+import pandas as pd
+from scipy.stats import chi2, f
+
+if TYPE_CHECKING:
+    from pyfixest.estimation.models.feols_ import Feols
+
+
+def wald_test(
+    model: Feols,
+    R: np.ndarray | None = None,
+    q: float | np.ndarray | None = None,
+    distribution: str = "F",
+) -> pd.Series:
+    """Conduct a Wald test for a fitted model."""
+    k_fe = np.sum(np.asarray(model._k_fe.values)) if model._has_fixef else 0
+
+    R = np.eye(model._k) if R is None else np.atleast_2d(np.asarray(R, dtype=float))
+
+    W, model._dfn = _wald_statistic(
+        beta_hat=model._beta_hat,
+        vcov=model._vcov,
+        R=R,
+        q=q,
+    )
+
+    if model._is_clustered:
+        model._dfd = np.min(np.array(model._G)) - 1
+    else:
+        model._dfd = model._N - model._k - k_fe
+
+    model._wald_statistic = W
+
+    # The F distribution is only used for the joint test that all
+    # coefficients are zero (R identity, q zero).
+    if distribution == "F" and (
+        not np.array_equal(R, np.eye(model._k)) or (q is not None and np.any(q))
+    ):
+        warnings.warn(
+            "Distribution changed to chi2, as R is not an identity matrix and q is not a zero vector."
+        )
+        distribution = "chi2"
+
+    if distribution == "F":
+        model._f_statistic = W / model._dfn
+        model._p_value = 1 - f.cdf(
+            model._f_statistic,
+            dfn=model._dfn,
+            dfd=model._dfd,
+        )
+        return pd.Series({"statistic": model._f_statistic, "pvalue": model._p_value})
+    if distribution == "chi2":
+        model._f_statistic = W / model._dfn
+        model._p_value = chi2.sf(model._wald_statistic, model._dfn)
+        return pd.Series({"statistic": model._wald_statistic, "pvalue": model._p_value})
+
+    raise ValueError("Distribution must be F or chi2")
 
 
 def _normalize_q(q: float | np.ndarray | None, n_restrictions: int) -> np.ndarray:

--- a/pyfixest/estimation/post_estimation/wald.py
+++ b/pyfixest/estimation/post_estimation/wald.py
@@ -3,45 +3,71 @@
 from __future__ import annotations
 
 import warnings
-from typing import TYPE_CHECKING
+from dataclasses import dataclass
 
 import numpy as np
-import pandas as pd
 from scipy.stats import chi2, f
 
-if TYPE_CHECKING:
-    from pyfixest.estimation.models.feols_ import Feols
+
+@dataclass(frozen=True)
+class _WaldStatistics:
+    """Scalar statistics consumed by the fitted-model compatibility wrapper."""
+
+    statistic: float
+    pvalue: float
+    wald_statistic: float
+    f_statistic: float
+    dfn: int
 
 
 def wald_test(
-    model: Feols,
+    *,
+    beta_hat: np.ndarray,
+    vcov: np.ndarray,
+    df_denom: float,
     R: np.ndarray | None = None,
     q: float | np.ndarray | None = None,
     distribution: str = "F",
-) -> pd.Series:
-    """Conduct a Wald test for a fitted model."""
-    k_fe = np.sum(np.asarray(model._k_fe.values)) if model._has_fixef else 0
+) -> _WaldStatistics:
+    """Compute Wald statistics from fitted coefficients and covariance.
 
-    R = np.eye(model._k) if R is None else np.atleast_2d(np.asarray(R, dtype=float))
+    Parameters
+    ----------
+    beta_hat : np.ndarray
+        Coefficient vector of shape (k,).
+    vcov : np.ndarray
+        Coefficient covariance matrix of shape (k, k).
+    df_denom : float
+        Denominator degrees of freedom for the F distribution, determined by
+        the caller from the fitted sample, fixed effects, and clustering.
+    R : np.ndarray, optional
+        Restriction matrix of shape (m, k). Defaults to the identity matrix.
+    q : float or np.ndarray, optional
+        Null values for the restrictions. Defaults to zero.
+    distribution : str, default "F"
+        Reference distribution, either "F" or "chi2". Nonidentity restrictions
+        or nonzero null values switch "F" to "chi2" with a warning.
 
-    W, model._dfn = _wald_statistic(
-        beta_hat=model._beta_hat,
-        vcov=model._vcov,
+    Returns
+    -------
+    _WaldStatistics
+        Scalar test statistics, p-value, and numerator degrees of freedom.
+    """
+    k = len(beta_hat)
+
+    R = np.eye(k) if R is None else np.atleast_2d(np.asarray(R, dtype=float))
+
+    W, dfn = _wald_statistic(
+        beta_hat=beta_hat,
+        vcov=vcov,
         R=R,
         q=q,
     )
 
-    if model._is_clustered:
-        model._dfd = np.min(np.array(model._G)) - 1
-    else:
-        model._dfd = model._N - model._k - k_fe
-
-    model._wald_statistic = W
-
     # The F distribution is only used for the joint test that all
     # coefficients are zero (R identity, q zero).
     if distribution == "F" and (
-        not np.array_equal(R, np.eye(model._k)) or (q is not None and np.any(q))
+        not np.array_equal(R, np.eye(k)) or (q is not None and np.any(q))
     ):
         warnings.warn(
             "Distribution changed to chi2, as R is not an identity matrix and q is not a zero vector."
@@ -49,19 +75,27 @@ def wald_test(
         distribution = "chi2"
 
     if distribution == "F":
-        model._f_statistic = W / model._dfn
-        model._p_value = 1 - f.cdf(
-            model._f_statistic,
-            dfn=model._dfn,
-            dfd=model._dfd,
+        f_statistic = W / dfn
+        pvalue = 1 - f.cdf(
+            f_statistic,
+            dfn=dfn,
+            dfd=df_denom,
         )
-        return pd.Series({"statistic": model._f_statistic, "pvalue": model._p_value})
-    if distribution == "chi2":
-        model._f_statistic = W / model._dfn
-        model._p_value = chi2.sf(model._wald_statistic, model._dfn)
-        return pd.Series({"statistic": model._wald_statistic, "pvalue": model._p_value})
+        statistic = f_statistic
+    elif distribution == "chi2":
+        f_statistic = W / dfn
+        pvalue = chi2.sf(W, dfn)
+        statistic = W
+    else:
+        raise ValueError("Distribution must be F or chi2")
 
-    raise ValueError("Distribution must be F or chi2")
+    return _WaldStatistics(
+        statistic=statistic,
+        pvalue=pvalue,
+        wald_statistic=W,
+        f_statistic=f_statistic,
+        dfn=dfn,
+    )
 
 
 def _normalize_q(q: float | np.ndarray | None, n_restrictions: int) -> np.ndarray:

--- a/tests/test_wald.py
+++ b/tests/test_wald.py
@@ -1,0 +1,33 @@
+import numpy as np
+import pandas as pd
+
+import pyfixest as pf
+from pyfixest.estimation.post_estimation.wald import wald_test
+
+
+def test_standalone_wald_test_matches_model_method():
+    data = pf.get_data()
+    method_fit = pf.feols("Y ~ X1 + X2 | f1", data)
+    standalone_fit = pf.feols("Y ~ X1 + X2 | f1", data)
+    restriction = np.array([[1.0, -1.0]])
+
+    expected = method_fit.wald_test(R=restriction, q=0.5, distribution="chi2")
+    actual = wald_test(
+        standalone_fit,
+        R=restriction,
+        q=0.5,
+        distribution="chi2",
+    )
+
+    pd.testing.assert_series_equal(actual, expected)
+    assert standalone_fit._wald_statistic == expected["statistic"]
+
+
+def test_standalone_wald_test_preserves_default_f_statistics():
+    fit = pf.feols("Y ~ X1 + X2", pf.get_data())
+
+    result = wald_test(fit)
+
+    assert result["statistic"] == fit._f_statistic
+    assert result["pvalue"] == fit._p_value
+    assert fit._wald_statistic == fit._f_statistic * fit._dfn

--- a/tests/test_wald.py
+++ b/tests/test_wald.py
@@ -1,5 +1,9 @@
+from __future__ import annotations
+
 import numpy as np
 import pandas as pd
+import pytest
+from scipy.stats import chi2
 
 import pyfixest as pf
 from pyfixest.estimation.post_estimation.wald import wald_test
@@ -8,26 +12,76 @@ from pyfixest.estimation.post_estimation.wald import wald_test
 def test_standalone_wald_test_matches_model_method():
     data = pf.get_data()
     method_fit = pf.feols("Y ~ X1 + X2 | f1", data)
-    standalone_fit = pf.feols("Y ~ X1 + X2 | f1", data)
     restriction = np.array([[1.0, -1.0]])
 
     expected = method_fit.wald_test(R=restriction, q=0.5, distribution="chi2")
     actual = wald_test(
-        standalone_fit,
+        beta_hat=method_fit.coef().to_numpy(),
+        vcov=method_fit._vcov,
+        df_denom=method_fit._dfd,
         R=restriction,
         q=0.5,
         distribution="chi2",
     )
 
-    pd.testing.assert_series_equal(actual, expected)
-    assert standalone_fit._wald_statistic == expected["statistic"]
+    pd.testing.assert_series_equal(
+        pd.Series({"statistic": actual.statistic, "pvalue": actual.pvalue}), expected
+    )
+    assert actual.wald_statistic == method_fit._wald_statistic
+    assert actual.f_statistic == method_fit._f_statistic
+    assert actual.dfn == method_fit._dfn == 1
 
 
-def test_standalone_wald_test_preserves_default_f_statistics():
-    fit = pf.feols("Y ~ X1 + X2", pf.get_data())
+@pytest.mark.parametrize(
+    "fml, options",
+    [
+        ("Y ~ X1 + X2", {}),
+        ("Y ~ X1 + X2 | f1", {"weights": "weights", "store_data": False}),
+        (
+            "Y ~ X1 + X2 | f1",
+            {"weights": "fweights", "weights_type": "fweights", "lean": True},
+        ),
+        ("Y ~ X1 + X2 | f1", {"vcov": {"CRV1": "f1+f2"}}),
+    ],
+)
+def test_standalone_wald_test_preserves_default_f_statistics(fml, options):
+    data = pf.get_data()
+    data["fweights"] = np.arange(len(data)) % 3 + 1
+    fit = pf.feols(fml, data, **options)
+    k_fe = np.sum(fit._k_fe.values) if fit._has_fixef else 0
+    df_denom = min(fit._G) - 1 if fit._is_clustered else fit._N - fit._k - k_fe
 
-    result = wald_test(fit)
+    result = wald_test(
+        beta_hat=fit.coef().to_numpy(), vcov=fit._vcov, df_denom=df_denom
+    )
 
-    assert result["statistic"] == fit._f_statistic
-    assert result["pvalue"] == fit._p_value
+    assert result.statistic == fit._f_statistic
+    assert result.pvalue == fit._p_value
+    assert result.dfn == fit._dfn
+    assert df_denom == fit._dfd
     assert fit._wald_statistic == fit._f_statistic * fit._dfn
+    pd.testing.assert_series_equal(
+        fit.wald_test(),
+        pd.Series({"statistic": result.statistic, "pvalue": result.pvalue}),
+    )
+
+
+def test_standalone_wald_test_with_readonly_numerical_inputs():
+    beta_hat = np.array([1.0, 2.0])
+    vcov = np.diag([2.0, 4.0])
+    restriction = np.array([[1.0, -1.0]])
+    null = np.array([0.5])
+    for array in (beta_hat, vcov, restriction, null):
+        array.flags.writeable = False
+
+    with pytest.warns(UserWarning, match="Distribution changed to chi2"):
+        result = wald_test(
+            beta_hat=beta_hat, vcov=vcov, df_denom=20, R=restriction, q=null
+        )
+
+    # The restriction has estimate -1, null 0.5, and variance 2 + 4.
+    expected_statistic = 1.5**2 / 6
+    assert result.statistic == result.wald_statistic == expected_statistic
+    assert result.f_statistic == expected_statistic
+    assert result.dfn == 1
+    assert result.pvalue == chi2.sf(expected_statistic, 1)


### PR DESCRIPTION
## Summary

Moves Wald computation into the standalone post-estimation module. The calculation receives coefficient and covariance arrays, denominator degrees of freedom, and restriction/distribution inputs instead of a fitted model. `Feols.wald_test()` remains the compatibility wrapper: its Series return value, legacy result attributes, internal consumers, and numerical results are preserved.

A private calculation record carries statistics back to the wrapper. This extraction can merge independently of the 1.0 component migration; the public `WaldTestResult`, removal of custom-test model mutation, and consumer migration remain in the later refactoring PR.

Closes #861.

## Verification

Code checks ran on `5e2ab2ff9eee4476603c97a8c48124550eeb807d`. Final head `2a1416e8cb6bdd5e9ed9ba942ead0a3b588beb09` has identical Python code/tests; its only follow-up removes the internal-refactor changelog entry, resolving the conflict with master. `git diff --check` and a nonmutating merge check passed on the final head.

- Passed: release contract, 1,355 cases (13.55s).
- Passed: focused Wald/error tests, 9 cases (2.19s).
- Passed: live-R Wald comparisons, 14 cases; 3 pre-existing skips (33.22s).
- Passed: IV first-stage checks, 60 cases; 6 pre-existing skips (28.34s).
- Passed: changed-file Ruff format/check and mypy (1.64s combined); `git diff --check` (under 1s).
- Deferred to CI on final head `2a1416e8`: Python baseline, full canonical R suites, and docs build. Targeted checks passed; repeating full suites locally adds no diagnostic value for this extraction. These remain required merge evidence.

<details>
<summary>Commands</summary>

```sh
pixi run -e py312 test-release-contract
pixi run -e py312 pytest tests/test_wald.py tests/test_errors.py -k wald --no-cov -q
pixi run -e py312-r pytest tests/test_wald_test.py tests/test_vs_fixest.py -k wald --no-cov -q
pixi run -e py312-r pytest tests/test_iv.py -k '1st_stage_iv or Fstat_ivDiag' --no-cov -q
for hook in ruff-format ruff-check mypy; do
  pixi run -e lint prek run "$hook" --files pyfixest/estimation/models/feols_.py pyfixest/estimation/post_estimation/wald.py tests/test_wald.py || exit
done
git diff --check
```

The IV test command initially failed collection in `py312` because that environment lacks rpy2; the R-enabled command above passed. Ruff formatting was applied and all quality checks then passed. The existing skipped reference cases remain skipped; they are not counted as evidence.

</details>
