### PR TITLE
feat(report): add editable Word export to etable

### DIFF
--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -17,6 +17,11 @@ fit3 = pf.feols("Y ~ X1 + X2 | f1", data = df)
 
 ## PyFixest 0.70.0 (In Development)
 
+### Word Regression Tables
+
+`pf.etable()` now supports `type="docx"` to return or save editable Word tables,
+with per-call formatting through `docx_style`.
+
 ### Fitted Model State
 
 Fitted models now expose their formula, observation-weight, within-transformed, and GLM working-state components for inspection, replacing the old private array aliases.

--- a/docs/tutorials/regression-tables.qmd
+++ b/docs/tutorials/regression-tables.qmd
@@ -101,7 +101,7 @@ pf.etable([fit1, fit2, fit3, fit4, fit5, fit6], signif_code=[0.01, 0.05, 0.1], d
 
 
 ## Other output formats
-By default, `pf.etable()` returns a GT object (see [the Great Tables package](https://posit-dev.github.io/great-tables/articles/intro.html)), but you can also opt to dataframe, markdown, or latex output via the `type` argument.
+By default, `pf.etable()` returns a GT object (see [the Great Tables package](https://posit-dev.github.io/great-tables/articles/intro.html)), but you can also opt to DataFrame, Markdown, LaTeX, Typst, or Word output via the `type` argument.
 
 
 ```{python}
@@ -168,6 +168,40 @@ if run:
 display(FileLink("latexdocs/SampleTableDoc.pdf"))
 ```
 
+
+### Word output
+
+Use `type="docx"` to create an editable Word table, including multi-level
+headers, coefficients and standard errors, fixed effects, statistics, and notes.
+The result is a `python-docx.Document` object. Pass `file_name` to save it
+directly; the same document is returned for further editing.
+
+```{python}
+#| output: false
+document = pf.etable(
+    [fit1, fit2, fit3, fit4, fit5, fit6],
+    type="docx",
+    file_name="regression_results.docx",
+    model_heads=["Baseline", "Two-way FE", "Interaction"] * 2,
+    coef_fmt="b:.3f*\n(se:.3f)",
+    docx_style={
+        "font_name": "Times New Roman",
+        "font_size_pt": 11,
+        "notes_font_size_pt": 9,
+        "first_col_width": "4cm",
+    },
+)
+```
+
+`docx_style` accepts the options in
+`maketables.MTable.DEFAULT_DOCX_STYLE` in the
+[maketables package](https://py-econometrics.github.io/maketables/).
+These settings apply only to Word output. Use `labels`, `felabels`, and `notes`
+to supply text in your preferred language. Font availability and pagination
+depend on the application opening the document.
+
+To add more content before saving, omit `file_name`, edit the returned document
+using python-docx, and call `document.save("regression_results.docx")`.
 
 ## Rename variables
 You can also rename variables if you want to have a more readable output. Just pass a dictionary to the `labels` argument. Note that interaction terms will also be relabeled using the specified labels for the interacted variables (if you want to manually relabel an interaction term differently, add it to the dictionary).

--- a/pyfixest/report/summarize.py
+++ b/pyfixest/report/summarize.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import maketables
 import numpy as np
 import pandas as pd
@@ -8,6 +12,10 @@ from pyfixest.estimation.models.feiv_ import Feiv
 from pyfixest.estimation.models.feols_ import Feols
 from pyfixest.estimation.models.fepois_ import Fepois
 from pyfixest.report.utils import _post_processing_input_checks
+
+if TYPE_CHECKING:
+    from docx.document import Document
+    from great_tables import GT
 
 ModelInputType = FixestMulti | Feols | Fepois | Feiv | list[Feols | Fepois | Feiv]
 
@@ -52,14 +60,15 @@ def etable(
     model_heads: list | None = None,
     head_order: str | None = "dh",
     file_name: str | None = None,
+    docx_style: dict[str, object] | None = None,
     **kwargs,
-) -> pd.DataFrame | str | None:
+) -> pd.DataFrame | GT | Document | str | None:
     r"""
     Generate a table summarizing the results of multiple regression models.
 
     This function uses the maketables package internally to create publication-ready
     regression tables. It supports various output formats including HTML (via Great Tables),
-    markdown, and LaTeX.
+    markdown, LaTeX, Typst, and Word.
 
     Parameters
     ----------
@@ -68,7 +77,8 @@ def etable(
         The models to be summarized in the table.
     type : str, optional
         Type of output. Either "df" for pandas DataFrame, "md" for markdown,
-        "gt" for great_tables, "tex" for LaTeX table, or "typst" for Typst table. Default is "gt".
+        "gt" for great_tables, "tex" for LaTeX, "typst" for Typst, or "docx"
+        for an editable Word document. Default is "gt".
     signif_code : list, optional
         Significance levels for the stars. Default is None, which sets
         [0.001, 0.01, 0.05]. Note that stars are only rendered if `coef_fmt`
@@ -154,17 +164,26 @@ def etable(
         When head_order is "d", only the dependent variable and model numbers are displayed
         and with "" only the model numbers. Default is "dh".
     file_name: str, optional
-        The name/path of the file to save the LaTeX table to. Default is None.
+        The name/path of the file to save when type is "gt", "tex", "typst",
+        or "docx". Default is None, which returns the output without saving it.
+    docx_style: dict, optional
+        Word style overrides, used only when type is "docx". Passed to
+        `maketables.MTable.make` as `docx_style`. For example,
+        `{"font_name": "Arial", "font_size_pt": 12, "notes_font_size_pt": 9}`.
+        See `maketables.MTable.DEFAULT_DOCX_STYLE` for supported options.
+        Default is None, which uses maketables' Word style defaults.
 
     Returns
     -------
-    pandas.DataFrame
-        A styled DataFrame with the coefficients and standard errors of the models.
-        When output is "tex", the LaTeX code is returned as a string.
+    pandas.DataFrame, great_tables.GT, docx.document.Document, str, or None
+        A DataFrame for "df", a GT object for "gt", a string for "html",
+        "tex", or "typst", or a Word Document for "docx". Markdown output
+        is printed and returns None. Word output is returned even when saved
+        via `file_name`, so it can be edited further with python-docx.
 
     Examples
     --------
-    For more examples, take a look at the [regression tables and summary statistics vignette](https://pyfixest.org/table-layout.html).
+    For more examples, see the [regression tables tutorial](/tutorials/regression-tables.qmd).
 
     ```{python}
     import pyfixest as pf
@@ -175,6 +194,16 @@ def etable(
     fit2 = pf.feols("Y~X1 + X2 | f1 + f2", df)
 
     pf.etable([fit1, fit2])
+    ```
+
+    ```{python}
+    document = pf.etable(
+        [fit1, fit2],
+        type="docx",
+        docx_style={"font_name": "Arial", "font_size_pt": 12},
+    )
+    # Save directly with file_name="results.docx", or edit the document first.
+    document.add_paragraph("Additional discussion of the estimates.")
     ```
     """
     # Apply pyfixest default for signif_code (different from maketables default)
@@ -200,7 +229,8 @@ def etable(
         "gt",
         "tex",
         "typst",
-    ], "type must be either 'df', 'md', 'html', 'gt' or 'tex'"
+        "docx",
+    ], "type must be either 'df', 'md', 'html', 'gt', 'tex', 'typst' or 'docx'"
 
     models_list = _post_processing_input_checks(models)
 
@@ -267,6 +297,11 @@ def etable(
             with open(file_name, "w") as f:
                 f.write(result.as_raw_html())
         return result
+    elif type == "docx":
+        document = table.make(type="docx", docx_style=docx_style)
+        if file_name is not None:
+            document.save(file_name)
+        return document
     elif type == "typst":
         result = table.make(type="typst")
         if file_name is not None:

--- a/tests/test_summarise.py
+++ b/tests/test_summarise.py
@@ -1,4 +1,7 @@
 import pandas as pd
+import pytest
+from docx import Document as open_document
+from docx.document import Document
 from great_tables import GT
 
 import pyfixest as pf
@@ -164,6 +167,77 @@ def test_etable_correct_output_type():
 
     typst_table = pf.etable(fit, type="typst")
     assert isinstance(typst_table, str)
+
+    docx_table = pf.etable(fit, type="docx")
+    assert isinstance(docx_table, Document)
+
+
+@pytest.mark.parametrize(
+    "formula, fit_kwargs",
+    [
+        ("Y ~ X1 + X2 | f1", {}),
+        ("sw(Y, Y2) ~ X1 + X2 | f1", {}),
+        ("Y ~ X2 + [X1 ~ Z1] | f1", {}),
+        ("Y ~ X1 + X2 | f1", {"weights": "weights"}),
+        ("Y ~ X1 + X2 | f1", {"weights": "frequency", "weights_type": "fweights"}),
+        ("Y ~ X1 + X2 | f1", {"lean": True}),
+        ("Y ~ X1 + X2 | f1", {"store_data": False}),
+    ],
+    ids=["fe", "multi", "iv", "aweights", "fweights", "lean", "no-data"],
+)
+def test_etable_docx_roundtrip(formula, fit_kwargs, tmp_path):
+    """Word preserves etable's displayed cells for different fitted-model inputs."""
+    data = get_data(N=150, seed=42)
+    data["frequency"] = [1 + i % 3 for i in range(len(data))]
+    fit = feols(formula, data=data, **fit_kwargs)
+    options = dict(
+        coef_fmt="b:.3f*\n(se:.3f)",
+        signif_code=[0.01, 0.05, 0.1],
+        labels={"X1": "政策暴露", "X2": "Control"},
+        notes="注: 模拟数据。",
+    )
+    expected = etable(fit, type="df", **options)
+    path = tmp_path / "regression.docx"
+    document = etable(fit, type="docx", file_name=path, **options)
+    reopened = open_document(path)
+    assert isinstance(document, Document)
+    assert reopened._element.xml == document._element.xml
+    assert len(reopened.tables) == 1
+    assert len(reopened.inline_shapes) == 0
+    rows = {row.cells[0].text: row for row in reopened.tables[0].rows}
+    for label in ("政策暴露", "Control"):
+        values = expected.xs(label, level=-1).iloc[0].tolist()
+        assert [cell.text for cell in rows[label].cells[1:]] == values
+    assert reopened.tables[0].rows[-1].cells[0].text == options["notes"]
+
+
+def test_etable_docx_style_and_existing_outputs():
+    """Word styles are per-call and leave the model and other output formats unchanged."""
+    data = get_data(N=150, seed=42)
+    models = [feols("Y ~ X1 | f1", data=data), feols("Y ~ X1 + X2 | f1", data=data)]
+    options = dict(model_heads=["Baseline", "Controls"], notes="Clustered by firm.")
+    before_df = etable(models, type="df", **options)
+    before_tex = etable(models, type="tex", **options)
+    style = {"font_name": "Arial", "font_size_pt": 12, "notes_font_size_pt": 8}
+    document = etable(models, type="docx", docx_style=style, **options)
+    table = document.tables[0]
+    assert table.rows[0].cells[1]._tc is table.rows[0].cells[2]._tc
+    assert [cell.text for cell in table.rows[1].cells[1:]] == ["Baseline", "Controls"]
+    assert [cell.text for cell in table.rows[2].cells[1:]] == ["(1)", "(2)"]
+    run = table.rows[1].cells[1].paragraphs[0].runs[0]
+    assert run.font.name == "Arial"
+    assert run.font.size.pt == 12
+    notes_run = table.rows[-1].cells[0].paragraphs[0].runs[0]
+    assert notes_run.font.size.pt == 8
+    assert style == {"font_name": "Arial", "font_size_pt": 12, "notes_font_size_pt": 8}
+    pd.testing.assert_frame_equal(etable(models, type="df", **options), before_df)
+    assert etable(models, type="tex", **options) == before_tex
+
+
+def test_etable_invalid_output_type():
+    """The invalid-format message includes both Word and Typst output."""
+    with pytest.raises(AssertionError, match="'typst' or 'docx'"):
+        etable([], type="invalid")
 
 
 def test_dtable_is_not_public():


### PR DESCRIPTION
## Summary

Adds `type="docx"` to `pf.etable()` so users can export editable regression tables to Word. The implementation reuses the existing MakeTables backend, accepts per-call `docx_style` overrides, saves through `file_name`, and returns a python-docx `Document` for further editing. Tests, API documentation, a tutorial example, and a changelog entry are included.

## Verification

- Local Python baseline: 3,731 passed, 6,044 skipped, 1 xfailed (85.84 s); reporting/API/error tests: 149 passed, 1 skipped (21.40 s).
- Word tests with MakeTables 0.1.4: 8 passed (2.19 s).
- Repository pre-commit hooks, including Ruff and mypy: passed.
- Quartodoc build, tutorial execution/render, and etable reference-page execution/render: passed.
- English and Chinese six-model samples: 96 displayed result cells matched; DOCX files reopened and rendered with LibreOffice.

Checks used a local uv environment. Baseline selection: `pytest tests -n 4 -m 'not (extended or against_r_core or against_r_extended or plots or hac)' --no-cov -q`. Targeted selection: `pytest tests/test_summarise.py tests/test_api.py tests/test_errors.py -q --no-cov`. Repository Pixi/platform CI has not run for this change; skipped release-reference cases are not numerical-parity evidence.

## Compatibility / risks

Word styling follows the MakeTables backend; line wrapping and pagination may differ from LaTeX. This change adds no runtime dependencies and does not modify estimation or inference.
