### PR TITLE
feat(glm): support CRV3 and randomization inference through family-aware refits

### DIFF
--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -69,8 +69,9 @@ fit3 = pf.feols("Y ~ X1 + X2 | f1", data = df)
   Sherman-Morrison calculation, and no longer leaves the fitted result in a
   partially updated state.
 - `Feols.update()` now rejects weighted models, IV models, and non-OLS models.
-- Non-Poisson GLMs now reject `CRV3` instead of silently refitting through the
-  Poisson jackknife. Poisson `CRV3` remains supported.
+- `CRV3` cluster-jackknife inference is now available for every GLM family.
+  Leave-one-cluster-out refits replay the fitted family and its IRLS
+  configuration through `feglm()`, rather than through the Poisson API.
 - CRV3 jackknife and slow randomization-inference refits now replay the
   original estimation options (weights, small-sample corrections, singleton
   handling, solver, demeaner, offset, IRLS tolerances).

--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -75,8 +75,10 @@ fit3 = pf.feols("Y ~ X1 + X2 | f1", data = df)
 - CRV3 jackknife and slow randomization-inference refits now replay the
   original estimation options (weights, small-sample corrections, singleton
   handling, solver, demeaner, offset, IRLS tolerances).
-- Randomization inference now rejects non-OLS and non-Poisson results instead
-  of reinterpreting GLM working state or quantile solver output as OLS arrays.
+- Randomization inference now supports GLMs through the slow algorithm, which
+  replays the fitted estimator's own public entry point. It rejects quantile
+  regression results instead of reinterpreting their solver output as OLS
+  arrays.
 - The wild cluster bootstrap now rejects non-OLS results.
 - `decompose()` now rejects models that were not estimated via `feols()`.
 - `tidy()`, `confint()`, and `summary()` gain an `inference_type` argument.

--- a/docs/developer/architecture.md
+++ b/docs/developer/architecture.md
@@ -262,7 +262,9 @@ Weighted `fixef()` stores `_sumFE` in response units, and `IV_Diag()` leaves
 the outer model's covariance label untouched.
 
 CRV3 jackknife and slow randomization-inference refits replay the original
-estimation options. A prebuilt LSMR preconditioner is the sole exception: its
+estimation options through the estimator's own public entry point, so a GLM
+refits through `feglm()` with its family rather than through a linear or
+Poisson approximation of it. A prebuilt LSMR preconditioner is the sole exception: its
 factorization belongs to one fixed-effect design, so refits keep its variant
 but rebuild it for the changed row set.
 

--- a/pyfixest/estimation/models/feglm_.py
+++ b/pyfixest/estimation/models/feglm_.py
@@ -113,9 +113,7 @@ class Feglm(Feols):
         self.separation_check = separation_check
         self._accelerate = accelerate
 
-        # The inherited slow jackknife refits with the linear/Poisson APIs and
-        # cannot yet preserve a generic GLM family's estimation contract.
-        self._support_crv3_inference = False
+        self._support_crv3_inference = True
         self._support_iid_inference = True
         self._support_hac_inference = True
         self._supports_wildboottest = False
@@ -422,6 +420,29 @@ class Feglm(Feols):
             )
         else:
             return yhat
+
+    def _estimation_refit_kwargs(self) -> dict[str, Any]:
+        """Return the full GLM estimation contract for data-changing refits."""
+        kwargs = super()._estimation_refit_kwargs()
+        kwargs.update(
+            {
+                "offset": self._offset_name,
+                "iwls_tol": self.tol,
+                "iwls_maxiter": self.maxiter,
+                "separation_check": (
+                    None
+                    if self.separation_check is None
+                    else list(self.separation_check)
+                ),
+            }
+        )
+        return kwargs
+
+    def _refit_entry_point(self) -> tuple[str, dict[str, Any]]:
+        """Replay GLMs through `feglm()`, which needs the family and IRLS setup."""
+        _, kwargs = super()._refit_entry_point()
+        kwargs.update({"family": self._family.name, "accelerate": self._accelerate})
+        return "feglm", kwargs
 
     def _validate_response(self) -> None:
         """Validate the prepared response against the family's constraints."""

--- a/pyfixest/estimation/models/feols_.py
+++ b/pyfixest/estimation/models/feols_.py
@@ -1068,15 +1068,25 @@ class Feols(ResultAccessorMixin):
             "context": self._context,
         }
 
+    def _refit_entry_point(self) -> tuple[str, dict[str, Any]]:
+        """Return the public estimation function that replays this estimator.
+
+        The name and the options are consumed by every path that re-estimates
+        the model on modified data: the CRV3 cluster jackknife and slow
+        randomization inference.
+        """
+        return "feols", self._estimation_refit_kwargs()
+
     def _crv3_refit(self, data: pd.DataFrame) -> Feols:
-        """Replay OLS for one leave-one-cluster-out sample."""
+        """Replay the estimator for one leave-one-cluster-out sample."""
+        entry_point, refit_kwargs = self._refit_entry_point()
         # lazy loading to avoid circular import
         fixest_module = import_module("pyfixest.estimation")
-        return fixest_module.feols(
+        return getattr(fixest_module, entry_point)(
             fml=self._fml,
             data=data,
             vcov="iid",
-            **self._estimation_refit_kwargs(),
+            **refit_kwargs,
         )
 
     def _vcov_crv3_slow(

--- a/pyfixest/estimation/models/feols_.py
+++ b/pyfixest/estimation/models/feols_.py
@@ -332,6 +332,7 @@ class Feols(ResultAccessorMixin):
         self._context = capture_context(context)
 
         self._support_crv3_inference = True
+        self._supports_ritest = True
         self._support_hac_inference = True
         self._supports_wildboottest = True
         self._supports_cluster_causal_variance = True
@@ -2297,9 +2298,10 @@ class Feols(ResultAccessorMixin):
             raise NotImplementedError(
                 "Randomization Inference is not supported for IV models."
             )
-        if self._method not in {"feols", "fepois"}:
+        if not self._supports_ritest:
             raise NotImplementedError(
-                "Randomization Inference is only supported for OLS and Poisson models."
+                "Randomization Inference is not supported for models of type "
+                f"'{self._method}'."
             )
 
         # check that resampvar in _coefnames
@@ -2355,7 +2357,9 @@ class Feols(ResultAccessorMixin):
                 """
             )
 
-        if choose_algorithm == "slow" or self._method == "fepois":
+        # The fast algorithm demeans and solves OLS arrays; every other
+        # estimator replays its own public API through the slow path.
+        if choose_algorithm == "slow" or self._method != "feols":
             vcov_input: str | dict[str, str]
             if cluster is not None:
                 vcov_input = {"CRV1": cluster}
@@ -2372,6 +2376,7 @@ class Feols(ResultAccessorMixin):
             if type == "randomization-c":
                 vcov_input = "iid"
 
+            ritest_entry_point, ritest_refit_kwargs = self._refit_entry_point()
             ri_stats = _get_ritest_stats_slow(
                 data=self._data,
                 resampvar=resampvar_,
@@ -2381,8 +2386,8 @@ class Feols(ResultAccessorMixin):
                 vcov=vcov_input,
                 type=type,
                 rng=rng,
-                model=self._method,
-                refit_kwargs=self._estimation_refit_kwargs(),
+                model=ritest_entry_point,
+                refit_kwargs=ritest_refit_kwargs,
             )
 
         else:

--- a/pyfixest/estimation/models/fepois_.py
+++ b/pyfixest/estimation/models/fepois_.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from importlib import import_module
 from typing import Any
 
 import numpy as np
@@ -206,33 +205,9 @@ class Fepois(Feglm):
             y_orig, self._Y_hat_response, poisson_summary_weights
         )
 
-    def _estimation_refit_kwargs(self) -> dict[str, Any]:
-        """Return the full Poisson estimation contract for data-changing refits."""
-        kwargs = super()._estimation_refit_kwargs()
-        kwargs.update(
-            {
-                "offset": self._offset_name,
-                "iwls_tol": self.tol,
-                "iwls_maxiter": self.maxiter,
-                "separation_check": (
-                    None
-                    if self.separation_check is None
-                    else list(self.separation_check)
-                ),
-            }
-        )
-        return kwargs
-
-    def _crv3_refit(self, data: pd.DataFrame) -> Fepois:
-        """Replay Poisson estimation for one leave-one-cluster-out sample."""
-        # lazy loading to avoid circular import
-        fixest_module = import_module("pyfixest.estimation")
-        return fixest_module.fepois(
-            fml=self._fml,
-            data=data,
-            vcov="iid",
-            **self._estimation_refit_kwargs(),
-        )
+    def _refit_entry_point(self) -> tuple[str, dict[str, Any]]:
+        """Replay Poisson fits through `fepois()`, its own public entry point."""
+        return "fepois", self._estimation_refit_kwargs()
 
     def _clear_attributes(self) -> None:
         """Apply GLM cleanup and discard the Poisson null-fit array when lean."""

--- a/pyfixest/estimation/post_estimation/ritest.py
+++ b/pyfixest/estimation/post_estimation/ritest.py
@@ -58,7 +58,8 @@ def _get_ritest_stats_slow(
     reps : int
         The number of repetitions.
     model : str
-        The model to estimate. Must be one of 'feols' or 'fepois'.
+        The public estimation function to replay, for example 'feols',
+        'fepois', or 'feglm'.
     rng : np.random.Generator
         The random number generator.
     vcov : str or dict[str, str]

--- a/pyfixest/estimation/quantreg/quantreg_.py
+++ b/pyfixest/estimation/quantreg/quantreg_.py
@@ -115,6 +115,7 @@ class Quantreg(Feols):
 
         self._supports_wildboottest = False
         self._support_crv3_inference = False
+        self._supports_ritest = False
         self._supports_cluster_causal_variance = False
         self._support_hac_inference = False
         self._support_decomposition = False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,7 @@ def pytest_addoption(parser):
 # Skip test files that require rpy2 when it is not installed (e.g. non-R pixi env).
 _rpy2_test_files = [
     "test_did.py",
+    "test_glm_crv3_vs_r.py",
     "test_hac_vs_fixest.py",
     "test_i.py",
     "test_iv.py",

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -609,24 +609,18 @@ def test_ritest_error(data):
         fit.plot_ritest()
 
 
-@pytest.mark.parametrize("estimator", ["feglm", "quantreg"])
-def test_ritest_rejects_non_ols_working_domains(estimator):
-    """RI must not interpret GLM or quantile arrays as OLS solver inputs."""
+def test_ritest_rejects_quantile_working_domains():
+    """RI must not interpret quantile solver output as OLS solver inputs."""
     data = pd.DataFrame(
         {
             "y": [0, 1, 0, 1, 1, 0, 1, 0],
             "x": np.linspace(-1.0, 1.0, 8),
         }
     )
-    if estimator == "feglm":
-        fit = pf.feglm("y ~ x", data=data, family="logit")
-    else:
-        with pytest.warns(FutureWarning, match="experimental"):
-            fit = pf.quantreg("y ~ x", data=data, maxiter=100)
+    with pytest.warns(FutureWarning, match="experimental"):
+        fit = pf.quantreg("y ~ x", data=data, maxiter=100)
 
-    with pytest.raises(
-        NotImplementedError, match=r"only supported for OLS and Poisson"
-    ):
+    with pytest.raises(NotImplementedError, match=r"not supported for models of type"):
         fit.ritest(resampvar="x", reps=1)
 
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1044,22 +1044,6 @@ def test_prediction_errors_glm():
             model.predict(se_fit=True)
 
 
-@pytest.mark.parametrize("family", ["gaussian", "logit", "probit"])
-def test_glm_crv3_is_explicitly_unsupported(family):
-    """Do not silently run Poisson jackknife refits for other GLM families."""
-    data = pf.get_data(model="Fepois").dropna().copy()
-    if family in ("logit", "probit"):
-        data["Y"] = (data["Y"] > data["Y"].median()).astype(int)
-
-    with pytest.raises(VcovTypeNotSupportedError, match="CRV3 inference"):
-        pf.feglm(
-            "Y ~ X1",
-            data=data,
-            family=family,
-            vcov={"CRV3": "f1"},
-        )
-
-
 def test_poisson_crv3_remains_supported():
     """Keep the longstanding Poisson jackknife path across both public APIs."""
     data = pf.get_data(model="Fepois").dropna().iloc[:120].copy()

--- a/tests/test_glm_crv3_vs_r.py
+++ b/tests/test_glm_crv3_vs_r.py
@@ -109,7 +109,9 @@ def test_glm_crv3_matches_r_cluster_jackknife(glm_cluster_data, family, depvar):
         atol=atol,
     )
 
-    centered = beta_jack[fit._coefnames].to_numpy() - beta_full[fit._coefnames].to_numpy()
+    centered = (
+        beta_jack[fit._coefnames].to_numpy() - beta_full[fit._coefnames].to_numpy()
+    )
     expected_vcov = centered.T @ centered
 
     np.testing.assert_allclose(fit._vcov, expected_vcov, rtol=rtol, atol=atol)

--- a/tests/test_glm_crv3_vs_r.py
+++ b/tests/test_glm_crv3_vs_r.py
@@ -1,0 +1,140 @@
+"""
+Compare the GLM cluster jackknife (`CRV3`) against leave-one-cluster-out refits in R.
+
+The reference is base R's `stats::glm()`: each leave-one-cluster-out fit is
+estimated in R, and the resulting coefficients are aggregated with the cluster
+jackknife of Mackinnon, Nielsen & Webb (2022), which centers at the full-sample
+estimate. Small-sample corrections are switched off on both sides so that the
+comparison is about the jackknife itself.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+import rpy2.robjects as ro
+from rpy2.robjects import pandas2ri
+from rpy2.robjects.packages import importr
+
+import pyfixest as pf
+
+stats = importr("stats")
+
+# IRLS in pyfixest and R's glm converge to the same coefficients but stop on
+# different criteria, so allow a small relative difference in the refits.
+rtol = 1e-06
+atol = 1e-08
+
+R_FAMILY = {
+    "logit": 'binomial(link = "logit")',
+    "probit": 'binomial(link = "probit")',
+    "poisson": 'poisson(link = "log")',
+    "gaussian": 'gaussian(link = "identity")',
+}
+
+
+@pytest.fixture
+def glm_cluster_data():
+    "Return clustered data with a binary, a count, and a continuous response."
+    rng = np.random.default_rng(20260906)
+    N = 300
+    G = 10
+    data = pd.DataFrame(
+        {
+            "x1": rng.normal(size=N),
+            "x2": rng.normal(size=N),
+            "cluster": np.arange(N) % G,
+        }
+    )
+    eta = 0.5 * data["x1"] - 0.3 * data["x2"]
+    data["y_bin"] = rng.binomial(1, 1 / (1 + np.exp(-eta)))
+    data["y_count"] = rng.poisson(np.exp(eta))
+    data["y_cont"] = eta + rng.normal(size=N)
+    return data
+
+
+def _r_cluster_jackknife(data: pd.DataFrame, fml: str, family: str) -> pd.DataFrame:
+    "Fit `fml` in R once per left-out cluster and return the coefficients."
+    with (ro.default_converter + pandas2ri.converter).context():
+        ro.globalenv["df"] = data
+    ro.r(f"""
+        fit_all <- glm({fml}, family = {R_FAMILY[family]}, data = df)
+        clusters <- sort(unique(df$cluster))
+        beta_jack <- t(sapply(clusters, function(g) {{
+            coef(glm({fml}, family = {R_FAMILY[family]}, data = df[df$cluster != g, ]))
+        }}))
+        coef_names <- names(coef(fit_all))
+        beta_full <- coef(fit_all)
+    """)
+    with (ro.default_converter + pandas2ri.converter).context():
+        beta_jack = np.asarray(ro.globalenv["beta_jack"])
+        beta_full = np.asarray(ro.globalenv["beta_full"])
+        coef_names = list(ro.globalenv["coef_names"])
+
+    return pd.DataFrame(beta_jack, columns=coef_names), pd.Series(
+        beta_full, index=coef_names
+    )
+
+
+@pytest.mark.against_r_core
+@pytest.mark.parametrize(
+    "family, depvar",
+    [
+        ("logit", "y_bin"),
+        ("probit", "y_bin"),
+        ("poisson", "y_count"),
+        ("gaussian", "y_cont"),
+    ],
+)
+def test_glm_crv3_matches_r_cluster_jackknife(glm_cluster_data, family, depvar):
+    "The GLM jackknife equals the same aggregation over R's leave-one-out fits."
+    fml = f"{depvar} ~ x1 + x2"
+    fit = pf.feglm(
+        fml,
+        data=glm_cluster_data,
+        family=family,
+        vcov={"CRV3": "cluster"},
+        ssc=pf.ssc(k_adj=False, G_adj=False),
+    )
+
+    beta_jack, beta_full = _r_cluster_jackknife(glm_cluster_data, fml, family)
+    beta_jack = beta_jack.rename(columns={"(Intercept)": "Intercept"})
+    beta_full = beta_full.rename({"(Intercept)": "Intercept"})
+
+    # coefficients first: a jackknife of the wrong estimator would still be
+    # positive definite, so compare the refit inputs, not only their spread.
+    np.testing.assert_allclose(
+        fit.coef().to_numpy(),
+        beta_full[fit._coefnames].to_numpy(),
+        rtol=rtol,
+        atol=atol,
+    )
+
+    centered = beta_jack[fit._coefnames].to_numpy() - beta_full[fit._coefnames].to_numpy()
+    expected_vcov = centered.T @ centered
+
+    np.testing.assert_allclose(fit._vcov, expected_vcov, rtol=rtol, atol=atol)
+
+
+@pytest.mark.against_r_core
+def test_glm_crv3_small_sample_correction(glm_cluster_data):
+    "The default correction rescales the jackknife by G / (G - 1) and N / (N - k)."
+    fml = "y_bin ~ x1 + x2"
+    unadjusted = pf.feglm(
+        fml,
+        data=glm_cluster_data,
+        family="logit",
+        vcov={"CRV3": "cluster"},
+        ssc=pf.ssc(k_adj=False, G_adj=False),
+    )
+    adjusted = pf.feglm(
+        fml, data=glm_cluster_data, family="logit", vcov={"CRV3": "cluster"}
+    )
+
+    G = glm_cluster_data["cluster"].nunique()
+    N = len(glm_cluster_data)
+    k = len(adjusted._coefnames)
+    factor = (G / (G - 1)) * ((N - 1) / (N - k))
+
+    np.testing.assert_allclose(
+        adjusted._vcov, factor * unadjusted._vcov, rtol=1e-10, atol=1e-12
+    )

--- a/tests/test_ritest.py
+++ b/tests/test_ritest.py
@@ -235,6 +235,112 @@ def test_fepois_slow_ritest_replays_estimation_contract(monkeypatch):
         assert kwargs["context"]["shift"] is shift
 
 
+def test_feglm_ritest_matches_ols_for_gaussian_family():
+    """A Gaussian GLM is OLS, so both slow RI paths must resample identically."""
+    data = pf.get_data().dropna()
+
+    ols = pf.feols("Y ~ X1 + X2", data=data)
+    ols.ritest(
+        resampvar="X1",
+        reps=25,
+        rng=np.random.default_rng(9),
+        choose_algorithm="slow",
+        store_ritest_statistics=True,
+    )
+
+    glm = pf.feglm("Y ~ X1 + X2", data=data, family="gaussian")
+    glm.ritest(
+        resampvar="X1",
+        reps=25,
+        rng=np.random.default_rng(9),
+        store_ritest_statistics=True,
+    )
+
+    np.testing.assert_allclose(
+        ols._ritest_statistics, glm._ritest_statistics, rtol=1e-08, atol=1e-08
+    )
+    assert ols._ritest_pvalue == glm._ritest_pvalue
+
+
+def test_feglm_ritest_is_centered_under_the_null():
+    """Resampling a treatment with no effect must center the statistics at zero."""
+    rng = np.random.default_rng(4242)
+    N = 400
+    data = pd.DataFrame(
+        {
+            "x": rng.normal(size=N),
+            "d": rng.binomial(1, 0.5, size=N),
+        }
+    )
+    data["y"] = rng.binomial(1, 1 / (1 + np.exp(-0.4 * data["x"])))
+
+    fit = pf.feglm("y ~ d + x", data=data, family="logit")
+    fit.ritest(
+        resampvar="d",
+        reps=100,
+        rng=np.random.default_rng(11),
+        store_ritest_statistics=True,
+    )
+
+    ri_stats = fit._ritest_statistics[1:]
+    standard_error = np.std(ri_stats, ddof=1) / np.sqrt(len(ri_stats))
+    assert abs(np.mean(ri_stats)) < 3 * standard_error
+    assert 0.0 <= fit._ritest_pvalue <= 1.0
+
+
+def test_feglm_slow_ritest_replays_estimation_contract(monkeypatch):
+    """GLM refits must keep the family and the IRLS configuration of the fit."""
+    import pyfixest.estimation as estimation
+
+    rng = np.random.default_rng(20260906)
+    N = 120
+    data = pd.DataFrame(
+        {
+            "x1": rng.normal(size=N),
+            "treatment": rng.binomial(1, 0.5, size=N),
+            "f1": np.arange(N) % 4,
+        }
+    )
+    data["y"] = rng.binomial(1, 0.5, size=N)
+
+    ssc_config = pf.ssc(k_adj=False, G_adj=False)
+    real_feglm = estimation.feglm
+    fit = real_feglm(
+        "y ~ treatment + x1 | f1",
+        data=data,
+        family="logit",
+        ssc=ssc_config,
+        iwls_tol=1e-10,
+        iwls_maxiter=100,
+        separation_check=[],
+        accelerate=False,
+    )
+    refit_calls = []
+
+    def recording_feglm(fml, *, data, vcov, **kwargs):
+        refit_calls.append((fml, vcov, kwargs))
+        return real_feglm(fml=fml, data=data, vcov=vcov, **kwargs)
+
+    monkeypatch.setattr(estimation, "feglm", recording_feglm)
+    fit.ritest(
+        resampvar="treatment",
+        reps=3,
+        choose_algorithm="slow",
+        rng=np.random.default_rng(1234),
+    )
+
+    assert len(refit_calls) == 3
+    for fml, vcov, kwargs in refit_calls:
+        assert fml == "y ~ treatment_resampled + x1 | f1"
+        assert vcov == "iid"
+        assert kwargs["family"] == "logit"
+        assert kwargs["ssc"] == ssc_config
+        assert kwargs["iwls_tol"] == 1e-10
+        assert kwargs["iwls_maxiter"] == 100
+        assert kwargs["separation_check"] == []
+        assert kwargs["accelerate"] is False
+
+
 @pytest.fixture
 def data_r_vs_t():
     return pf.get_data(N=5000, seed=2999)


### PR DESCRIPTION
## Summary

The `CRV3` cluster jackknife and slow randomization inference now work for every GLM family. Both paths re-estimate the model on modified data, and both now do it through the fitted estimator's own public entry point: a GLM replays through `feglm()` with its family, IRLS tolerances, separation check, offset, and acceleration setting, while OLS and Poisson keep `feols()` and `fepois()`. That single seam (`_refit_entry_point`) replaces the per-class `_crv3_refit` overrides and the method-name checks in `ritest()`.

Layer 10 on top of #1525 (`fix/atomic-covariance-state`). It lifts two restrictions that layer 1 (#1516) introduced deliberately, now that the refit-replay machinery from #1524 makes family-faithful refits possible. Quantile regression still rejects both paths, and the fast randomization algorithm stays OLS-only because it demeans and solves linear arrays directly.

## Verification

- New external reference: `tests/test_glm_crv3_vs_r.py` compares the GLM jackknife against leave-one-cluster-out fits from R's `stats::glm()` for logit, probit, poisson, and gaussian (5 passed), plus the small-sample-correction factor.
- GLM randomization inference: a Gaussian GLM reproduces the OLS statistics exactly under the same seed, the logit statistics are centered under the null, and a contract test asserts the family and IRLS options reach every refit.
- Release contract: 1,355 passed. Fast live R (`test-r-fixest-fast`): 22 passed. `tests/test_errors.py`, `tests/test_ritest.py`, `tests/test_ses.py`, `tests/test_glm_crv3_vs_r.py`: 387 passed, 1 skipped.
- Whole-tree `ruff-check` / `ruff-format` hooks pass. mypy was not run: no mypy binary is available in the local pixi environments, and the hook does not install here; CI covers it.

Stacked PRs receive pre-commit CI only. Human review required; no automatic merge.
